### PR TITLE
feat(reco-core): Batch A multi-consumer API additions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,6 +22,7 @@ env:
     libavcodec-dev libavformat-dev libavutil-dev
     libswscale-dev libavdevice-dev libavfilter-dev libswresample-dev
     libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+    libfontconfig1-dev
     pkg-config clang
 
 jobs:
@@ -119,21 +120,11 @@ jobs:
       - name: Check full CLI
         run: cargo check -p reco-cli
 
-  check-macos-intel:
-    name: Check (macOS Intel)
-    runs-on: macos-15-intel
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-      - name: Install dependencies
-        run: brew install ffmpeg gstreamer gst-plugins-base pkg-config
-      - name: Check reco-core
-        run: cargo check -p reco-core
-      - name: Check reco-core (profiling)
-        run: cargo check -p reco-core --features profiling
-      - name: Check full CLI
-        run: cargo check -p reco-cli
+  # macOS Intel (x86_64-apple-darwin) is suspended - the ort-sys crate
+  # publishes no prebuilt ONNX Runtime binary for that target with
+  # reco-detect's feature set, and we have no hardware to test on.
+  # Re-enable once ort-sys gains a prebuilt for x86_64-apple-darwin or
+  # reco-detect is switched to `features = ["load-dynamic"]` there.
 
   check-windows:
     name: Check (Windows)

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -194,7 +194,7 @@ pub fn run_camera(
         // Warm up: discard first frame (camera ISP + pipeline init)
         if let Some(pair) = source.next_pair()? {
             let stereo = StereoFrame::Nv12(pair);
-            session.detect_and_update_director(&stereo, start.elapsed());
+            session.detect_and_update_director(&stereo, start.elapsed())?;
             let pos = session.director_position();
             session.process_frame(&stereo, pos.yaw, pos.pitch)?;
             println!("Warmup complete, starting capture...");
@@ -212,7 +212,7 @@ pub fn run_camera(
             };
 
             let stereo = StereoFrame::Nv12(pair);
-            session.detect_and_update_director(&stereo, start.elapsed());
+            session.detect_and_update_director(&stereo, start.elapsed())?;
             let pos = session.director_position();
             session.process_frame(&stereo, pos.yaw, pos.pitch)?;
             frame_count += 1;
@@ -243,7 +243,7 @@ pub fn run_camera(
                 }
             };
 
-            session.detect_and_update_director(&frame, start.elapsed());
+            session.detect_and_update_director(&frame, start.elapsed())?;
             let pos = session.director_position();
             session.process_frame(&frame, pos.yaw, pos.pitch)?;
             frame_count += 1;

--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -536,33 +536,31 @@ impl ApplicationHandler for App {
                 self.source.take();
                 event_loop.exit();
             }
-            WindowEvent::Resized(size) => {
-                if size.width > 0 && size.height > 0 {
-                    self.width = size.width;
-                    self.height = size.height;
-                    if let (Some(surface), Some(renderer)) = (&self.surface, &mut self.renderer) {
-                        let render_format = StitchRenderer::strip_srgb(self.surface_format);
-                        let view_formats = if render_format != self.surface_format {
-                            vec![render_format]
-                        } else {
-                            vec![]
-                        };
-                        surface.configure(
-                            renderer.gpu().device(),
-                            &reco_core::wgpu::SurfaceConfiguration {
-                                usage: reco_core::wgpu::TextureUsages::RENDER_ATTACHMENT,
-                                format: self.surface_format,
-                                width: self.width,
-                                height: self.height,
-                                present_mode: reco_core::wgpu::PresentMode::Fifo,
-                                desired_maximum_frame_latency: 2,
-                                alpha_mode: self.alpha_mode,
-                                view_formats,
-                            },
-                        );
-                        renderer.pipeline_mut().resize(self.width, self.height);
-                        self.needs_redraw = true;
-                    }
+            WindowEvent::Resized(size) if size.width > 0 && size.height > 0 => {
+                self.width = size.width;
+                self.height = size.height;
+                if let (Some(surface), Some(renderer)) = (&self.surface, &mut self.renderer) {
+                    let render_format = StitchRenderer::strip_srgb(self.surface_format);
+                    let view_formats = if render_format != self.surface_format {
+                        vec![render_format]
+                    } else {
+                        vec![]
+                    };
+                    surface.configure(
+                        renderer.gpu().device(),
+                        &reco_core::wgpu::SurfaceConfiguration {
+                            usage: reco_core::wgpu::TextureUsages::RENDER_ATTACHMENT,
+                            format: self.surface_format,
+                            width: self.width,
+                            height: self.height,
+                            present_mode: reco_core::wgpu::PresentMode::Fifo,
+                            desired_maximum_frame_latency: 2,
+                            alpha_mode: self.alpha_mode,
+                            view_formats,
+                        },
+                    );
+                    renderer.pipeline_mut().resize(self.width, self.height);
+                    self.needs_redraw = true;
                 }
             }
             WindowEvent::KeyboardInput { event, .. } => {
@@ -779,20 +777,18 @@ impl ApplicationHandler for App {
                     }
                 }
             }
-            WindowEvent::CursorMoved { position, .. } => {
-                if self.mouse_dragging {
-                    if let Some((prev_x, prev_y)) = self.last_mouse_pos {
-                        let dx = position.x - prev_x;
-                        let dy = position.y - prev_y;
-                        // Accumulate into smoothing targets (raw deltas)
-                        self.target_yaw += dx as f32 * MOUSE_SENSITIVITY;
-                        self.target_pitch += dy as f32 * MOUSE_SENSITIVITY;
-                    } else {
-                        // First move after click - switch to Poll for smooth updates
-                        event_loop.set_control_flow(ControlFlow::Poll);
-                    }
-                    self.last_mouse_pos = Some((position.x, position.y));
+            WindowEvent::CursorMoved { position, .. } if self.mouse_dragging => {
+                if let Some((prev_x, prev_y)) = self.last_mouse_pos {
+                    let dx = position.x - prev_x;
+                    let dy = position.y - prev_y;
+                    // Accumulate into smoothing targets (raw deltas)
+                    self.target_yaw += dx as f32 * MOUSE_SENSITIVITY;
+                    self.target_pitch += dy as f32 * MOUSE_SENSITIVITY;
+                } else {
+                    // First move after click - switch to Poll for smooth updates
+                    event_loop.set_control_flow(ControlFlow::Poll);
                 }
+                self.last_mouse_pos = Some((position.x, position.y));
             }
             WindowEvent::MouseWheel { delta, .. } => {
                 let scroll = match delta {

--- a/crates/reco-core/src/analyze.rs
+++ b/crates/reco-core/src/analyze.rs
@@ -1,0 +1,219 @@
+//! Detection-only pipeline for analytics consumers.
+//!
+//! [`AnalyzePipeline`] is a lightweight sibling of
+//! [`StitchSession`](crate::session::StitchSession) for consumers that
+//! need detection data but not a stitched video output (heatmaps,
+//! highlight reels, coaching stats, offline analytics).
+//!
+//! Compared to `StitchSession` it omits:
+//! - GPU render pipeline
+//! - NV12 converter and readback buffers
+//! - Encoder and async encode thread
+//! - Director and viewport clamping
+//!
+//! What remains is the detection pipeline plus the calibration+scene
+//! needed to map per-camera detections into panorama coordinates. A
+//! typical analytics consumer builds a [`FrameSource`] (usually a file
+//! decoder), attaches a detector and a [`DetectionSink`], and calls
+//! [`AnalyzePipeline::run`] to drive the loop.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use reco_core::analyze::AnalyzePipeline;
+//!
+//! let mut pipeline = AnalyzePipeline::new(calibration);
+//! pipeline.set_detector(Box::new(my_detector));
+//! pipeline.set_detection_sink(Box::new(|dets, frame_idx, ts_ms| {
+//!     csv_writer.write_row(dets, frame_idx, ts_ms)?;
+//!     Ok(())
+//! }));
+//!
+//! let processed = pipeline.run(&mut source, u64::MAX, &interrupted, None)?;
+//! ```
+
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use thiserror::Error;
+
+use crate::calibration::MatchCalibration;
+use crate::detector::Detection;
+use crate::director::MappedDetection;
+use crate::projection::{self, CoverageBoundary, PanoramaExtent};
+use crate::scene::SceneGeometry;
+use crate::session::detection::DetectionPipeline;
+use crate::session::{DetectionSink, DetectionSinkError, FrameProgress, ProgressCallback};
+use crate::source::{FrameSource, SourceError, StereoFrame};
+
+/// Errors from [`AnalyzePipeline::run`].
+#[derive(Debug, Error)]
+pub enum AnalyzeError {
+    /// Frame source error.
+    #[error("source: {0}")]
+    Source(#[from] SourceError),
+
+    /// Detection sink error.
+    #[error("detection sink: {0}")]
+    DetectionSink(#[source] DetectionSinkError),
+}
+
+/// Detection-only pipeline that decodes frames and fires a sink without
+/// running GPU render or encode.
+///
+/// Owns the detector and [`DetectionSink`]; holds calibration + scene so
+/// it can map camera-space detections to panorama yaw/pitch. Intended for
+/// offline analytics and standalone detection consumers that would
+/// otherwise pay the full stitch+encode cost just to reach the detection
+/// callback.
+pub struct AnalyzePipeline {
+    calibration: MatchCalibration,
+    scene: SceneGeometry,
+    coverage: CoverageBoundary,
+    detection: DetectionPipeline,
+    frame_count: u64,
+}
+
+impl AnalyzePipeline {
+    /// Create an analyze pipeline for the given camera calibration.
+    ///
+    /// Builds the scene geometry and coverage boundary up-front so
+    /// [`panorama_extent`](Self::panorama_extent) is available before the
+    /// first frame is processed. No GPU or encoder resources are
+    /// allocated.
+    pub fn new(calibration: MatchCalibration) -> Self {
+        let aspect = calibration.left.width as f32 / calibration.left.height as f32;
+        let scene = SceneGeometry::from_layout_with_aspect(&calibration.layout, aspect);
+        let coverage = CoverageBoundary::from_calibration(&calibration, &scene);
+
+        Self {
+            calibration,
+            scene,
+            coverage,
+            detection: DetectionPipeline::new(),
+            frame_count: 0,
+        }
+    }
+
+    /// Attach a CPU detector for object detection on decoded frames.
+    pub fn set_detector(&mut self, detector: Box<dyn crate::detector::Detector>) {
+        self.detection.set_detector(detector);
+    }
+
+    /// Set the detection interval (run detection every N frames).
+    pub fn set_detection_interval(&mut self, interval: u64) {
+        self.detection.set_detection_interval(interval);
+    }
+
+    /// Set a fallible sink for receiving tracked detection data.
+    ///
+    /// Replaces any previously registered sink. Sink errors abort
+    /// [`run`](Self::run) with [`AnalyzeError::DetectionSink`].
+    pub fn set_detection_sink(&mut self, sink: Box<dyn DetectionSink>) {
+        self.detection.set_sink(sink);
+    }
+
+    /// The precomputed coverage boundary derived from the calibration.
+    pub fn coverage(&self) -> &CoverageBoundary {
+        &self.coverage
+    }
+
+    /// Full angular extent of the stitched panorama (yaw/pitch ranges).
+    pub fn panorama_extent(&self) -> PanoramaExtent {
+        let (yaw_min, yaw_max) = self.coverage.yaw_range();
+        let (pitch_min, pitch_max) = self.coverage.pitch_range();
+        PanoramaExtent {
+            yaw_min,
+            yaw_max,
+            pitch_min,
+            pitch_max,
+        }
+    }
+
+    /// Number of frames processed so far.
+    pub fn frame_count(&self) -> u64 {
+        self.frame_count
+    }
+
+    /// Run the decode → detect → sink loop to completion.
+    ///
+    /// Blocks until the source is exhausted, the frame limit is reached,
+    /// or `interrupted` is set. Returns the number of frames processed.
+    ///
+    /// GPU-resident frames (`StereoFrame::GpuResident`,
+    /// `StereoFrame::MetalResident`) are counted but skipped for
+    /// detection since they carry no CPU-accessible pixel data — the
+    /// CPU-only decoder path is the intended companion for this method.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(skip_all, name = "analyze_run")
+    )]
+    pub fn run(
+        &mut self,
+        source: &mut dyn FrameSource,
+        frame_limit: u64,
+        interrupted: &AtomicBool,
+        mut on_progress: Option<ProgressCallback>,
+    ) -> Result<u64, AnalyzeError> {
+        let info = source.info();
+        let (width, height) = (info.width, info.height);
+        let start = std::time::Instant::now();
+
+        while self.frame_count < frame_limit && !interrupted.load(Ordering::Relaxed) {
+            let frame = match source.next_frame()? {
+                Some(f) => f,
+                None => break,
+            };
+
+            let should_detect = self.detection.should_detect(self.frame_count);
+
+            if should_detect && self.is_cpu_frame(&frame) {
+                let raw = self.detection.run_detection(&frame, width, height);
+                self.detection.set_last_detections(self.map_detections(raw));
+            }
+
+            let timestamp_ms = start.elapsed().as_secs_f64() * 1000.0;
+            self.detection
+                .fire_sink(self.frame_count, timestamp_ms)
+                .map_err(AnalyzeError::DetectionSink)?;
+
+            self.frame_count += 1;
+
+            if let Some(cb) = on_progress.as_mut() {
+                cb(&FrameProgress {
+                    frames_completed: self.frame_count,
+                    elapsed: start.elapsed(),
+                });
+            }
+        }
+
+        Ok(self.frame_count)
+    }
+
+    /// Whether the frame carries CPU-accessible plane data.
+    fn is_cpu_frame(&self, frame: &StereoFrame) -> bool {
+        matches!(frame, StereoFrame::Yuv420p(_) | StereoFrame::Nv12(_))
+    }
+
+    fn map_detections(&self, detections: Vec<Detection>) -> Vec<MappedDetection> {
+        detections
+            .iter()
+            .map(|d| {
+                let position = projection::camera_to_panorama(
+                    d.camera,
+                    d.center_x,
+                    d.center_y,
+                    &self.calibration,
+                    &self.scene,
+                );
+                MappedDetection {
+                    camera: d.camera,
+                    class_id: d.class_id,
+                    confidence: d.confidence,
+                    camera_center: (d.center_x, d.center_y),
+                    camera_size: (d.width, d.height),
+                    position,
+                }
+            })
+            .collect()
+    }
+}

--- a/crates/reco-core/src/director.rs
+++ b/crates/reco-core/src/director.rs
@@ -23,7 +23,7 @@
 //!
 //! Detection data isn't just for the director. The same [`MappedDetection`]s
 //! are available to external consumers via
-//! [`StitchSession::set_detection_callback`](crate::session::StitchSession::set_detection_callback).
+//! [`StitchSession::set_detection_sink`](crate::session::StitchSession::set_detection_sink).
 //! This enables building coaching assistants, VAR systems, and stats
 //! pipelines on top of the detection data without modifying the director.
 

--- a/crates/reco-core/src/lib.rs
+++ b/crates/reco-core/src/lib.rs
@@ -72,6 +72,7 @@ macro_rules! profile_scope {
 /// use [`gpu::OutputFormat`] and the [`session`] API instead.
 pub use wgpu;
 
+pub mod analyze;
 pub(crate) mod async_encode;
 pub mod calibration;
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -95,6 +96,7 @@ pub mod nv12_converter;
 pub mod pipeline;
 pub mod projection;
 pub mod renderer;
+pub mod rgba_readback;
 pub mod scene;
 pub mod session;
 pub mod source;

--- a/crates/reco-core/src/projection.rs
+++ b/crates/reco-core/src/projection.rs
@@ -390,6 +390,53 @@ pub struct ClampedPosition {
     pub pitch: f32,
 }
 
+/// Full angular extent of the stitched panorama (radians).
+///
+/// Returned by [`StitchSession::panorama_extent`](crate::session::StitchSession::panorama_extent).
+/// Analytics consumers (heatmaps, zone stats) use this to size grids that
+/// span the full coverage rather than hardcoding `±45° yaw, ±20° pitch`.
+#[derive(Debug, Clone, Copy)]
+pub struct PanoramaExtent {
+    /// Minimum yaw with coverage from either camera (radians).
+    pub yaw_min: f32,
+    /// Maximum yaw with coverage from either camera (radians).
+    pub yaw_max: f32,
+    /// Minimum pitch with coverage from either camera (radians).
+    pub pitch_min: f32,
+    /// Maximum pitch with coverage from either camera (radians).
+    pub pitch_max: f32,
+}
+
+impl PanoramaExtent {
+    /// Width of the yaw range in radians.
+    pub fn yaw_span(&self) -> f32 {
+        self.yaw_max - self.yaw_min
+    }
+
+    /// Width of the pitch range in radians.
+    pub fn pitch_span(&self) -> f32 {
+        self.pitch_max - self.pitch_min
+    }
+
+    /// Map an angular position in radians to normalized `[0, 1]`
+    /// coordinates within this extent.
+    ///
+    /// Returns `None` if the extent is degenerate (zero span on either
+    /// axis). Values outside the extent are returned as-is (not clamped),
+    /// so callers can detect out-of-bounds detections.
+    pub fn normalize(&self, yaw: f32, pitch: f32) -> Option<(f32, f32)> {
+        let yaw_span = self.yaw_span();
+        let pitch_span = self.pitch_span();
+        if yaw_span <= 0.0 || pitch_span <= 0.0 {
+            return None;
+        }
+        Some((
+            (yaw - self.yaw_min) / yaw_span,
+            (pitch - self.pitch_min) / pitch_span,
+        ))
+    }
+}
+
 /// Angular offsets of viewport boundary points from center.
 ///
 impl CoverageBoundary {
@@ -579,8 +626,42 @@ impl CoverageBoundary {
         }
     }
 
+    /// Global yaw coverage range across the full panorama (radians).
+    ///
+    /// Returns `(yaw_min, yaw_max)`, the widest-point extremes of the
+    /// stitched panorama. Useful for heatmap consumers that need to
+    /// bucket detections by yaw across the full coverage.
+    ///
+    /// This is the global extent, not the per-pitch range. For a
+    /// pitch-aware range, sample with [`yaw_range_at`](Self::yaw_range_at).
+    pub fn yaw_range(&self) -> (f32, f32) {
+        let mut lo = f32::INFINITY;
+        let mut hi = f32::NEG_INFINITY;
+        for &(a, b) in &self.slices {
+            if a <= b {
+                lo = lo.min(a);
+                hi = hi.max(b);
+            }
+        }
+        if lo > hi { (0.0, 0.0) } else { (lo, hi) }
+    }
+
+    /// Global pitch coverage range across the full panorama (radians).
+    ///
+    /// Returns `(pitch_min, pitch_max)`. Used alongside
+    /// [`yaw_range`](Self::yaw_range) by heatmap and analytics consumers
+    /// that need panorama bounds without reaching into private state.
+    pub fn pitch_range(&self) -> (f32, f32) {
+        (self.pitch_min, self.pitch_max)
+    }
+
     /// Look up the combined yaw coverage range at a given pitch.
-    fn yaw_range_at(&self, pitch: f32) -> (f32, f32) {
+    ///
+    /// Returns the interpolated `(yaw_min, yaw_max)` where at least one
+    /// camera plane provides coverage. Used by the director for
+    /// perspective-aware clamping; analytics consumers typically want
+    /// [`yaw_range`](Self::yaw_range) for the global extent instead.
+    pub fn yaw_range_at(&self, pitch: f32) -> (f32, f32) {
         self.interpolate_slice(&self.slices, pitch)
     }
 
@@ -1118,5 +1199,84 @@ mod tests {
         // Just inside the edge
         assert!(point_in_polygon([0.001, 0.5], &unit_square()));
         assert!(point_in_polygon([0.999, 0.5], &unit_square()));
+    }
+
+    #[test]
+    fn coverage_yaw_and_pitch_ranges_match_internal_state() {
+        let cal = test_calibration();
+        let scene = test_scene(&cal);
+        let coverage = CoverageBoundary::from_calibration(&cal, &scene);
+
+        let (yaw_min, yaw_max) = coverage.yaw_range();
+        assert!(yaw_min < yaw_max, "yaw range must be non-empty");
+        assert!(yaw_min.is_finite() && yaw_max.is_finite());
+
+        let (pitch_min, pitch_max) = coverage.pitch_range();
+        assert_eq!(pitch_min, coverage.pitch_min);
+        assert_eq!(pitch_max, coverage.pitch_max);
+    }
+
+    #[test]
+    fn coverage_yaw_range_is_widest_slice_envelope() {
+        // yaw_range() must be at least as wide as any yaw_range_at(pitch)
+        // sample, since it's the envelope over all pitch slices.
+        let cal = test_calibration();
+        let scene = test_scene(&cal);
+        let coverage = CoverageBoundary::from_calibration(&cal, &scene);
+
+        let (y_lo_global, y_hi_global) = coverage.yaw_range();
+        let (p_lo, p_hi) = coverage.pitch_range();
+
+        for i in 0..=10 {
+            let t = i as f32 / 10.0;
+            let pitch = p_lo + t * (p_hi - p_lo);
+            let (y_lo, y_hi) = coverage.yaw_range_at(pitch);
+            if y_lo > y_hi {
+                continue; // degenerate interpolation outside coverage
+            }
+            assert!(
+                y_lo >= y_lo_global - 1e-4,
+                "pitch {pitch} yaw lo {y_lo} below global {y_lo_global}"
+            );
+            assert!(
+                y_hi <= y_hi_global + 1e-4,
+                "pitch {pitch} yaw hi {y_hi} above global {y_hi_global}"
+            );
+        }
+    }
+
+    #[test]
+    fn panorama_extent_normalize_is_in_range_at_corners() {
+        let ext = PanoramaExtent {
+            yaw_min: -0.5,
+            yaw_max: 0.5,
+            pitch_min: -0.3,
+            pitch_max: 0.3,
+        };
+        assert_eq!(ext.yaw_span(), 1.0);
+        assert_eq!(ext.pitch_span(), 0.6);
+
+        let (u, v) = ext.normalize(-0.5, -0.3).unwrap();
+        assert!((u - 0.0).abs() < 1e-6);
+        assert!((v - 0.0).abs() < 1e-6);
+
+        let (u, v) = ext.normalize(0.5, 0.3).unwrap();
+        assert!((u - 1.0).abs() < 1e-6);
+        assert!((v - 1.0).abs() < 1e-6);
+
+        let (u, v) = ext.normalize(0.0, 0.0).unwrap();
+        assert!((u - 0.5).abs() < 1e-6);
+        assert!((v - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn panorama_extent_normalize_rejects_degenerate() {
+        let ext = PanoramaExtent {
+            yaw_min: 0.0,
+            yaw_max: 0.0,
+            pitch_min: 0.0,
+            pitch_max: 0.0,
+        };
+        assert!(ext.normalize(0.0, 0.0).is_none());
     }
 }

--- a/crates/reco-core/src/rgba_readback.rs
+++ b/crates/reco-core/src/rgba_readback.rs
@@ -1,0 +1,367 @@
+//! GPU → CPU RGBA readback with triple-buffered staging.
+//!
+//! [`RgbaReadback`] reads pixels from an RGBA wgpu texture (typically the
+//! stitch pipeline's render target) into a tightly-packed
+//! `Vec<u8>` of `[R, G, B, A, R, G, B, A, ...]` bytes. It strips the
+//! 256-byte row padding wgpu requires for `copy_texture_to_buffer` so
+//! callers receive exactly `width * height * 4` bytes.
+//!
+//! ## Triple-buffered readback
+//!
+//! Uses the same pattern as [`Nv12Converter`](crate::nv12_converter::Nv12Converter):
+//! three staging buffers cycle so the CPU always reads from 2 frames ago,
+//! which is guaranteed to have completed on the GPU. This avoids the
+//! blocking `poll(Wait)` stall (3-8ms at 1080p) that a single-buffered
+//! reader incurs.
+//!
+//! ## Why a separate type
+//!
+//! [`Nv12Converter`](crate::nv12_converter::Nv12Converter) also runs a
+//! compute shader to convert RGBA → NV12 before the readback. GUI and
+//! OBS consumers want the raw RGBA (or BGRA) pixels for display, not an
+//! encoded NV12 stream. Sharing the NV12 converter would force every
+//! consumer to pay for the GPU conversion work; instead this module
+//! handles the staging-buffer + map-async + row-strip plumbing directly.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use reco_core::rgba_readback::RgbaReadback;
+//!
+//! let mut readback = RgbaReadback::new(&gpu, width, height)?;
+//! // Inside the render loop:
+//! let cmd = pipeline.render_to_target(&left, &right, yaw, pitch)?;
+//! if let Some(rgba) = readback.readback(&gpu, pipeline.render_target(), cmd)? {
+//!     // rgba is &[u8] of length width * height * 4
+//!     display.update(rgba);
+//! }
+//! ```
+
+use crate::gpu::GpuContext;
+
+/// GPU → CPU RGBA readback with triple-buffered staging.
+///
+/// Call [`readback`](Self::readback) once per rendered frame with the
+/// pipeline's command buffer. Returns the RGBA bytes from 2 frames ago
+/// (or `None` on the first two calls during pipeline warm-up).
+///
+/// Call [`flush_pending`](Self::flush_pending) in a loop after the main
+/// frame loop to drain the remaining buffered frames.
+pub struct RgbaReadback {
+    /// Triple-buffered staging buffers (CPU-readable, GPU-writable).
+    staging: [wgpu::Buffer; 3],
+    /// Triple-buffered tightly-packed output buffers (no row padding).
+    output: [Vec<u8>; 3],
+    /// Which staging buffer to write to next (0, 1, or 2).
+    current_slot: usize,
+    /// Number of frames pending readback (0, 1, or 2).
+    pending_count: u8,
+    width: u32,
+    height: u32,
+    /// Bytes per row on the CPU side (tightly packed): `width * 4`.
+    bytes_per_row: u32,
+    /// Bytes per row in the staging buffer (rounded up to 256 for wgpu).
+    padded_bytes_per_row: u32,
+    /// Reusable channel for map_async signaling (avoids per-frame alloc).
+    map_tx: std::sync::mpsc::SyncSender<Result<(), wgpu::BufferAsyncError>>,
+    map_rx: std::sync::mpsc::Receiver<Result<(), wgpu::BufferAsyncError>>,
+}
+
+impl RgbaReadback {
+    /// Create a readback helper for a texture of the given dimensions.
+    ///
+    /// Allocates three staging buffers plus three tightly-packed output
+    /// `Vec<u8>`s (no per-frame allocation during the frame loop).
+    pub fn new(gpu: &GpuContext, width: u32, height: u32) -> Result<Self, RgbaReadbackError> {
+        if width == 0 || height == 0 {
+            return Err(RgbaReadbackError::InvalidDimensions(format!(
+                "width and height must be > 0, got {width}x{height}"
+            )));
+        }
+
+        let bytes_per_row = width * 4;
+        // wgpu requires `copy_texture_to_buffer` rows aligned to 256 bytes
+        // (D3D12 / Vulkan requirement, enforced as
+        // `COPY_BYTES_PER_ROW_ALIGNMENT`).
+        let padded_bytes_per_row = bytes_per_row.div_ceil(256) * 256;
+        let staging_size = (padded_bytes_per_row as u64) * (height as u64);
+        let output_len = (bytes_per_row as usize) * (height as usize);
+
+        let device = &gpu.device;
+        let staging = [
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("rgba_staging_0"),
+                size: staging_size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            }),
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("rgba_staging_1"),
+                size: staging_size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            }),
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("rgba_staging_2"),
+                size: staging_size,
+                usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::MAP_READ,
+                mapped_at_creation: false,
+            }),
+        ];
+
+        let (map_tx, map_rx) = std::sync::mpsc::sync_channel(1);
+
+        log::info!(
+            "RgbaReadback: {width}x{height} → {staging_size} bytes staging \
+             ({} MB, row padding {padded_bytes_per_row}/{bytes_per_row})",
+            staging_size / 1_048_576,
+        );
+
+        Ok(Self {
+            staging,
+            output: [
+                vec![0u8; output_len],
+                vec![0u8; output_len],
+                vec![0u8; output_len],
+            ],
+            current_slot: 0,
+            pending_count: 0,
+            width,
+            height,
+            bytes_per_row,
+            padded_bytes_per_row,
+            map_tx,
+            map_rx,
+        })
+    }
+
+    /// Submit the render command buffer and read back RGBA pixels.
+    ///
+    /// Enqueues `render_commands` plus a `copy_texture_to_buffer` into the
+    /// current staging slot, then maps and strips row padding from the
+    /// staging buffer written 2 frames ago.
+    ///
+    /// Returns `None` on the first two calls (GPU warmup), and
+    /// `Some(&[u8])` of length `width * height * 4` afterward. The slice
+    /// is tightly packed `R, G, B, A` in the order wgpu wrote it (matches
+    /// the render target's texture format — `Rgba8Unorm` or `Bgra8Unorm`
+    /// depending on how the pipeline was created).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(skip_all, name = "rgba_readback")
+    )]
+    pub fn readback(
+        &mut self,
+        gpu: &GpuContext,
+        source: &wgpu::Texture,
+        render_commands: wgpu::CommandBuffer,
+    ) -> Result<Option<&[u8]>, RgbaReadbackError> {
+        let write_slot = self.current_slot;
+
+        self.submit_copy(gpu, source, render_commands, write_slot)?;
+
+        // Read back from 2 frames ago (pending >= 2).
+        let has_result = if self.pending_count >= 2 {
+            let read_slot = (write_slot + 1) % 3;
+            self.map_and_strip(gpu, read_slot)?;
+            true
+        } else {
+            false
+        };
+
+        self.pending_count = (self.pending_count + 1).min(2);
+        self.current_slot = (write_slot + 1) % 3;
+
+        if has_result {
+            let read_slot = (write_slot + 1) % 3;
+            Ok(Some(&self.output[read_slot]))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Flush one pending frame from the triple-buffer pipeline.
+    ///
+    /// Call this in a loop after the frame loop ends to drain remaining
+    /// frames. Returns `None` when no frames are pending. Uses blocking
+    /// poll since no new GPU work follows to overlap with.
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(skip_all, name = "rgba_flush")
+    )]
+    pub fn flush_pending(&mut self, gpu: &GpuContext) -> Result<Option<&[u8]>, RgbaReadbackError> {
+        if self.pending_count == 0 {
+            return Ok(None);
+        }
+        // Oldest pending slot: walk back by pending_count from current_slot.
+        let read_slot = (self.current_slot + 3 - self.pending_count as usize) % 3;
+        self.map_and_strip_blocking(gpu, read_slot)?;
+        self.pending_count -= 1;
+        Ok(Some(&self.output[read_slot]))
+    }
+
+    /// Output width in pixels.
+    pub fn width(&self) -> u32 {
+        self.width
+    }
+
+    /// Output height in pixels.
+    pub fn height(&self) -> u32 {
+        self.height
+    }
+
+    fn submit_copy(
+        &self,
+        gpu: &GpuContext,
+        source: &wgpu::Texture,
+        render_commands: wgpu::CommandBuffer,
+        slot: usize,
+    ) -> Result<(), RgbaReadbackError> {
+        let mut encoder = gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("rgba_readback_encoder"),
+            });
+
+        encoder.copy_texture_to_buffer(
+            wgpu::TexelCopyTextureInfo {
+                texture: source,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            wgpu::TexelCopyBufferInfo {
+                buffer: &self.staging[slot],
+                layout: wgpu::TexelCopyBufferLayout {
+                    offset: 0,
+                    bytes_per_row: Some(self.padded_bytes_per_row),
+                    rows_per_image: Some(self.height),
+                },
+            },
+            wgpu::Extent3d {
+                width: self.width,
+                height: self.height,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        gpu.queue.submit([render_commands, encoder.finish()]);
+        Ok(())
+    }
+
+    /// Map the staging buffer at `slot` and copy its contents into the
+    /// corresponding output buffer, stripping wgpu's per-row padding.
+    ///
+    /// Uses a non-blocking `PollType::Poll` first since the GPU work is
+    /// 2 frames old and should already be complete; falls back to a
+    /// blocking wait if the poll reports no progress.
+    fn map_and_strip(&mut self, gpu: &GpuContext, slot: usize) -> Result<(), RgbaReadbackError> {
+        crate::profile_scope!("rgba_map_async");
+        let buffer_slice = self.staging[slot].slice(..);
+        let tx = self.map_tx.clone();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+
+        gpu.device
+            .poll(wgpu::PollType::Poll)
+            .map_err(|_| RgbaReadbackError::BufferMapFailed)?;
+
+        match self.map_rx.try_recv() {
+            Ok(result) => result.map_err(|_| RgbaReadbackError::BufferMapFailed)?,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {
+                gpu.device
+                    .poll(wgpu::PollType::wait_indefinitely())
+                    .map_err(|_| RgbaReadbackError::BufferMapFailed)?;
+                self.map_rx
+                    .recv()
+                    .map_err(|_| RgbaReadbackError::BufferMapFailed)?
+                    .map_err(|_| RgbaReadbackError::BufferMapFailed)?;
+            }
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(RgbaReadbackError::BufferMapFailed);
+            }
+        }
+
+        self.copy_mapped_to_output(slot);
+        Ok(())
+    }
+
+    fn map_and_strip_blocking(
+        &mut self,
+        gpu: &GpuContext,
+        slot: usize,
+    ) -> Result<(), RgbaReadbackError> {
+        crate::profile_scope!("rgba_flush_blocking");
+        let buffer_slice = self.staging[slot].slice(..);
+        let tx = self.map_tx.clone();
+        buffer_slice.map_async(wgpu::MapMode::Read, move |result| {
+            let _ = tx.send(result);
+        });
+        gpu.device
+            .poll(wgpu::PollType::wait_indefinitely())
+            .map_err(|_| RgbaReadbackError::BufferMapFailed)?;
+        self.map_rx
+            .recv()
+            .map_err(|_| RgbaReadbackError::BufferMapFailed)?
+            .map_err(|_| RgbaReadbackError::BufferMapFailed)?;
+        self.copy_mapped_to_output(slot);
+        Ok(())
+    }
+
+    /// Copy the mapped staging buffer into `output[slot]`, stripping
+    /// wgpu's per-row padding so the output is tightly packed.
+    fn copy_mapped_to_output(&mut self, slot: usize) {
+        let mapped = self.staging[slot].slice(..).get_mapped_range();
+        let row_stride = self.padded_bytes_per_row as usize;
+        let row_bytes = self.bytes_per_row as usize;
+        let height = self.height as usize;
+        let output = &mut self.output[slot];
+
+        if row_stride == row_bytes {
+            // No padding - single copy.
+            output.copy_from_slice(&mapped[..row_bytes * height]);
+        } else {
+            for row in 0..height {
+                let src = row * row_stride;
+                let dst = row * row_bytes;
+                output[dst..dst + row_bytes].copy_from_slice(&mapped[src..src + row_bytes]);
+            }
+        }
+        drop(mapped);
+        self.staging[slot].unmap();
+    }
+}
+
+/// Errors from [`RgbaReadback`].
+#[derive(Debug, thiserror::Error)]
+pub enum RgbaReadbackError {
+    /// GPU buffer mapping failed (device lost, timeout, ...).
+    #[error("RGBA buffer mapping failed")]
+    BufferMapFailed,
+
+    /// Invalid output dimensions.
+    #[error("invalid RGBA dimensions: {0}")]
+    InvalidDimensions(String),
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn padded_row_stride_matches_width_when_aligned() {
+        // 1920 * 4 = 7680, which is a multiple of 256.
+        let padded = (1920u32 * 4).div_ceil(256) * 256;
+        assert_eq!(padded, 7680);
+    }
+
+    #[test]
+    fn padded_row_stride_rounds_up_unaligned_widths() {
+        // 100 * 4 = 400, which rounds up to 512.
+        let padded = (100u32 * 4).div_ceil(256) * 256;
+        assert_eq!(padded, 512);
+
+        // 64 * 4 = 256, already aligned.
+        let padded = (64u32 * 4).div_ceil(256) * 256;
+        assert_eq!(padded, 256);
+    }
+}

--- a/crates/reco-core/src/session/detection.rs
+++ b/crates/reco-core/src/session/detection.rs
@@ -1,15 +1,17 @@
 //! Detection pipeline extracted from [`StitchSession`](crate::session::StitchSession).
 //!
 //! Owns the detector backends (CPU, GPU/CUDA, Metal), detection interval,
-//! callback, and cached detections. This keeps detection concerns separated
-//! from the rendering/encoding pipeline in `StitchSession`.
+//! sink, and cached detections. Separates detection concerns from the
+//! rendering/encoding pipeline in `StitchSession`, and is reused by
+//! [`AnalyzePipeline`](crate::analyze::AnalyzePipeline) for detection-only
+//! consumers.
 
 use crate::detector::{CameraId, Detection, Detector};
 use crate::director::MappedDetection;
 
-use super::DetectionCallback;
+use super::{DetectionSink, DetectionSinkError};
 
-/// Detection pipeline owning detector backends, interval, callback,
+/// Detection pipeline owning detector backends, interval, sink,
 /// and cached detections.
 ///
 /// Used internally by [`StitchSession`](crate::session::StitchSession) and also
@@ -22,7 +24,7 @@ pub struct DetectionPipeline {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     pub(super) metal_detector: Option<Box<dyn crate::detector::MetalDetector>>,
     detection_interval: u64,
-    callback: Option<DetectionCallback>,
+    sink: Option<Box<dyn DetectionSink>>,
     pub(super) last_detections: Vec<MappedDetection>,
 }
 
@@ -42,7 +44,7 @@ impl DetectionPipeline {
             #[cfg(any(target_os = "macos", target_os = "ios"))]
             metal_detector: None,
             detection_interval: 1,
-            callback: None,
+            sink: None,
             last_detections: Vec::new(),
         }
     }
@@ -97,15 +99,39 @@ impl DetectionPipeline {
         self.detection_interval = interval.max(1);
     }
 
-    /// Set a callback for receiving tracked detection data.
-    pub fn set_callback(&mut self, cb: DetectionCallback) {
-        self.callback = Some(cb);
+    /// Set the sink that receives tracked detection data each frame.
+    ///
+    /// Replaces any sink set previously. Sink errors returned from
+    /// [`DetectionSink::on_detections`] abort the current session call
+    /// with [`SessionError::DetectionSink`](super::SessionError::DetectionSink).
+    pub fn set_sink(&mut self, sink: Box<dyn DetectionSink>) {
+        self.sink = Some(sink);
+    }
+
+    /// The most recent panorama-mapped detections.
+    ///
+    /// Owned by the pipeline so both [`StitchSession`](super::StitchSession)
+    /// and standalone callers (analyze path) can read or replace this
+    /// buffer without duplicating state.
+    pub fn last_detections(&self) -> &[MappedDetection] {
+        &self.last_detections
+    }
+
+    /// Replace the cached detections (e.g. after the caller has mapped
+    /// raw detector output to panorama coordinates).
+    pub fn set_last_detections(&mut self, dets: Vec<MappedDetection>) {
+        self.last_detections = dets;
     }
 
     /// Run the CPU detector on a stereo frame's raw data.
     ///
-    /// Returns an empty vec if no CPU detector is attached.
-    pub(super) fn run_detection(
+    /// Returns an empty vec if no CPU detector is attached. GPU-resident
+    /// frames (no CPU-accessible pixels) also return an empty vec.
+    ///
+    /// The caller is responsible for mapping raw detections to panorama
+    /// coordinates if needed (see
+    /// [`projection::camera_to_panorama`](crate::projection::camera_to_panorama)).
+    pub fn run_detection(
         &mut self,
         frame: &crate::source::StereoFrame,
         source_width: u32,
@@ -245,11 +271,21 @@ impl DetectionPipeline {
         detections
     }
 
-    /// Fire the detection callback with the current cached detections.
-    pub(super) fn fire_callback(&mut self, frame_count: u64, timestamp_ms: f64) {
-        if let Some(ref mut cb) = self.callback {
-            cb(&self.last_detections, frame_count, timestamp_ms);
+    /// Fire the detection sink with the current cached detections.
+    ///
+    /// Returns `Ok(())` when no sink is attached or the sink succeeds.
+    /// Sink errors propagate so `run` / `step` can abort. Callers that
+    /// compute panorama-mapped detections externally should first call
+    /// [`set_last_detections`](Self::set_last_detections).
+    pub fn fire_sink(
+        &mut self,
+        frame_index: u64,
+        timestamp_ms: f64,
+    ) -> Result<(), DetectionSinkError> {
+        if let Some(ref mut sink) = self.sink {
+            sink.on_detections(&self.last_detections, frame_index, timestamp_ms)?;
         }
+        Ok(())
     }
 }
 

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -143,14 +143,62 @@ pub enum ErrorPolicy {
     },
 }
 
-/// Callback for receiving tracked detection data.
+/// Boxed error type propagated by a [`DetectionSink`] implementation.
 ///
-/// Called each frame with the tracked objects (may be empty on non-detection
-/// frames or when no detector is configured). Use this to build external
-/// consumers like coaching assistants, VAR systems, or stats pipelines.
+/// Sinks return this so I/O failures (disk full, broken pipe) can bubble
+/// up through [`StitchSession::run`] as a [`SessionError::DetectionSink`]
+/// instead of being swallowed by a logger.
+pub type DetectionSinkError = Box<dyn std::error::Error + Send + Sync>;
+
+/// Fallible sink for per-frame tracked detection data.
 ///
-/// Arguments: `(objects, frame_index, timestamp_ms)`
-pub type DetectionCallback = Box<dyn FnMut(&[MappedDetection], u64, f64) + Send>;
+/// Sinks receive detections mapped to panorama coordinates every frame
+/// (including frames where no detector ran; the vector will be empty or
+/// hold the last known positions). The sink returns a `Result`, so CSV
+/// writers, socket senders, and similar consumers can surface I/O
+/// failures instead of logging and continuing with a corrupt output.
+///
+/// Any closure matching the signature `FnMut(&[MappedDetection], u64, f64)
+/// -> Result<(), DetectionSinkError>` automatically implements this trait
+/// via the blanket impl below, so callers can write:
+///
+/// ```rust,ignore
+/// session.set_detection_sink(Box::new(|dets, frame_idx, ts_ms| {
+///     writer.write_csv_row(dets, frame_idx, ts_ms)?;
+///     Ok(())
+/// }));
+/// ```
+///
+/// A sink is called once per frame. Errors returned from the sink abort
+/// the current session call (`step`, `process_frame`, or `run`) with
+/// [`SessionError::DetectionSink`].
+pub trait DetectionSink: Send {
+    /// Receive tracked detections for a single frame.
+    ///
+    /// `detections` is the same data the director sees (panorama
+    /// coordinates, camera origin, confidence). `frame_index` is 0-based.
+    /// `timestamp_ms` is measured from session start (not PTS).
+    fn on_detections(
+        &mut self,
+        detections: &[MappedDetection],
+        frame_index: u64,
+        timestamp_ms: f64,
+    ) -> Result<(), DetectionSinkError>;
+}
+
+impl<F> DetectionSink for F
+where
+    F: FnMut(&[MappedDetection], u64, f64) -> Result<(), DetectionSinkError> + Send,
+{
+    fn on_detections(
+        &mut self,
+        detections: &[MappedDetection],
+        frame_index: u64,
+        timestamp_ms: f64,
+    ) -> Result<(), DetectionSinkError> {
+        (self)(detections, frame_index, timestamp_ms)
+    }
+}
 
 /// Errors from [`StitchSession`].
 #[derive(Debug, Error)]
@@ -187,6 +235,14 @@ pub enum SessionError {
     /// Missing or invalid configuration.
     #[error("config: {0}")]
     Config(String),
+
+    /// A [`DetectionSink`] returned an error.
+    ///
+    /// Surfaces I/O failures from user-supplied sinks (CSV writers,
+    /// network senders, ...) so they are not silently swallowed. The
+    /// inner error is whatever the sink returned.
+    #[error("detection sink: {0}")]
+    DetectionSink(#[source] DetectionSinkError),
 }
 
 /// Builder for constructing a [`StitchSession`] with sensible defaults.
@@ -566,6 +622,26 @@ impl StitchSession {
         self.coverage.as_ref()
     }
 
+    /// Full angular extent of the stitched panorama.
+    ///
+    /// Higher-level shortcut for analytics consumers (heatmaps, zone
+    /// statistics) that want the coverage bounds without reaching into
+    /// [`CoverageBoundary`](crate::projection::CoverageBoundary). Returns
+    /// `None` if the session has no coverage boundary (should not happen
+    /// for sessions built from a valid calibration).
+    pub fn panorama_extent(&self) -> Option<crate::projection::PanoramaExtent> {
+        self.coverage.as_ref().map(|c| {
+            let (yaw_min, yaw_max) = c.yaw_range();
+            let (pitch_min, pitch_max) = c.pitch_range();
+            crate::projection::PanoramaExtent {
+                yaw_min,
+                yaw_max,
+                pitch_min,
+                pitch_max,
+            }
+        })
+    }
+
     /// Attach an encoder to this session.
     ///
     /// The encoder is moved to a background thread for async encoding.
@@ -644,16 +720,28 @@ impl StitchSession {
         self.director = Some(director);
     }
 
-    /// Set a callback for receiving tracked detection data.
+    /// Set the sink that receives tracked detection data each frame.
     ///
-    /// Called each frame with the current tracked objects, frame index,
-    /// and timestamp. Use this to build external consumers like coaching
-    /// assistants, VAR systems, or stats pipelines.
+    /// The sink is called once per frame with the current tracked
+    /// objects, frame index, and timestamp. Errors returned from the
+    /// sink abort the current session call ([`run`](Self::run),
+    /// [`step`](Self::step), [`process_frame`](Self::process_frame))
+    /// with [`SessionError::DetectionSink`].
     ///
-    /// The callback receives the same [`MappedDetection`] data as the director,
-    /// including panorama-space coordinates.
-    pub fn set_detection_callback(&mut self, cb: DetectionCallback) {
-        self.detection.set_callback(cb);
+    /// Closures matching `FnMut(&[MappedDetection], u64, f64) -> Result<(),
+    /// DetectionSinkError>` implement [`DetectionSink`] automatically via
+    /// the blanket impl, so typical usage is:
+    ///
+    /// ```rust,ignore
+    /// session.set_detection_sink(Box::new(|dets, frame_idx, ts_ms| {
+    ///     writer.write_row(dets, frame_idx, ts_ms)?;
+    ///     Ok(())
+    /// }));
+    /// ```
+    ///
+    /// Replaces any previously registered sink.
+    pub fn set_detection_sink(&mut self, sink: Box<dyn DetectionSink>) {
+        self.detection.set_sink(sink);
     }
 
     /// Get the current viewport position from the director, or default.
@@ -696,12 +784,13 @@ impl StitchSession {
     ///
     /// Detection only runs every `detection_interval` frames. On skipped
     /// frames, the last tracked objects are reused so the director still
-    /// has context. The detection callback fires every frame.
+    /// has context. The detection sink fires every frame; an error from
+    /// the sink aborts this call with [`SessionError::DetectionSink`].
     pub fn detect_and_update_director(
         &mut self,
         frame: &StereoFrame,
         elapsed: std::time::Duration,
-    ) {
+    ) -> Result<(), SessionError> {
         let should_detect = self.detection.should_detect(self.frame_count);
 
         if should_detect {
@@ -710,7 +799,7 @@ impl StitchSession {
             self.detection.last_detections = self.map_detections(detections);
         }
 
-        self.fire_callback_and_update_director(elapsed, should_detect);
+        self.fire_sink_and_update_director(elapsed, should_detect)
     }
 
     /// Update the director without detection (zero-copy paths).
@@ -721,8 +810,11 @@ impl StitchSession {
         any(target_os = "linux", target_os = "windows"),
         allow(dead_code, reason = "used by macOS zero-copy path")
     )]
-    pub(crate) fn update_director(&mut self, elapsed: std::time::Duration) {
-        self.fire_callback_and_update_director(elapsed, false);
+    pub(crate) fn update_director(
+        &mut self,
+        elapsed: std::time::Duration,
+    ) -> Result<(), SessionError> {
+        self.fire_sink_and_update_director(elapsed, false)
     }
 
     /// Run GPU-resident detection and update the director.
@@ -742,7 +834,7 @@ impl StitchSession {
         left_slot: u8,
         right_slot: u8,
         elapsed: std::time::Duration,
-    ) {
+    ) -> Result<(), SessionError> {
         let should_detect = self.detection.should_detect(self.frame_count);
 
         if should_detect && self.detection.has_gpu_detector() {
@@ -757,7 +849,7 @@ impl StitchSession {
             self.detection.last_detections = self.map_detections(detections);
         }
 
-        self.fire_callback_and_update_director(elapsed, should_detect);
+        self.fire_sink_and_update_director(elapsed, should_detect)
     }
 
     /// Run Metal-resident detection and update the director.
@@ -777,7 +869,7 @@ impl StitchSession {
         width: u32,
         height: u32,
         elapsed: std::time::Duration,
-    ) {
+    ) -> Result<(), SessionError> {
         let should_detect = self.detection.should_detect(self.frame_count);
 
         if should_detect && self.detection.has_metal_detector() {
@@ -788,25 +880,30 @@ impl StitchSession {
             self.detection.last_detections = self.map_detections(detections);
         }
 
-        self.fire_callback_and_update_director(elapsed, should_detect);
+        self.fire_sink_and_update_director(elapsed, should_detect)
     }
 
-    /// Fire the detection callback and update the director with current state.
+    /// Fire the detection sink and update the director with current state.
     ///
     /// Shared tail for all detection paths (CPU, GPU, Metal, no-detection).
-    /// Fires the callback with `last_detections` (which may be empty if no
+    /// Fires the sink with `last_detections` (which may be empty if no
     /// detector ran this frame) and passes a [`DirectorContext`] to the
     /// director. Viewport constraining is handled separately by
     /// [`director_position`](Self::director_position).
-    fn fire_callback_and_update_director(
+    ///
+    /// Sink errors surface as [`SessionError::DetectionSink`] and abort the
+    /// current session call.
+    fn fire_sink_and_update_director(
         &mut self,
         elapsed: std::time::Duration,
         fresh_detection: bool,
-    ) {
+    ) -> Result<(), SessionError> {
         let timestamp_ms = elapsed.as_secs_f64() * 1000.0;
 
-        // Fire callback for external consumers.
-        self.detection.fire_callback(self.frame_count, timestamp_ms);
+        // Fire sink for external consumers.
+        self.detection
+            .fire_sink(self.frame_count, timestamp_ms)
+            .map_err(SessionError::DetectionSink)?;
 
         // Update director with detections and timing only.
         // Coverage clamping is applied later in director_position().
@@ -819,6 +916,7 @@ impl StitchSession {
             };
             director.update(&ctx);
         }
+        Ok(())
     }
 
     /// Map raw detections to panorama coordinates.
@@ -882,7 +980,7 @@ impl StitchSession {
         override_position: Option<ViewportPosition>,
     ) -> Result<StepResult, SessionError> {
         // Run detection and update director.
-        self.detect_and_update_director(frame, elapsed);
+        self.detect_and_update_director(frame, elapsed)?;
 
         // Get viewport position (from director or override).
         let pos = if let Some(ovr) = override_position {
@@ -1021,7 +1119,7 @@ impl StitchSession {
         if let Some((left_buf, right_buf)) = buf_info {
             self.detect_and_update_director_gpu(
                 left_buf, right_buf, left_slot, right_slot, elapsed,
-            );
+            )?;
         }
         let pos = self.director_position();
 
@@ -1190,7 +1288,7 @@ impl StitchSession {
                 }
                 _ => {
                     // CPU-resident frames (Yuv420p, Nv12)
-                    self.detect_and_update_director(&frame, start.elapsed());
+                    self.detect_and_update_director(&frame, start.elapsed())?;
                     let pos = self.director_position();
                     self.process_frame(&frame, pos.yaw, pos.pitch)?;
                 }
@@ -1241,7 +1339,7 @@ impl StitchSession {
                 }
             };
             decoded_count += 1;
-            self.detect_and_update_director(&frame, start.elapsed());
+            self.detect_and_update_director(&frame, start.elapsed())?;
             buffer.push_back(frame);
         }
 
@@ -1263,7 +1361,7 @@ impl StitchSession {
                 };
                 if let Some(f) = frame {
                     decoded_count += 1;
-                    self.detect_and_update_director(&f, start.elapsed());
+                    self.detect_and_update_director(&f, start.elapsed())?;
                     buffer.push_back(f);
                 }
             }

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -465,3 +465,49 @@ fn compute_frame_limit_negative_fps_uses_fallback() {
     let result = compute_frame_limit(Some(10.0), None, -1.0);
     assert_eq!(result, 300);
 }
+
+// ─── DetectionSink behavioral tests ─────────────────────────────────────
+
+use crate::session::detection::DetectionPipeline;
+
+#[test]
+fn detection_sink_closure_fires_with_detections() {
+    // Closures matching the sink signature should implement DetectionSink
+    // via the blanket impl and observe the same data the callback API does.
+    let mut pipeline = DetectionPipeline::new();
+    let counter = Arc::new(AtomicU64::new(0));
+    let c = counter.clone();
+    pipeline.set_sink(Box::new(
+        move |_dets: &[_],
+              _idx: u64,
+              _ts: f64|
+              -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            c.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        },
+    ));
+
+    pipeline.fire_sink(0, 0.0).unwrap();
+    pipeline.fire_sink(1, 33.3).unwrap();
+    pipeline.fire_sink(2, 66.6).unwrap();
+
+    assert_eq!(counter.load(Ordering::Relaxed), 3);
+}
+
+#[test]
+fn detection_sink_error_is_propagated() {
+    // A sink that returns Err must not be swallowed; fire_sink propagates
+    // the error so the session can surface it via SessionError::DetectionSink.
+    let mut pipeline = DetectionPipeline::new();
+    pipeline.set_sink(Box::new(
+        |_dets: &[_],
+         _idx: u64,
+         _ts: f64|
+         -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Err("disk full".into())
+        },
+    ));
+
+    let err = pipeline.fire_sink(0, 0.0).unwrap_err();
+    assert!(err.to_string().contains("disk full"));
+}

--- a/crates/reco-core/src/session/zero_copy_linux.rs
+++ b/crates/reco-core/src/session/zero_copy_linux.rs
@@ -244,7 +244,7 @@ impl StitchSession {
                 signal.left_slot,
                 signal.right_slot,
                 start.elapsed(),
-            );
+            )?;
             let pos = self.director_position();
             let render_buf = self.pipeline.render_gpu_frame(
                 &bind_groups,

--- a/crates/reco-core/src/session/zero_copy_macos.rs
+++ b/crates/reco-core/src/session/zero_copy_macos.rs
@@ -57,9 +57,9 @@ impl StitchSession {
                     width,
                     height,
                     start.elapsed(),
-                );
+                )?;
             } else {
-                self.update_director(start.elapsed());
+                self.update_director(start.elapsed())?;
             }
             let pos = self.director_position();
             let render_buf = self.pipeline.render_imported_textures(

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -300,4 +300,21 @@ pub trait FrameSource: Send {
     fn total_frames(&self) -> Option<u64> {
         None
     }
+
+    /// Whether the source has reached end-of-stream.
+    ///
+    /// Once [`try_next_frame`](Self::try_next_frame) or
+    /// [`next_frame`](Self::next_frame) has returned `Ok(None)` for reasons
+    /// that are final (container EOF, camera stream ended), implementations
+    /// should return `true` from this method so callers can distinguish
+    /// "finished" from "frame not ready yet".
+    ///
+    /// Used by interactive consumers (GUI playback, OBS) that need to tell
+    /// end-of-stream apart from a transiently empty decode channel without
+    /// a timeout heuristic. File sources should override this to track EOF;
+    /// live sources (cameras) can keep the default (`false`) since they
+    /// never exhaust under normal operation.
+    fn is_exhausted(&self) -> bool {
+        false
+    }
 }

--- a/crates/reco-core/src/stitch_renderer.rs
+++ b/crates/reco-core/src/stitch_renderer.rs
@@ -25,6 +25,7 @@ use crate::nv12_converter::Nv12Converter;
 use crate::pipeline::{Nv12Planes, PipelineError, StitchPipeline, YuvPlanes};
 use crate::projection::CoverageBoundary;
 use crate::renderer::InputFormat;
+use crate::rgba_readback::RgbaReadback;
 use crate::scene::SceneGeometry;
 use crate::viewport::ViewportConfig;
 
@@ -38,8 +39,10 @@ pub struct StitchRenderer {
     pipeline: StitchPipeline,
     /// Precomputed coverage boundary for no-black-edge clamping.
     coverage: CoverageBoundary,
-    /// NV12 converter for readback (lazy-initialized on first readback call).
+    /// NV12 converter for encode readback (lazy-initialized on first call).
     nv12: Option<Nv12Converter>,
+    /// RGBA readback helper for display in GUI frameworks (lazy-initialized).
+    rgba: Option<RgbaReadback>,
 }
 
 impl StitchRenderer {
@@ -85,6 +88,7 @@ impl StitchRenderer {
             pipeline,
             coverage,
             nv12: None,
+            rgba: None,
         })
     }
 
@@ -180,6 +184,79 @@ impl StitchRenderer {
             nv12.flush_pending(self.pipeline.gpu())
                 .map_err(|e| PipelineError::InvalidConfig {
                     reason: format!("NV12 flush: {e}"),
+                })
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Render a stereo frame and read back tightly-packed RGBA pixels.
+    ///
+    /// Intended for GUI frameworks and plugin consumers (OBS, egui) that
+    /// need CPU-side pixels for display. Mirrors
+    /// [`render_and_readback_nv12`](Self::render_and_readback_nv12) but
+    /// outputs `width * height * 4` bytes of RGBA in the render target's
+    /// texture format (`Rgba8Unorm` or `Bgra8Unorm` — see
+    /// [`strip_srgb`](Self::strip_srgb)).
+    ///
+    /// Uses [`RgbaReadback`]'s triple-buffer staging so the returned slice
+    /// is always from 2 frames ago. `None` on the first two calls during
+    /// warmup; `Some(&[u8])` from the third call onward. Call
+    /// [`flush_rgba`](Self::flush_rgba) in a loop after the frame loop to
+    /// drain the last two frames.
+    ///
+    /// Use alongside [`render_yuv`](Self::render_yuv) when the GPU drives a
+    /// surface and you only need readback for a secondary display path:
+    /// ```rust,ignore
+    /// renderer.render_yuv(&left, &right, yaw, pitch, &surface_view)?;
+    /// if let Some(rgba) = renderer.render_and_readback_rgba(&left, &right, yaw, pitch)? {
+    ///     shared_display_buffer.copy_from_slice(rgba);
+    /// }
+    /// ```
+    ///
+    /// Note that this submits its own render command buffer internally
+    /// (the double-render is cheap — shader cost is negligible next to
+    /// display compositing), so callers that only need readback should
+    /// use this method alone rather than combining with `render_yuv`.
+    pub fn render_and_readback_rgba(
+        &mut self,
+        left: &YuvPlanes<'_>,
+        right: &YuvPlanes<'_>,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Option<&[u8]>, PipelineError> {
+        if self.rgba.is_none() {
+            let w = self.pipeline.viewport().width;
+            let h = self.pipeline.viewport().height;
+            self.rgba = Some(RgbaReadback::new(self.pipeline.gpu(), w, h).map_err(|e| {
+                PipelineError::InvalidConfig {
+                    reason: format!("RGBA readback init: {e}"),
+                }
+            })?);
+            log::info!("StitchRenderer: RGBA readback initialized ({w}x{h})");
+        }
+
+        let cmd = self.pipeline.render_to_target(left, right, yaw, pitch)?;
+
+        let rgba = self.rgba.as_mut().unwrap();
+        let data = rgba
+            .readback(self.pipeline.gpu(), self.pipeline.render_target(), cmd)
+            .map_err(|e| PipelineError::InvalidConfig {
+                reason: format!("RGBA readback: {e}"),
+            })?;
+
+        Ok(data)
+    }
+
+    /// Flush one pending RGBA frame from the triple-buffer pipeline.
+    ///
+    /// Call in a loop after the frame loop ends to drain the final 1-2
+    /// frames. Returns `None` when no frames remain.
+    pub fn flush_rgba(&mut self) -> Result<Option<&[u8]>, PipelineError> {
+        if let Some(ref mut rgba) = self.rgba {
+            rgba.flush_pending(self.pipeline.gpu())
+                .map_err(|e| PipelineError::InvalidConfig {
+                    reason: format!("RGBA flush: {e}"),
                 })
         } else {
             Ok(None)

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -153,14 +153,10 @@ impl Playback {
             }
             None => {
                 // Could be "not ready yet" or "end of stream".
-                // FfmpegFileSource returns Disconnected for EOF.
-                // try_next_frame returns Ok(None) for both cases,
-                // but after EOF the channel disconnects and stays None.
-                // If we've been getting None for a while with no new
-                // frames, assume EOF.
-                if self.last_frame_time.is_some()
-                    && now.duration_since(self.last_frame_time.unwrap()) > self.frame_duration * 30
-                {
+                // `FrameSource::is_exhausted()` answers unambiguously once
+                // the decoder channel has disconnected, so no timeout
+                // heuristic is needed.
+                if source.is_exhausted() {
                     self.state = PlayState::Finished;
                 }
                 Ok(false)

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -43,6 +43,14 @@ pub struct FfmpegFileSource {
     total_frame_count: Option<u64>,
     /// Current frame position (incremented on each next_frame).
     current_frame: u64,
+    /// True once the decode pipeline has signaled end-of-stream.
+    ///
+    /// Set when the internal receiver reports `Disconnected` (both decode
+    /// threads have finished). A blocking `recv()` returning `Err` or a
+    /// non-blocking `try_recv()` returning `Disconnected` are the two
+    /// places this becomes `true`. Reset by `seek()`, which respawns
+    /// the decode pipeline.
+    exhausted: bool,
 }
 
 #[cfg(feature = "ffmpeg")]
@@ -110,6 +118,7 @@ impl FfmpegFileSource {
             sync_offset,
             total_frame_count,
             current_frame: 0,
+            exhausted: false,
         })
     }
 
@@ -320,7 +329,10 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
                 self.current_frame += 1;
                 Ok(Some(StereoFrame::Yuv420p(pair)))
             }
-            Err(_) => Ok(None),
+            Err(_) => {
+                self.exhausted = true;
+                Ok(None)
+            }
         }
     }
 
@@ -331,7 +343,10 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
                 Ok(Some(StereoFrame::Yuv420p(pair)))
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => Ok(None),
-            Err(std::sync::mpsc::TryRecvError::Disconnected) => Ok(None),
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                self.exhausted = true;
+                Ok(None)
+            }
         }
     }
 
@@ -379,11 +394,16 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
             Some(secs),
         );
         self.current_frame = frame;
+        self.exhausted = false;
         Ok(())
     }
 
     fn total_frames(&self) -> Option<u64> {
         self.total_frame_count
+    }
+
+    fn is_exhausted(&self) -> bool {
+        self.exhausted
     }
 }
 

