### PR TITLE
feat(reco-core): Batch C minor ergonomics

### DIFF
--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -499,6 +499,7 @@ impl ApplicationHandler for App {
             self.input_width,
             self.input_height,
             surface_format,
+            reco_core::renderer::InputFormat::Yuv420p,
         )
         .expect("create renderer");
 

--- a/crates/reco-core/src/detector.rs
+++ b/crates/reco-core/src/detector.rs
@@ -20,6 +20,15 @@ pub enum CameraId {
     Right,
 }
 
+impl std::fmt::Display for CameraId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Left => f.write_str("L"),
+            Self::Right => f.write_str("R"),
+        }
+    }
+}
+
 /// Raw camera frame data for detection.
 ///
 /// Provides access to all YUV planes so detectors can use luma-only

--- a/crates/reco-core/src/director.rs
+++ b/crates/reco-core/src/director.rs
@@ -88,7 +88,10 @@ pub struct MappedDetection {
     /// Bounding box center in normalized camera coordinates `[0.0, 1.0]`.
     pub camera_center: (f32, f32),
 
-    /// Bounding box size in normalized camera coordinates.
+    /// Bounding box size in normalized `[0, 1]` camera coordinates.
+    ///
+    /// Multiply by the camera's pixel dimensions to get pixel size:
+    /// `pixel_w = camera_size.0 * calibration.left.width as f32`.
     pub camera_size: (f32, f32),
 
     /// Position in panorama space (yaw/pitch).

--- a/crates/reco-core/src/pipeline.rs
+++ b/crates/reco-core/src/pipeline.rs
@@ -213,13 +213,19 @@ impl StitchPipeline {
     /// target. Use this for viewport-metadata changes (e.g. surface
     /// reconfigure in a preview window). For actual output resolution
     /// changes, rebuild the pipeline with [`Self::with_gpu`].
-    pub fn resize(&mut self, width: u32, height: u32) {
+    /// Returns `Some((width, height))` on success, or `None` if the
+    /// dimensions were zero (ignored). Consumers that own external
+    /// staging buffers (e.g.
+    /// [`RgbaReadback`](crate::rgba_readback::RgbaReadback)) should
+    /// recreate them when the returned size differs from the previous.
+    pub fn resize(&mut self, width: u32, height: u32) -> Option<(u32, u32)> {
         if width == 0 || height == 0 {
             log::warn!("resize({width}, {height}) ignored: dimensions must be non-zero");
-            return;
+            return None;
         }
         self.viewport.width = width;
         self.viewport.height = height;
+        Some((width, height))
     }
 
     /// Set the vertical field of view in degrees.

--- a/crates/reco-core/src/stitch_renderer.rs
+++ b/crates/reco-core/src/stitch_renderer.rs
@@ -12,7 +12,8 @@
 //! use reco_core::stitch_renderer::StitchRenderer;
 //!
 //! let renderer = StitchRenderer::new(
-//!     calibration, gpu, viewport, input_width, input_height, surface_format,
+//!     calibration, gpu, viewport, input_width, input_height,
+//!     surface_format, input_format,
 //! )?;
 //!
 //! // In the render loop:
@@ -28,6 +29,25 @@ use crate::renderer::InputFormat;
 use crate::rgba_readback::RgbaReadback;
 use crate::scene::SceneGeometry;
 use crate::viewport::ViewportConfig;
+
+/// Where to render the stitched panorama.
+///
+/// Pass to [`StitchRenderer::render`] to choose between surface display
+/// and readback without calling different methods.
+pub enum RenderTarget<'a> {
+    /// Present directly to a window surface.
+    Surface(&'a wgpu::TextureView),
+    /// Render to the internal RGBA texture for readback.
+    Texture,
+}
+
+/// What happened after a [`StitchRenderer::render`] call.
+pub enum RenderOutcome {
+    /// Surface render submitted to the GPU queue (nothing to do).
+    Submitted,
+    /// Texture render returned a command buffer for readback.
+    Commands(wgpu::CommandBuffer),
+}
 
 /// Surface-oriented stitch renderer.
 ///
@@ -60,6 +80,9 @@ impl StitchRenderer {
     /// * `input_width` - Width of each input camera frame in pixels.
     /// * `input_height` - Height of each input camera frame in pixels.
     /// * `surface_format` - The surface's texture format (sRGB is stripped automatically).
+    /// * `input_format` - Pixel format of the input frames
+    ///   ([`Yuv420p`](InputFormat::Yuv420p) for file decode,
+    ///   [`Nv12`](InputFormat::Nv12) for Jetson/NVDEC live input).
     pub fn new(
         calibration: MatchCalibration,
         gpu: GpuContext,
@@ -67,6 +90,7 @@ impl StitchRenderer {
         input_width: u32,
         input_height: u32,
         surface_format: wgpu::TextureFormat,
+        input_format: InputFormat,
     ) -> Result<Self, PipelineError> {
         let render_format = Self::strip_srgb(surface_format);
 
@@ -81,7 +105,7 @@ impl StitchRenderer {
             input_width,
             input_height,
             render_format,
-            InputFormat::Yuv420p,
+            input_format,
         )?;
 
         Ok(Self {
@@ -123,6 +147,39 @@ impl StitchRenderer {
     ) -> Result<(), PipelineError> {
         self.pipeline
             .render_nv12_to_view(left, right, yaw, pitch, view)
+    }
+
+    /// Render YUV420P frames to either a surface view or the internal
+    /// texture target, depending on the [`RenderTarget`] variant.
+    ///
+    /// Replaces the need to choose between `render_yuv` (surface) and
+    /// `pipeline().render_to_target` (readback). The outcome tells the
+    /// caller what happened:
+    ///
+    /// - [`RenderOutcome::Submitted`] — GPU work was submitted for a
+    ///   surface present; nothing left to do.
+    /// - [`RenderOutcome::Commands`] — a command buffer is ready for
+    ///   readback (pass to [`RgbaReadback::readback`](crate::rgba_readback::RgbaReadback::readback)
+    ///   or [`Nv12Converter::convert_and_readback`](crate::nv12_converter::Nv12Converter::convert_and_readback)).
+    pub fn render(
+        &self,
+        left: &YuvPlanes<'_>,
+        right: &YuvPlanes<'_>,
+        yaw: f32,
+        pitch: f32,
+        target: RenderTarget<'_>,
+    ) -> Result<RenderOutcome, PipelineError> {
+        match target {
+            RenderTarget::Surface(view) => {
+                self.pipeline
+                    .render_to_view(left, right, yaw, pitch, view)?;
+                Ok(RenderOutcome::Submitted)
+            }
+            RenderTarget::Texture => {
+                let cmd = self.pipeline.render_to_target(left, right, yaw, pitch)?;
+                Ok(RenderOutcome::Commands(cmd))
+            }
+        }
     }
 
     // ── Render + Readback API ──

--- a/crates/reco-gui/src/preview.rs
+++ b/crates/reco-gui/src/preview.rs
@@ -190,6 +190,7 @@ impl PreviewBridge {
             input_width,
             input_height,
             surface_format,
+            reco_core::renderer::InputFormat::Yuv420p,
         )?;
 
         let device = renderer.gpu().device();


### PR DESCRIPTION
## Summary

Implements Batch C of the roadmap (#228 -> #227). Five small reco-core
API cleanups surfaced across consumer FRICTION docs. Low-priority,
none blocks a consumer today.

### Changes

1. **`StitchRenderer::new` takes `InputFormat`** - was hardcoded to `Yuv420p`. GUI / OBS consumers can now construct a renderer for NV12 input without dropping to `StitchPipeline::with_gpu`. Callers in reco-cli / reco-gui pass `InputFormat::Yuv420p` (unchanged behavior).

2. **Unified `StitchRenderer::render(target: RenderTarget)` API** - `RenderTarget::Surface(&view)` presents, `RenderTarget::Texture` returns a command buffer for readback. `RenderOutcome` tells the caller what happened. Removes the asymmetry between `render_yuv` (submits internally) and `pipeline().render_to_target` (returns CommandBuffer). Existing methods remain for callers that already chose.

3. **`StitchPipeline::resize()` returns `Option<(u32, u32)>`** - new dimensions on success, `None` if zero-dim and the call was ignored. Consumers that own external staging buffers (RgbaReadback, NV12 converter) can detect when they need to be recreated.

4. **`MappedDetection.camera_size` doc clarity** - example showing how to multiply by calibration width/height to get pixels.

5. **`impl Display for CameraId`** - prints `L` / `R`. CSV writers and loggers no longer need to match on the enum.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features gstreamer -- -D warnings`
- [x] `cargo clippy --all-targets --features profiling -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features profiling,gstreamer`
- [x] `cargo test --all` (173 passed, 0 failed)
- [ ] Optional: construct a StitchRenderer with `InputFormat::Nv12` on Jetson and verify NV12 live preview works.

Closes #227. Closes the umbrella #228 for code batches (Batch D is
upstream Slint proposals, filed separately).