### PR TITLE
chore(reco-gui): use Slider.released instead of .changed for seek

### DIFF
--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -175,7 +175,11 @@ export component RecoApp inherits Window {
                         maximum: root.total-frames == 0 ? 1 : root.total-frames;
                         value: root.current-frame;
                         enabled: root.files-loaded;
-                        changed(val) => {
+                        // `released` fires only on user pointer release,
+                        // unlike `changed` which also fires when Rust
+                        // writes `current-frame` back after a decode
+                        // (feedback loop).
+                        released(val) => {
                             if root.total-frames > 0 {
                                 root.seek(val / root.total-frames);
                             }


### PR DESCRIPTION
## Summary

Slint's Slider widget has a `released(value: float)` callback that
fires only on user pointer release (and keyboard commit), not on
every value mutation. Switching the seek slider from `changed` to
`released` eliminates the feedback loop between Rust-side playback
writing `current-frame` back and the slider re-firing its callback.

No observable bug on main today (current tick rate is low enough to
not saturate), but `released` is the correct callback for a seek
slider regardless. It also removes the need for a client-side
debounce once the higher-tick-rate playback from #217 lands.

Discovered while investigating Batch D of #228: the
[reco-gui/FRICTION.md item #11](https://github.com/reco-project/video-stitcher/blob/spike/wgpu-28-interop/crates/reco-gui/FRICTION.md)
note (on the spike branch) suggested filing a Slint upstream
request, but `released` has existed since at least Slint 1.15 (see
`internal/compiler/widgets/common/slider-base.slint`). The FRICTION
note will be marked resolved when #217 merges.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build -p reco-gui`
- [ ] Manual: load a video pair, drag the seek slider, verify seek fires only on release (not mid-drag).