--- a/crates/reco-io/src/analyze_job.rs
+++ b/crates/reco-io/src/analyze_job.rs
@@ -1,0 +1,240 @@
+//! One-shot detection-only job (analytics sibling of
+//! [`StitchJob`](crate::StitchJob)).
+//!
+//! [`AnalyzeJob`] decodes one or more paired videos, runs a detector on
+//! each CPU-resident frame, and fires a [`DetectionSink`] per frame.
+//! There is no GPU stitch pipeline, no NV12 converter, and no encoder —
+//! analytics consumers (heatmaps, highlight reels, offline stats) use
+//! this to avoid paying for render + encode just to reach the sink.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! use reco_io::AnalyzeJob;
+//!
+//! let interrupted = std::sync::atomic::AtomicBool::new(false);
+//! let result = AnalyzeJob::new("left.mp4", "right.mp4", "match.json")
+//!     .detector(Box::new(my_detector))
+//!     .on_detections(Box::new(|dets, frame_idx, ts_ms| {
+//!         csv.write_row(dets, frame_idx, ts_ms)?;
+//!         Ok(())
+//!     }))
+//!     .run(&interrupted)?;
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use reco_core::analyze::{AnalyzeError, AnalyzePipeline};
+use reco_core::detector::Detector;
+use reco_core::session::{DetectionSink, FrameProgress};
+use reco_core::source::FrameSource;
+
+use crate::stitch_job::{InputPath, StitchError};
+
+/// Boxed progress callback type alias to satisfy clippy::type_complexity.
+type ProgressCallback = Box<dyn FnMut(&FrameProgress) + Send>;
+
+/// Where to load calibration from.
+enum CalibrationSource {
+    /// Load from a JSON file path.
+    File(PathBuf),
+    /// Use an in-memory calibration (no file I/O).
+    Memory(Box<reco_core::calibration::MatchCalibration>),
+}
+
+/// One-shot detection-only job: video files in, per-frame detections out.
+///
+/// No GPU, no encoder, no render. Intended for analytics consumers
+/// (heatmaps, highlights, stats) that need only detection data mapped
+/// into panorama coordinates.
+pub struct AnalyzeJob {
+    left: InputPath,
+    right: InputPath,
+    calibration: CalibrationSource,
+
+    // Processing settings
+    max_frames: Option<u64>,
+    duration: Option<f64>,
+    sync_offset: Option<i64>,
+    detection_interval: u64,
+
+    // Detector + sink
+    detector: Option<Box<dyn Detector>>,
+    sink: Option<Box<dyn DetectionSink>>,
+
+    // Callback
+    on_progress: Option<ProgressCallback>,
+}
+
+/// Result of a completed analyze job.
+#[derive(Debug)]
+pub struct AnalyzeResult {
+    /// Number of frames processed.
+    pub frames_processed: u64,
+    /// Total wall-clock time.
+    pub elapsed: Duration,
+    /// Decode mode (e.g. "CPU upload").
+    pub decode_mode: String,
+}
+
+impl AnalyzeResult {
+    /// Average frames per second.
+    pub fn fps(&self) -> f64 {
+        self.frames_processed as f64 / self.elapsed.as_secs_f64()
+    }
+}
+
+impl AnalyzeJob {
+    /// Create an analyze job from file paths (loads calibration from JSON).
+    pub fn new(
+        left: impl Into<InputPath>,
+        right: impl Into<InputPath>,
+        calibration: impl AsRef<Path>,
+    ) -> Self {
+        Self {
+            left: left.into(),
+            right: right.into(),
+            calibration: CalibrationSource::File(calibration.as_ref().to_path_buf()),
+            max_frames: None,
+            duration: None,
+            sync_offset: None,
+            detection_interval: 1,
+            detector: None,
+            sink: None,
+            on_progress: None,
+        }
+    }
+
+    /// Create an analyze job with an in-memory calibration.
+    pub fn with_calibration(
+        left: impl Into<InputPath>,
+        right: impl Into<InputPath>,
+        calibration: reco_core::calibration::MatchCalibration,
+    ) -> Self {
+        let mut job = Self::new(left, right, Path::new(""));
+        job.calibration = CalibrationSource::Memory(Box::new(calibration));
+        job
+    }
+
+    // ── Processing settings ──
+
+    /// Limit the number of frames to process.
+    pub fn max_frames(mut self, n: u64) -> Self {
+        self.max_frames = Some(n);
+        self
+    }
+
+    /// Limit processing to a duration in seconds.
+    pub fn duration(mut self, secs: f64) -> Self {
+        self.duration = Some(secs);
+        self
+    }
+
+    /// Override the temporal sync offset between cameras (frames).
+    pub fn sync_offset(mut self, frames: i64) -> Self {
+        self.sync_offset = Some(frames);
+        self
+    }
+
+    /// Run detection every N frames (default 1, every frame).
+    pub fn detection_interval(mut self, interval: u64) -> Self {
+        self.detection_interval = interval.max(1);
+        self
+    }
+
+    // ── Detector + sink ──
+
+    /// Attach the CPU detector. Required before [`run`](Self::run).
+    pub fn detector(mut self, detector: Box<dyn Detector>) -> Self {
+        self.detector = Some(detector);
+        self
+    }
+
+    /// Attach the per-frame detection sink. Required before [`run`](Self::run).
+    pub fn on_detections(mut self, sink: Box<dyn DetectionSink>) -> Self {
+        self.sink = Some(sink);
+        self
+    }
+
+    /// Attach a progress callback. Called per processed frame.
+    pub fn on_progress(mut self, cb: impl FnMut(&FrameProgress) + Send + 'static) -> Self {
+        self.on_progress = Some(Box::new(cb));
+        self
+    }
+
+    // ── Execute ──
+
+    /// Run the analyze job.
+    ///
+    /// Blocking call. Returns an [`AnalyzeResult`] with statistics, or
+    /// an error from calibration loading, source opening, decode, or the
+    /// detection sink.
+    pub fn run(mut self, interrupted: &AtomicBool) -> Result<AnalyzeResult, StitchError> {
+        crate::init();
+        let start = std::time::Instant::now();
+
+        // Load calibration
+        let cal = match self.calibration {
+            CalibrationSource::File(ref path) => {
+                reco_core::calibration::MatchCalibration::from_file(path)
+                    .map_err(|e| StitchError::Calibration(format!("{e}")))?
+            }
+            CalibrationSource::Memory(cal) => *cal,
+        };
+        let effective_sync = self.sync_offset.unwrap_or(cal.sync_offset);
+
+        // Open the CPU decode path. GPU-resident sources won't yield
+        // CPU-accessible frames, which is a problem for detection —
+        // FfmpegFileSource stays on the CPU upload path.
+        let mut source = crate::adapters::FfmpegFileSource::open_with_offset(
+            self.left.first_path(),
+            self.right.first_path(),
+            effective_sync,
+        )?;
+        let info = source.info();
+        let decode_mode = format!("{}", source.decode_backend());
+
+        // Build analyze pipeline.
+        let mut pipeline = AnalyzePipeline::new(cal);
+        pipeline.set_detection_interval(self.detection_interval);
+        if let Some(det) = self.detector.take() {
+            pipeline.set_detector(det);
+        } else {
+            return Err(StitchError::Other(
+                "AnalyzeJob: detector is required; call .detector(...)".into(),
+            ));
+        }
+        if let Some(sink) = self.sink.take() {
+            pipeline.set_detection_sink(sink);
+        } else {
+            return Err(StitchError::Other(
+                "AnalyzeJob: detection sink is required; call .on_detections(...)".into(),
+            ));
+        }
+
+        let frame_limit =
+            reco_core::session::compute_frame_limit(self.duration, self.max_frames, info.fps);
+
+        let frames_processed = pipeline
+            .run(
+                &mut source,
+                frame_limit,
+                interrupted,
+                self.on_progress.take(),
+            )
+            .map_err(|e| match e {
+                AnalyzeError::Source(s) => StitchError::Source(s),
+                AnalyzeError::DetectionSink(e) => {
+                    StitchError::Session(reco_core::session::SessionError::DetectionSink(e))
+                }
+            })?;
+
+        Ok(AnalyzeResult {
+            frames_processed,
+            elapsed: start.elapsed(),
+            decode_mode,
+        })
+    }
+}

