### PR TITLE
fix: use matrix.arch for macOS artifact paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -405,9 +405,9 @@ jobs:
         if: matrix.platform == 'darwin'
         uses: actions/upload-artifact@v4
         with:
-          name: macos-installer
+          name: macos-installer-${{ matrix.arch }}
           path: |
-            out/make/zip/darwin/arm64/*.zip
+            out/make/zip/darwin/${{ matrix.arch }}/*.zip
             out/make/latest-mac.yml
           retention-days: 7
 
@@ -433,7 +433,8 @@ jobs:
           files: |
             artifacts/linux-installers/**/*
             artifacts/windows-installer/**/*
-            artifacts/macos-installer/**/*
+            artifacts/macos-installer-arm64/**/*
+            artifacts/macos-installer-x64/**/*
           draft: ${{ github.event_name == 'workflow_dispatch' }}
           prerelease: ${{ contains(github.ref_name, '-') }}
           generate_release_notes: true


### PR DESCRIPTION
## Description

<!-- Brief description of the changes -->

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📖 Documentation update
- [ ] 🧹 Code cleanup / refactor

## Checklist

- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Tests pass locally (`npm test`)
- [ ] Lint/format checks pass (`npm run lint && npm run format:check`)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->
