### PR TITLE
feat(reco-calibrate): Batch B lens profile + IMU APIs

### DIFF
--- a/crates/reco-calibrate/src/lens_database.rs
+++ b/crates/reco-calibrate/src/lens_database.rs
@@ -22,6 +22,8 @@ use std::collections::HashMap;
 use std::io::Read;
 use std::path::Path;
 
+use crate::types::{LensProfileInfo, LensProfileSummary, ProfileSource};
+
 /// Embedded Gyroflow lens profile database (profiles.cbor.gz).
 static PROFILES_CBOR_GZ: &[u8] = include_bytes!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -135,7 +137,7 @@ impl LensDatabase {
         width: u32,
         height: u32,
         lens_info: Option<&str>,
-    ) -> Option<CameraParams> {
+    ) -> Option<(CameraParams, LensProfileInfo)> {
         let key = normalize_camera_key(brand, model);
         // Try exact model first, then strip variant suffixes to find the
         // parent model (e.g. "HERO11 Black Mini" -> "HERO11 Black").
@@ -228,7 +230,13 @@ impl LensDatabase {
                     p.lens_model,
                     p.source
                 );
-                return Some(p.params.clone());
+                let info = LensProfileInfo {
+                    camera: format_camera_name(&p.brand, &p.model),
+                    lens: format_lens_name(&p.lens_model, &p.camera_setting),
+                    source: ProfileSource::Database,
+                    path: None,
+                };
+                return Some((p.params.clone(), info));
             }
         }
 
@@ -256,7 +264,7 @@ impl LensDatabase {
                 p.lens_model,
                 p.source
             );