--- a/crates/reco-io/src/lib.rs
+++ b/crates/reco-io/src/lib.rs
@@ -29,6 +29,9 @@ pub mod smart_source;
 pub mod stitch_job;
 
 #[cfg(feature = "ffmpeg")]
+pub mod analyze_job;
+
+#[cfg(feature = "ffmpeg")]
 pub mod zero_copy;
 
 #[cfg(feature = "ffmpeg")]
@@ -36,6 +39,9 @@ pub use smart_source::SmartFileSource;
 
 #[cfg(feature = "ffmpeg")]
 pub use stitch_job::{InputPath, StitchJob, StitchResult};
+
+#[cfg(feature = "ffmpeg")]
+pub use analyze_job::{AnalyzeJob, AnalyzeResult};
 
 /// Initialize enabled backends. Call once at program start.
 ///

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -41,6 +41,12 @@ pub struct SmartFileSource {
     right_rotation: i32,
     /// Human-readable description of the active decode path.
     decode_mode: &'static str,
+    /// True once the active backend has signaled end-of-stream.
+    ///
+    /// For the CPU mode this tracks the inner `FfmpegFileSource`'s flag;
+    /// for zero-copy modes this is set locally when the pair receiver
+    /// returns `Err` (decode threads finished).
+    exhausted: bool,
 }
 
 enum SourceMode {
@@ -210,6 +216,7 @@ impl SmartFileSource {
             left_rotation,
             right_rotation,
             decode_mode: "CPU upload",
+            exhausted: false,
         })
     }
 
@@ -359,6 +366,7 @@ impl SmartFileSource {
             left_rotation,
             right_rotation,
             decode_mode: "GPU zero-copy (CUDA/Vulkan)",
+            exhausted: false,
         })
     }
 
@@ -393,6 +401,7 @@ impl SmartFileSource {
             left_rotation,
             right_rotation,
             decode_mode: "Metal zero-copy (VideoToolbox)",
+            exhausted: false,
         })
     }
 
@@ -490,7 +499,13 @@ impl FrameSource for SmartFileSource {
 
     fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
         match &mut self.mode {
-            SourceMode::Cpu(source) => source.next_frame(),
+            SourceMode::Cpu(source) => {
+                let frame = source.next_frame()?;
+                if frame.is_none() {
+                    self.exhausted = true;
+                }
+                Ok(frame)
+            }
             #[cfg(target_os = "linux")]
             SourceMode::GpuZeroCopy(state) => {
                 let rx = state
@@ -502,7 +517,10 @@ impl FrameSource for SmartFileSource {
                         left_slot: signal.left_slot,
                         right_slot: signal.right_slot,
                     })),
-                    Err(_) => Ok(None),
+                    Err(_) => {
+                        self.exhausted = true;
+                        Ok(None)
+                    }
                 }
             }
             #[cfg(target_os = "macos")]