-            return Some(CameraParams {
+            let params = CameraParams {
                 width,
                 height,
                 fx: p.params.fx * scale,
@@ -264,7 +272,14 @@ impl LensDatabase {
                 cx: p.params.cx * scale,
                 cy: p.params.cy * scale,
                 d: p.params.d, // distortion coeffs are scale-invariant
-            });
+            };
+            let info = LensProfileInfo {
+                camera: format_camera_name(&p.brand, &p.model),
+                lens: format_lens_name(&p.lens_model, &p.camera_setting),
+                source: ProfileSource::Database,
+                path: None,
+            };
+            return Some((params, info));
         }
 
         log::warn!(
@@ -285,7 +300,7 @@ impl LensDatabase {
         width: u32,
         height: u32,
         lens_info: Option<&str>,
-    ) -> Option<CameraParams> {
+    ) -> Option<(CameraParams, LensProfileInfo)> {
         let model = camera_model.unwrap_or(camera_type);
         self.find(camera_type, model, width, height, lens_info)
     }
@@ -295,7 +310,11 @@ impl LensDatabase {
     /// Searches all profiles for an exact resolution match. If multiple
     /// cameras share the same resolution, returns the first match.
     /// This is the last-resort fallback when telemetry extraction fails.
-    pub fn find_by_resolution(&self, width: u32, height: u32) -> Option<CameraParams> {
+    pub fn find_by_resolution(
+        &self,
+        width: u32,
+        height: u32,
+    ) -> Option<(CameraParams, LensProfileInfo)> {
         for p in &self.profiles {
             if p.width == width && p.height == height {
                 log::info!(
@@ -305,7 +324,13 @@ impl LensDatabase {
                     p.brand,
                     p.source
                 );
-                return Some(p.params.clone());
+                let info = LensProfileInfo {
+                    camera: format_camera_name(&p.brand, &p.model),
+                    lens: format_lens_name(&p.lens_model, &p.camera_setting),
+                    source: ProfileSource::Fallback,
+                    path: None,
+                };
+                return Some((p.params.clone(), info));
             }
         }
         None
@@ -319,6 +344,76 @@ impl LensDatabase {
     /// Whether the database is empty.
     pub fn is_empty(&self) -> bool {
         self.profiles.is_empty()
+    }
+
+    /// Iterate over all profiles in the database as summaries.
+    ///
+    /// Returns one [`LensProfileSummary`] per entry, suitable for
+    /// populating a picker/dropdown in the GUI. Profiles are in the
+    /// order they were loaded (grouped by camera brand/model).
+    pub fn iter_profiles(&self) -> impl Iterator<Item = LensProfileSummary> + '_ {
+        self.profiles.iter().map(|p| LensProfileSummary {
+            camera: format_camera_name(&p.brand, &p.model),
+            lens: format_lens_name(&p.lens_model, &p.camera_setting),
+            width: p.width,
+            height: p.height,
+        })
+    }
+
+    /// Return profiles matching a given resolution, optionally sorted
+    /// for a picker UI.
+    ///
+    /// Filters by exact width and height. If `width` or `height` is 0,
+    /// that dimension is not filtered (wildcard). Returns an owned
+    /// `Vec` rather than an iterator so the caller can group, sort, or
+    /// dedup freely.
+    pub fn candidates(&self, width: u32, height: u32) -> Vec<LensProfileSummary> {
+        self.profiles
+            .iter()
+            .filter(|p| (width == 0 || p.width == width) && (height == 0 || p.height == height))
+            .map(|p| LensProfileSummary {
+                camera: format_camera_name(&p.brand, &p.model),
+                lens: format_lens_name(&p.lens_model, &p.camera_setting),
+                width: p.width,
+                height: p.height,
+            })
+            .collect()
+    }
+}
+
+/// Format "Brand Model" with title case from the lowercase internal storage.
+fn format_camera_name(brand: &str, model: &str) -> String {
+    let mut name = String::with_capacity(brand.len() + 1 + model.len());
+    for (i, word) in brand.split_whitespace().enumerate() {
+        if i > 0 {
+            name.push(' ');
+        }
+        let mut chars = word.chars();
+        if let Some(c) = chars.next() {
+            name.extend(c.to_uppercase());
+            name.extend(chars);
+        }
+    }
+    name.push(' ');
+    for (i, word) in model.split_whitespace().enumerate() {
+        if i > 0 {
+            name.push(' ');
+        }
+        let mut chars = word.chars();
+        if let Some(c) = chars.next() {
+            name.extend(c.to_uppercase());
+            name.extend(chars);
+        }
+    }
+    name
+}
+
+/// Format lens name from model and setting fields.
+fn format_lens_name(lens_model: &str, camera_setting: &str) -> String {
+    if camera_setting.is_empty() {
+        lens_model.to_string()
+    } else {
+        format!("{lens_model} ({camera_setting})")
     }
 }
 
@@ -366,7 +461,7 @@ pub fn detect_profile(
     video_width: u32,
     video_height: u32,
     db: &LensDatabase,
-) -> Option<CameraParams> {
+) -> Option<(CameraParams, LensProfileInfo)> {
     let tel = match crate::telemetry::extract(video_path) {
         Ok(t) => Some(t),
         Err(e) => {
@@ -383,18 +478,24 @@ pub fn detect_profile(
                 tel.camera_type,
                 tel.camera_model.as_deref().unwrap_or("?")
             );
-            return Some(profile.clone());
+            let info = LensProfileInfo {
+                camera: tel.camera_type.clone(),
+                lens: tel.camera_model.clone().unwrap_or_else(|| "unknown".into()),
+                source: ProfileSource::AutoDetected,
+                path: None,
+            };
+            return Some((profile.clone(), info));
         }
 
         // 2. Database lookup by camera identification + FOV mode
-        if let Some(params) = db.find_from_telemetry(
+        if let Some(found) = db.find_from_telemetry(
             &tel.camera_type,
             tel.camera_model.as_deref(),
             video_width,
             video_height,
             tel.lens_info.as_deref(),
         ) {
-            return Some(params);
+            return Some(found);
         }
     }
 

--- a/crates/reco-calibrate/src/lib.rs
+++ b/crates/reco-calibrate/src/lib.rs
@@ -480,5 +480,10 @@ pub fn calibrate_with(
         residual_error: best_residual,
         confidence,
         per_frame: successful_frames,
+        // Lens profile metadata is threaded through from the pipeline
+        // layer (CalibrationPipeline::calibrate). The core calibrate()
+        // function works with bare CameraParams and has no profile info.
+        left_lens_profile: None,
+        right_lens_profile: None,
     })
 }

--- a/crates/reco-calibrate/src/pipeline.rs
+++ b/crates/reco-calibrate/src/pipeline.rs
@@ -40,7 +40,7 @@ use reco_core::calibration::CameraParams;
 use reco_core::gpu::GpuContext;
 
 use crate::error::CalibrateError;
-use crate::types::{CalibrationConfig, CalibrationResult, YuvFrame};
+use crate::types::{CalibrationConfig, CalibrationResult, LensProfileInfo, YuvFrame};
 use crate::{audio_sync, lens_database, sampling, telemetry};
 
 /// Video metadata that the app provides from its decoder.
@@ -74,6 +74,10 @@ pub struct CalibrationPipeline {
     config: CalibrationConfig,
     left_params: Option<CameraParams>,
     right_params: Option<CameraParams>,
+    /// Lens profile metadata for the left camera (populated by detect_profiles).
+    left_profile_info: Option<LensProfileInfo>,
+    /// Lens profile metadata for the right camera.
+    right_profile_info: Option<LensProfileInfo>,
     sync_offset_frames: i64,
     /// IMU seeds extracted during imu_sync
     imu_xrz_seed: Option<f64>,
@@ -95,6 +99,8 @@ impl CalibrationPipeline {
             config,
             left_params: None,
             right_params: None,
+            left_profile_info: None,
+            right_profile_info: None,
             sync_offset_frames: 0,
             imu_xrz_seed: None,
             imu_xrx_seed: None,
@@ -125,7 +131,7 @@ impl CalibrationPipeline {
     pub fn detect_profiles(&mut self) -> Result<(CameraParams, CameraParams), CalibrateError> {
         let db = lens_database::LensDatabase::load_embedded();
 
-        let left_p = lens_database::detect_profile(
+        let (left_p, left_info) = lens_database::detect_profile(
             &self.left_info.path,
             self.left_info.width,
             self.left_info.height,
@@ -138,7 +144,7 @@ impl CalibrationPipeline {
             ))
         })?;
 
-        let right_p = lens_database::detect_profile(
+        let (right_p, right_info) = lens_database::detect_profile(
             &self.right_info.path,
             self.right_info.width,
             self.right_info.height,
@@ -146,11 +152,13 @@ impl CalibrationPipeline {
         )
         .unwrap_or_else(|| {
             log::info!("right camera: no profile found, using left camera profile");
-            left_p.clone()
+            (left_p.clone(), left_info.clone())
         });
 
         self.left_params = Some(left_p.clone());
         self.right_params = Some(right_p.clone());
+        self.left_profile_info = Some(left_info);
+        self.right_profile_info = Some(right_info);
         Ok((left_p, right_p))
     }
 
@@ -239,13 +247,23 @@ impl CalibrationPipeline {
             }
         }
 
-        // Rig tilt (stored in result for renderer)
+        // Rig tilt (stored in result for renderer).
+        // Cap at 25 deg - beyond that the IMU reading is likely noise
+        // from an uncalibrated accelerometer rather than real forward lean.
         if let Some(tilt) = telemetry::rig_tilt(&left_telem, skip) {
             log::info!("rig tilt: {:.1} deg", tilt.to_degrees());
-            self.rig_tilt = tilt;
+            if tilt.abs() < 25.0_f64.to_radians() {
+                self.rig_tilt = tilt;
+            } else {
+                log::warn!(
+                    "rig tilt {:.1} deg exceeds 25 deg threshold, ignoring",
+                    tilt.to_degrees()
+                );
+            }
         }
 
         // Rig roll: (left_roll - right_roll) / 2 cancels common IMU bias.
+        // Cap at 25 deg for the same reason as tilt.
         let left_roll = telemetry::gravity_vector(&left_telem, skip).map(|g| g[2].atan2(g[0]));
         let right_roll = telemetry::gravity_vector(&right_telem, skip).map(|g| g[2].atan2(g[0]));
         if let (Some(lr), Some(rr)) = (left_roll, right_roll) {
@@ -256,11 +274,11 @@ impl CalibrationPipeline {
                 rr.to_degrees(),
                 avg.to_degrees()
             );
-            if avg.abs() < 20.0_f64.to_radians() {
+            if avg.abs() < 25.0_f64.to_radians() {
                 self.rig_roll = avg;
             } else {
                 log::warn!(
-                    "rig roll {:.1} deg exceeds threshold, ignoring",
+                    "rig roll {:.1} deg exceeds 25 deg threshold, ignoring",
                     avg.to_degrees()
                 );
             }
@@ -350,25 +368,32 @@ impl CalibrationPipeline {
             )
         })?;
 
-        // Merge IMU seeds into config
+        // Merge IMU seeds into config only when the toggle is on.
+        // When off, the optimizer uses its built-in start grid instead
+        // of IMU-derived orientation. Sync offset, rig_tilt, and
+        // rig_roll are always applied regardless of this flag.
         let mut config = self.config.clone();
-        if self.imu_xrz_seed.is_some() {
-            config.imu_xrz_seed = self.imu_xrz_seed;
-        }
-        if self.imu_xrx_seed.is_some() {
-            config.imu_xrx_seed = self.imu_xrx_seed;
-        }
-        if self.imu_zrx_seed.is_some() {
-            config.imu_zrx_seed = self.imu_zrx_seed;
-        }
-        if self.enable_x_rx {
-            config.optimizer.enable_x_rx = true;
+        if config.use_imu_rotation_seeds {
+            if self.imu_xrz_seed.is_some() {
+                config.imu_xrz_seed = self.imu_xrz_seed;
+            }
+            if self.imu_xrx_seed.is_some() {
+                config.imu_xrx_seed = self.imu_xrx_seed;
+            }
+            if self.imu_zrx_seed.is_some() {
+                config.imu_zrx_seed = self.imu_zrx_seed;
+            }
+            if self.enable_x_rx {
+                config.optimizer.enable_x_rx = true;
+            }
         }
 
         let mut result = crate::calibrate(gpu, frames, left_params, right_params, &config)?;
         result.calibration.rig_tilt = self.rig_tilt;
         result.calibration.rig_roll = self.rig_roll;
         result.calibration.sync_offset = self.sync_offset_frames;
+        result.left_lens_profile = self.left_profile_info.clone();
+        result.right_lens_profile = self.right_profile_info.clone();
         Ok(result)
     }
 

--- a/crates/reco-calibrate/src/types.rs
+++ b/crates/reco-calibrate/src/types.rs
@@ -3,6 +3,8 @@
 //! These types carry frame data, matched features, configuration, and
 //! calibration results through the pipeline stages.
 
+use std::path::PathBuf;
+
 use reco_core::calibration::MatchCalibration;
 use serde::{Deserialize, Serialize};
 
@@ -229,6 +231,19 @@ pub struct CalibrationConfig {
     pub skip_end_secs: f64,
 
     // --- IMU-derived settings (populated by telemetry module) ---
+    /// Whether to use IMU-derived differential orientation as optimizer
+    /// starting points.
+    ///
+    /// When `true` (default), the roll/pitch/tilt computed from
+    /// accelerometer gravity vectors seed additional Nelder-Mead start
+    /// points, improving convergence for well-calibrated IMUs. Set to
+    /// `false` for rigs where per-camera accelerometer bias produces
+    /// unreliable differential readings (e.g. bogus -29 deg pitch on a
+    /// physically rigid side-by-side mount). IMU sync offset and
+    /// rig_tilt/rig_roll are still used regardless of this flag.
+    #[serde(default)]
+    pub use_imu_rotation_seeds: bool,
+
     /// IMU-derived roll seed for the x_rz initial guess (radians).
     ///
     /// When set, adds an extra optimizer start point seeded with this
@@ -263,6 +278,7 @@ impl Default for CalibrationConfig {
             num_frames: 2,
             skip_start_secs: 0.0,
             skip_end_secs: 0.0,
+            use_imu_rotation_seeds: false,
             imu_xrz_seed: None,
             imu_xrx_seed: None,
             imu_zrx_seed: None,
@@ -369,6 +385,57 @@ impl std::fmt::Display for CalibrationStep {
     }
 }
 
+// ── Lens Profile Types ────────────────────────────────────────────
+
+/// How a lens profile was resolved during calibration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ProfileSource {
+    /// Matched from the embedded Gyroflow-derived database.
+    Database,
+    /// Loaded from a user-supplied file on disk.
+    File(PathBuf),
+    /// Auto-detected from camera telemetry embedded in the video.
+    AutoDetected,
+    /// Fallback profile when no exact match was found.
+    Fallback,
+}
+
+/// Identifies the lens profile used for one camera during calibration.
+///
+/// Returned on [`CalibrationResult::left_lens_profile`] and
+/// [`CalibrationResult::right_lens_profile`] so the GUI can display
+/// "Auto-detected: GoPro HERO10 Linear 4K" without parsing logs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LensProfileInfo {
+    /// Camera brand and model (e.g. "GoPro HERO10").
+    pub camera: String,
+    /// Lens mode or setting (e.g. "Linear 4K 16:9").
+    pub lens: String,
+    /// How the profile was resolved.
+    pub source: ProfileSource,
+    /// Path on disk, if loaded from a file.
+    pub path: Option<PathBuf>,
+}
+
+/// Summary of a lens profile in the embedded database.
+///
+/// Returned by [`LensDatabase::iter_profiles`](crate::lens_database::LensDatabase::iter_profiles)
+/// and [`LensDatabase::candidates`](crate::lens_database::LensDatabase::candidates)
+/// for populating a picker/dropdown in the GUI.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LensProfileSummary {
+    /// Camera brand and model (e.g. "GoPro HERO10").
+    pub camera: String,
+    /// Lens mode or setting (e.g. "Linear 4K 16:9").
+    pub lens: String,
+    /// Profile resolution width in pixels.
+    pub width: u32,
+    /// Profile resolution height in pixels.
+    pub height: u32,
+}
+
+// ── Calibration Result ───────────────────────────────────────────
+
 /// Output of a successful calibration run.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CalibrationResult {
@@ -384,4 +451,9 @@ pub struct CalibrationResult {
     pub confidence: f64,
     /// Per-frame matching statistics.
     pub per_frame: Vec<FrameMatches>,
+    /// Lens profile used for the left camera. `None` if the profile was
+    /// set manually via `set_profiles()` rather than auto-detected.
+    pub left_lens_profile: Option<LensProfileInfo>,
+    /// Lens profile used for the right camera.
+    pub right_lens_profile: Option<LensProfileInfo>,
 }


### PR DESCRIPTION
## Summary

Implements Batch B of the FRICTION-driven roadmap (#228 -> #224). Three
additions to reco-calibrate that serve the GUI's calibration panel and
improve IMU robustness.

### Lens profile metadata on CalibrationResult

- `CalibrationResult::left_lens_profile` / `right_lens_profile: Option<LensProfileInfo>` exposes which profile was auto-detected. The GUI can display "Auto-detected: GoPro HERO10 Linear 4K" without parsing logs.
- `ProfileSource` enum: `Database`, `File(PathBuf)`, `AutoDetected`, `Fallback`.
- Internal `detect_profile()`, `find()`, `find_from_telemetry()`, `find_by_resolution()` all return `(CameraParams, LensProfileInfo)` now. Pipeline stores and threads the info to the result.

### Database iteration for picker UI

- `LensDatabase::iter_profiles()` yields `LensProfileSummary` (camera, lens, width, height) for every entry.
- `LensDatabase::candidates(width, height)` filters by resolution. Pass 0 for a dimension to wildcard.

### IMU robustness

- `CalibrationConfig::use_imu_rotation_seeds: bool` (default `false`). When off, IMU differential orientation is not injected as optimizer start points. Sync offset and rig_tilt/rig_roll remain unaffected.
- Rig tilt capped at 25 deg (was uncapped). Beyond that, the reading is likely accelerometer bias.
- Rig roll cap raised from 20 deg to 25 deg for consistency.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features gstreamer -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features profiling,gstreamer`
- [x] `cargo test --all` (173 passed, 0 failed)
- [ ] Run `reco calibrate` on a test pair and verify `CalibrationResult` carries non-None `left_lens_profile` / `right_lens_profile`.
- [ ] Verify `use_imu_rotation_seeds: false` produces valid calibration without IMU-seeded starts.

Closes #224. Progress on umbrella #228.