@@ -511,7 +529,10 @@ impl FrameSource for SmartFileSource {
                     left: pair.left,
                     right: pair.right,
                 })),
-                Err(_) => Ok(None),
+                Err(_) => {
+                    self.exhausted = true;
+                    Ok(None)
+                }
             },
         }
     }
@@ -530,6 +551,19 @@ impl FrameSource for SmartFileSource {
 
     fn right_rotation(&self) -> i32 {
         self.right_rotation
+    }
+
+    fn is_exhausted(&self) -> bool {
+        // CPU mode defers to the inner FfmpegFileSource's own flag, which
+        // is also set by `try_next_frame` (the zero-copy modes don't
+        // implement `try_next_frame`, so their local flag is sufficient).
+        match &self.mode {
+            SourceMode::Cpu(source) => self.exhausted || source.is_exhausted(),
+            #[cfg(target_os = "linux")]
+            SourceMode::GpuZeroCopy(_) => self.exhausted,
+            #[cfg(target_os = "macos")]
+            SourceMode::MetalZeroCopy(_) => self.exhausted,
+        }
     }
 }
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -28,6 +28,7 @@ use reco_core::calibration::MatchCalibration;
 use reco_core::gpu::GpuContext;
 use reco_core::pipeline::{StitchPipeline, YuvPlanes};
 use reco_core::renderer::InputFormat;
+use reco_core::rgba_readback::RgbaReadback;
 use reco_core::viewport::ViewportConfig;
 
 use crate::ffi;
@@ -63,6 +64,10 @@ struct RecoSource {
     /// The wgpu stitching pipeline (None until calibration is loaded).
     pipeline: Option<StitchPipeline>,
 
+    /// RGBA readback helper (triple-buffered staging + row-padding strip).
+    /// None until the pipeline is built.
+    readback: Option<RgbaReadback>,
+
     /// The shared GPU context.
     gpu: Option<GpuContext>,
 
@@ -86,7 +91,9 @@ struct RecoSource {
     /// Camera pitch in degrees (converted to radians for the pipeline).
     pitch_degrees: f64,
 
-    /// CPU-side RGBA buffer from the last render (readback from wgpu).
+    /// CPU-side RGBA buffer from the last render (owned copy of the most
+    /// recent frame from `RgbaReadback`, so `video_render` can read it on
+    /// the OBS graphics thread without holding a borrow).
     rgba_buffer: Vec<u8>,
 
     /// Whether `rgba_buffer` has new data since the last `video_render`.
@@ -101,6 +108,7 @@ impl RecoSource {
     fn new() -> Self {
         Self {
             pipeline: None,
+            readback: None,
             gpu: None,
             calibration: None,
             config_path: String::new(),
@@ -167,14 +175,29 @@ impl RecoSource {
                     self.input_height,
                     pipeline.gpu_name(),
                 );
+                // Build the RGBA readback helper alongside the pipeline.
+                // `RgbaReadback` owns the triple-buffered staging + row
+                // padding strip that used to live inline in this file.
+                match RgbaReadback::new(pipeline.gpu(), self.output_width, self.output_height) {
+                    Ok(readback) => {
+                        self.readback = Some(readback);
+                    }
+                    Err(e) => {
+                        log::error!("reco-obs: failed to create RGBA readback: {e}");
+                        self.pipeline = None;
+                        self.readback = None;
+                        return;
+                    }
+                }
                 self.pipeline = Some(pipeline);
-                // Pre-allocate the readback buffer.
+                // Pre-allocate the owned buffer that `video_render` reads.
                 let buf_size = (self.output_width * self.output_height * 4) as usize;
                 self.rgba_buffer.resize(buf_size, 0);
             }
             Err(e) => {
                 log::error!("reco-obs: failed to create pipeline: {e}");
                 self.pipeline = None;
+                self.readback = None;
             }
         }
     }
@@ -215,7 +238,10 @@ impl RecoSource {
             Some(p) => p,
             None => return,
         };
-
+        let readback = match &mut self.readback {
+            Some(r) => r,
+            None => return,
+        };
         let gpu = match &self.gpu {
             Some(g) => g,
             None => return,
@@ -252,101 +278,28 @@ impl RecoSource {
         let yaw = (self.yaw_degrees as f32).to_radians();
         let pitch = (self.pitch_degrees as f32).to_radians();
 
-        match pipeline.render_to_target(&left, &right, yaw, pitch) {
-            Ok(cmd_buf) => {
-                gpu.queue().submit(std::iter::once(cmd_buf));
-
-                // Readback: copy render target to CPU buffer.
-                // FRICTION: There is no built-in readback helper on
-                // StitchPipeline. Consumers must manually create a staging
-                // buffer, issue a copy command, map it, and extract bytes.
-                // The Nv12Converter does this internally but is tightly
-                // coupled to NV12 output. An `fn readback_rgba(&self) -> &[u8]`
-                // method on the pipeline (or a standalone ReadbackHelper)
-                // would be very useful for plugin consumers that need RGBA.
-
-                let render_target = pipeline.render_target();
-                let width = self.output_width;
-                let height = self.output_height;
-                let bytes_per_row = width * 4;
-                // wgpu requires rows aligned to 256 bytes.
-                let padded_bytes_per_row = (bytes_per_row + 255) & !255;
-
-                let staging_buf = gpu
-                    .device()
-                    .create_buffer(&reco_core::wgpu::BufferDescriptor {
-                        label: Some("reco-obs readback"),
-                        size: (padded_bytes_per_row * height) as u64,
-                        usage: reco_core::wgpu::BufferUsages::COPY_DST
-                            | reco_core::wgpu::BufferUsages::MAP_READ,
-                        mapped_at_creation: false,
-                    });
-
-                let mut encoder = gpu.device().create_command_encoder(
-                    &reco_core::wgpu::CommandEncoderDescriptor {
-                        label: Some("reco-obs readback encoder"),
-                    },
-                );
-
-                encoder.copy_texture_to_buffer(
-                    reco_core::wgpu::TexelCopyTextureInfo {
-                        texture: render_target,
-                        mip_level: 0,
-                        origin: reco_core::wgpu::Origin3d::ZERO,
-                        aspect: reco_core::wgpu::TextureAspect::All,
-                    },
-                    reco_core::wgpu::TexelCopyBufferInfo {
-                        buffer: &staging_buf,
-                        layout: reco_core::wgpu::TexelCopyBufferLayout {
-                            offset: 0,
-                            bytes_per_row: Some(padded_bytes_per_row),
-                            rows_per_image: Some(height),
-                        },
-                    },
-                    reco_core::wgpu::Extent3d {
-                        width,
-                        height,
-                        depth_or_array_layers: 1,
-                    },
-                );
-
-                gpu.queue().submit(std::iter::once(encoder.finish()));
-
-                // Synchronous map (blocking). Acceptable for now; a double/
-                // triple-buffer scheme would avoid stalling the pipeline.
-                let slice = staging_buf.slice(..);
-                let (tx, rx) = std::sync::mpsc::channel();
-                slice.map_async(reco_core::wgpu::MapMode::Read, move |result| {
-                    let _ = tx.send(result);
-                });
-                let _ = gpu
-                    .device()
-                    .poll(reco_core::wgpu::PollType::wait_indefinitely());
-
-                match rx.recv() {
-                    Ok(Ok(())) => {
-                        let mapped = slice.get_mapped_range();
-                        // Copy rows, stripping padding.
-                        for row in 0..height as usize {
-                            let src_offset = row * padded_bytes_per_row as usize;
-                            let dst_offset = row * bytes_per_row as usize;
-                            self.rgba_buffer[dst_offset..dst_offset + bytes_per_row as usize]
-                                .copy_from_slice(
-                                    &mapped[src_offset..src_offset + bytes_per_row as usize],
-                                );
-                        }
-                        self.frame_ready.store(true, Ordering::Release);
-                    }
-                    Ok(Err(e)) => {
-                        log::error!("reco-obs: buffer map failed: {e}");
-                    }
-                    Err(e) => {
-                        log::error!("reco-obs: readback channel error: {e}");
-                    }
-                }
-            }
+        // Render + triple-buffered RGBA readback via the shared
+        // `RgbaReadback` helper in reco-core. Returns `None` on the first
+        // two calls (pipeline warmup) and tightly-packed RGBA thereafter,
+        // so the wgpu 256-byte row padding is stripped for us.
+        let cmd_buf = match pipeline.render_to_target(&left, &right, yaw, pitch) {
+            Ok(cmd) => cmd,
             Err(e) => {
                 log::error!("reco-obs: render failed: {e}");
+                return;
+            }
+        };
+
+        match readback.readback(gpu, pipeline.render_target(), cmd_buf) {
+            Ok(Some(rgba)) => {
+                self.rgba_buffer.copy_from_slice(rgba);
+                self.frame_ready.store(true, Ordering::Release);
+            }
+            Ok(None) => {
+                // Pipeline warmup; next tick will have data.
+            }
+            Err(e) => {
+                log::error!("reco-obs: RGBA readback failed: {e}");
             }
         }
     }


### PR DESCRIPTION
## Summary

Implements Batch A of the FRICTION-driven roadmap (#228 → #223). Adds
the five reco-core / reco-io APIs that every consumer (reco-gui,
reco-obs, and the archived reco-highlights / reco-heatmap /
reco-stats) independently flagged as painful.

Single-path, no back-compat shims - the project is pre-release and we
control every consumer.

### API additions

- `StitchRenderer::render_and_readback_rgba` + new `rgba_readback::RgbaReadback` module. Triple-buffered RGBA readback that mirrors the existing NV12 helper. Strips wgpu's 256-byte row padding so consumers get tightly packed `width * height * 4` bytes.
- `analyze::AnalyzePipeline` in reco-core + `reco_io::AnalyzeJob` in reco-io. Decode + detect + sink with no GPU render, no NV12 converter, no encoder. Unblocks analytics consumers that previously paid for a full stitched video just to reach the detection callback.
- `DetectionSink` trait returning `Result<(), DetectionSinkError>` + `StitchSession::set_detection_sink` + `SessionError::DetectionSink`. Closures implement the trait via blanket impl so typical usage is `Box::new(|dets, idx, ts| -> Result<_,_> { ... })`. The old `DetectionCallback` / `set_detection_callback` path is removed entirely.
- `CoverageBoundary::yaw_range` / `pitch_range` accessors plus a new `PanoramaExtent` struct returned by `StitchSession::panorama_extent` and `AnalyzePipeline::panorama_extent`. Heatmap / zone-stats consumers get correct bounds instead of hardcoding `+/-45deg yaw, +/-20deg pitch`.
- `FrameSource::is_exhausted` trait method (default `false`). `FfmpegFileSource` tracks mpsc `Disconnected`; `SmartFileSource` delegates to the active mode; live cameras keep the default.

### Modularity tightening done in the same pass

- `DetectionPipeline` now has a complete public API (`set_sink`, `set_detector`, `run_detection`, `last_detections`, `set_last_detections`, `fire_sink`). No more `pub(super)` escape hatches in the hot path - it's reusable as a standalone component.
- `AnalyzePipeline` no longer duplicates a `last_detections` buffer; writes directly into `DetectionPipeline` via `set_last_detections`. One fire method (`fire_sink`) instead of two.

### Consumer updates

- **reco-obs**: uses `RgbaReadback` directly. Drops ~100 lines of hand-rolled staging-buffer / bind-group / row-strip code from `source.rs`.
- **reco-gui**: `Playback::tick` uses `source.is_exhausted()` instead of the 30-frame stall-timer EOF heuristic.

### Tests added

- Projection: `coverage_yaw_and_pitch_ranges_match_internal_state`, `coverage_yaw_range_is_widest_slice_envelope`, `panorama_extent_normalize_*`.
- Session: `detection_sink_closure_fires_with_detections`, `detection_sink_error_is_propagated`.
- Rgba readback: row-stride alignment tests.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings` (clean against `main` + wgpu 29 fork)
- [x] `cargo test --all` (173 passed, 0 failed)
- [ ] Run reco-gui against a test video and confirm end-of-stream flips to `Finished`.
- [ ] Run reco-obs in an OBS session and confirm the panorama still renders.
- [ ] Run a detection-only workflow via the new `AnalyzeJob` and verify the sink fires per frame without GPU encoder init.

Closes #223. Progress on umbrella #228.