### PR TITLE
feat(reco-gui): Tier 1 - runtime AI probe, lens profile display, IMU seeds toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5308,6 +5308,7 @@ dependencies = [
  "reco-autocam",
  "reco-calibrate",
  "reco-core",
+ "reco-detect",
  "reco-io",
  "rfd",
  "serde_json",

--- a/crates/reco-calibrate/src/lib.rs
+++ b/crates/reco-calibrate/src/lib.rs
@@ -74,7 +74,8 @@ pub use traits::{
 };
 pub use types::{
     AkazeConfig, CalibrationConfig, CalibrationProgress, CalibrationResult, CalibrationStep,
-    GrayFrame, MatchConfig, OptimizerConfig, YuvFrame,
+    GrayFrame, LensProfileInfo, LensProfileSummary, MatchConfig, OptimizerConfig, ProfileSource,
+    YuvFrame,
 };
 
 use reco_core::calibration::{CameraParams, MatchCalibration};

--- a/crates/reco-detect/src/probe.rs
+++ b/crates/reco-detect/src/probe.rs
@@ -68,53 +68,68 @@ pub fn probe_execution_providers() -> AiProbeResult {
 
     if let Some(_builder) = builder {
         // TensorRT EP
+        //
+        // `with_execution_providers` returns `Result<SessionBuilder,
+        // ort::Error<SessionBuilder>>`, whose generic payload differs
+        // from the `Error<()>` that `Session::builder()` yields. We can
+        // stringify both into a common `Result<(), String>` so the
+        // error arms agree on type.
         #[cfg(feature = "tensorrt")]
         {
-            match Session::builder()
-                .and_then(|b| b.with_execution_providers([ort::ep::TensorRT::default().build()]))
-            {
-                Ok(_) => {
+            let result: Result<(), String> = match Session::builder() {
+                Ok(b) => b
+                    .with_execution_providers([ort::ep::TensorRT::default().build()])
+                    .map(|_| ())
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e.to_string()),
+            };
+            match result {
+                Ok(()) => {
                     providers.push("TensorRT".into());
                     can_run_on_gpu_frames = true;
                 }
-                Err(e) => {
-                    errors.push(format!("TensorRT: {e}"));
-                }
+                Err(e) => errors.push(format!("TensorRT: {e}")),
             }
         }
 
         // CUDA EP (only when TensorRT is not compiled in, matching ort_session.rs logic)
         #[cfg(all(feature = "cuda", not(feature = "tensorrt")))]
         {
-            match Session::builder()
-                .and_then(|b| b.with_execution_providers([ort::ep::CUDA::default().build()]))
-            {
-                Ok(_) => {
+            let result: Result<(), String> = match Session::builder() {
+                Ok(b) => b
+                    .with_execution_providers([ort::ep::CUDA::default().build()])
+                    .map(|_| ())
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e.to_string()),
+            };
+            match result {
+                Ok(()) => {
                     providers.push("CUDA".into());
                     // CUDA EP alone can't handle NV12 device pointers
                     // without NPP preprocessing, so can_run_on_gpu_frames
                     // stays false unless TensorRT succeeded above.
                 }
-                Err(e) => {
-                    errors.push(format!("CUDA: {e}"));
-                }
+                Err(e) => errors.push(format!("CUDA: {e}")),
             }
         }
 
         // CoreML EP (macOS)
         #[cfg(feature = "coreml")]
         {
-            match Session::builder().and_then(|b| {
-                b.with_execution_providers([ort::ep::CoreML::default()
-                    .with_compute_units(ort::ep::coreml::ComputeUnits::All)
-                    .build()])
-            }) {
-                Ok(_) => {
+            let result: Result<(), String> = match Session::builder() {
+                Ok(b) => b
+                    .with_execution_providers([ort::ep::CoreML::default()
+                        .with_compute_units(ort::ep::coreml::ComputeUnits::All)
+                        .build()])
+                    .map(|_| ())
+                    .map_err(|e| e.to_string()),
+                Err(e) => Err(e.to_string()),
+            };
+            match result {
+                Ok(()) => {
                     providers.push("CoreML".into());
                 }
-                Err(e) => {
-                    errors.push(format!("CoreML: {e}"));
-                }
+                Err(e) => errors.push(format!("CoreML: {e}")),
             }
         }
 

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -23,6 +23,7 @@ profiling = ["tracing", "reco-core/profiling", "reco-io/profiling", "reco-calibr
 reco-core = { path = "../reco-core" }
 reco-io = { path = "../reco-io", features = ["ffmpeg"] }
 reco-calibrate = { path = "../reco-calibrate", features = ["io"] }
+reco-detect = { path = "../reco-detect" }
 reco-autocam = { path = "../reco-autocam", optional = true }
 
 slint = { version = "~1.15", features = ["unstable-wgpu-28"] }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -23,6 +23,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
+use reco_calibrate::{LensProfileInfo, ProfileSource};
 use reco_core::calibration::MatchCalibration;
 use reco_core::pipeline::YuvPlanes;
 use reco_core::wgpu;
@@ -85,8 +86,18 @@ const CAMERA_EPSILON: f32 = 0.0005;
 /// much better bundle-adjustment fit at the cost of a few extra seconds.
 const CALIBRATION_FRAMES: usize = 4;
 
+/// Calibration payload sent from the background worker: the computed
+/// match calibration plus the lens profile info each side resolved to,
+/// so the GUI can tell the user "we auto-detected GoPro HERO10 Linear 4K"
+/// without re-running detection.
+struct CalibrationOutput {
+    calibration: MatchCalibration,
+    left_lens_profile: Option<LensProfileInfo>,
+    right_lens_profile: Option<LensProfileInfo>,
+}
+
 /// Result sent from the calibration background thread.
-type CalibrationResult = Result<MatchCalibration, String>;
+type CalibrationResult = Result<CalibrationOutput, String>;
 
 /// Application state shared between Slint callbacks.
 struct AppState {
@@ -137,42 +148,51 @@ struct AppState {
     cal_baseline_layout: Option<reco_core::calibration::PlaneLayout>,
 }
 
-/// Compile-time AI capability summary.
+/// Runtime AI capability summary.
 ///
-/// Reports which ONNX Runtime execution providers were baked into
-/// this binary. A runtime probe would be better (hardware might not
-/// support what we compiled in), but reco-autocam exposes no such
-/// API today — see reco-gui/FRICTION.md #12.
+/// Calls `reco_detect::probe_execution_providers()` to discover which
+/// ONNX Runtime execution providers actually load on this machine,
+/// not just which were compiled in. Replaces the old compile-time
+/// `cfg!()` summary that lied when a feature was baked in but the
+/// runtime libraries were missing.
+///
+/// Returns `(status_text, can_run_ai_on_gpu_frames)`.
 fn ai_capability_summary() -> (String, bool) {
-    #[allow(unused_mut)]
-    let mut available: Vec<&'static str> = Vec::new();
-    #[cfg(feature = "tensorrt")]
-    available.push("TensorRT");
-    #[cfg(feature = "cuda")]
-    available.push("CUDA");
-    #[cfg(feature = "coreml")]
-    available.push("CoreML");
-
     #[cfg(not(feature = "autocam"))]
     return ("AI: disabled (build without autocam feature)".into(), false);
 
     #[cfg(feature = "autocam")]
     {
-        if available.is_empty() {
-            // CPU is always available but can't run alongside zero-copy
-            // GPU decode — autocam will refuse on NVDEC-resident frames.
-            (
-                "AI: CPU-only (ball tracking needs tensorrt / cuda feature for hardware decode)"
-                    .into(),
+        let probe = reco_detect::probe_execution_providers();
+        if !probe.is_available() {
+            return (
+                format!(
+                    "AI: unavailable ({})",
+                    probe
+                        .errors
+                        .first()
+                        .cloned()
+                        .unwrap_or_else(|| "no execution providers loaded".into())
+                ),
                 false,
-            )
-        } else {
+            );
+        }
+        if probe.can_run_on_gpu_frames {
             (
                 format!(
-                    "AI: {} available (hardware decode + inference)",
-                    available.join(", ")
+                    "AI: {} (hardware decode + inference)",
+                    probe.providers.join(", ")
                 ),
                 true,
+            )
+        } else {
+            // CPU (or CUDA-without-NPP) works but can't consume GPU-resident frames.
+            (
+                format!(
+                    "AI: {} (CPU-only path; ball tracking disabled on hardware decode)",
+                    probe.best_provider()
+                ),
+                false,
             )
         }
     }
@@ -483,6 +503,62 @@ impl AppState {
 }
 
 /// Extract just the filename from a path for display.
+/// Human-readable description of how a lens profile was resolved.
+fn profile_source_label(info: &LensProfileInfo) -> &'static str {
+    match info.source {
+        ProfileSource::AutoDetected => "Auto-detected",
+        ProfileSource::Database => "Database match",
+        ProfileSource::File(_) => "File",
+        ProfileSource::Fallback => "Fallback",
+    }
+}
+
+/// Populate the Slint lens-profile properties from calibration output.
+///
+/// Stamps the detected camera/lens/source for left and right, plus the
+/// count of alternate profiles in the embedded database that match the
+/// current video resolution (`in_w` x `in_h`). The candidate count lets
+/// the user tell at a glance whether they could reasonably override the
+/// auto-detected profile - zero means the picker has nothing new to offer.
+fn set_lens_profile_props(
+    app: &RecoApp,
+    left: Option<LensProfileInfo>,
+    right: Option<LensProfileInfo>,
+    in_w: u32,
+    in_h: u32,
+) {
+    if let Some(info) = &left {
+        app.set_lens_left_camera(info.camera.clone().into());
+        app.set_lens_left_lens(info.lens.clone().into());
+        app.set_lens_left_source(profile_source_label(info).into());
+    } else {
+        app.set_lens_left_camera("Unknown".into());
+        app.set_lens_left_lens("".into());
+        app.set_lens_left_source("Not detected".into());
+    }
+    if let Some(info) = &right {
+        app.set_lens_right_camera(info.camera.clone().into());
+        app.set_lens_right_lens(info.lens.clone().into());
+        app.set_lens_right_source(profile_source_label(info).into());
+    } else {
+        app.set_lens_right_camera("Unknown".into());
+        app.set_lens_right_lens("".into());
+        app.set_lens_right_source("Not detected".into());
+    }
+
+    // Count candidate profiles for the current resolution so the user
+    // sees whether alternates exist. Loading the embedded database is
+    // O(1) after the first call (static OnceCell inside reco-calibrate).
+    let candidates = if in_w > 0 && in_h > 0 {
+        let db = reco_calibrate::lens_database::LensDatabase::load_embedded();
+        db.candidates(in_w, in_h).len() as i32
+    } else {
+        0
+    };
+    app.set_lens_candidates_count(candidates);
+    app.set_lens_info_available(left.is_some() || right.is_some());
+}
+
 fn display_name(path: &std::path::Path) -> String {
     path.file_name()
         .map(|n| n.to_string_lossy().into_owned())
@@ -649,6 +725,14 @@ fn main() -> anyhow::Result<()> {
         };
         drop(s);
 
+        // Snapshot the IMU-seed opt-in so the worker thread doesn't
+        // need to touch the Slint app at all (which would require the
+        // Weak handle to upgrade successfully off the UI thread).
+        let use_imu_seeds = app_weak
+            .upgrade()
+            .map(|a| a.get_use_imu_seeds())
+            .unwrap_or(false);
+
         if let Some(app) = app_weak.upgrade() {
             app.set_calibrating(true);
             app.set_calibration_step("Starting...".into());
@@ -675,6 +759,7 @@ fn main() -> anyhow::Result<()> {
             // feature matches are noisier per frame.
             let config = reco_calibrate::CalibrationConfig {
                 num_frames: CALIBRATION_FRAMES,
+                use_imu_rotation_seeds: use_imu_seeds,
                 ..Default::default()
             };
             let result = reco_calibrate::video::calibrate_videos(
@@ -702,7 +787,11 @@ fn main() -> anyhow::Result<()> {
             let cal_result: CalibrationResult = match result {
                 Ok(r) => {
                     log::info!("Auto-calibration complete: {} matches", r.total_matches,);
-                    Ok(r.calibration)
+                    Ok(CalibrationOutput {
+                        calibration: r.calibration,
+                        left_lens_profile: r.left_lens_profile,
+                        right_lens_profile: r.right_lens_profile,
+                    })
                 }
                 Err(e) => Err(format!("{e}")),
             };
@@ -1227,6 +1316,8 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
             // Seed calibration slider values from the baseline layout.
             let layout = s.cal_baseline_layout.clone();
 
+            let (in_w, in_h) = s.playback.input_dimensions().unwrap_or((0, 0));
+
             if let Some(app) = app_weak.upgrade() {
                 app.set_files_loaded(true);
                 app.set_total_frames(total as i32);
@@ -1244,6 +1335,11 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     app.set_cal_x_ty(layout.x_ty as f32);
                     app.set_cal_dirty(false);
                 }
+                // Manual calibration JSON does not embed lens-profile info,
+                // so clear the display (hide the lens card) and just show
+                // the candidates count for this resolution so the user
+                // still knows how many database entries could match.
+                set_lens_profile_props(&app, None, None, in_w, in_h);
                 // Seed export dialog output filename suggestion to
                 // sit next to the left-video file for convenience.
                 let left_path = s.left_path.clone();
@@ -1296,43 +1392,49 @@ fn handle_calibration_result(
     }
 
     match result {
-        Ok(cal) => match state.init_with_calibration(cal) {
-            Ok(true) => {
-                let fps = state.playback.fps();
-                let total = state.playback.total_frames().unwrap_or(0);
-                let gpu_name = state
-                    .bridge
-                    .as_ref()
-                    .map(|b| b.renderer().gpu().gpu_name().to_string())
-                    .unwrap_or_default();
-                let img = state.render_current();
+        Ok(output) => {
+            let left_profile = output.left_lens_profile.clone();
+            let right_profile = output.right_lens_profile.clone();
+            match state.init_with_calibration(output.calibration) {
+                Ok(true) => {
+                    let fps = state.playback.fps();
+                    let total = state.playback.total_frames().unwrap_or(0);
+                    let gpu_name = state
+                        .bridge
+                        .as_ref()
+                        .map(|b| b.renderer().gpu().gpu_name().to_string())
+                        .unwrap_or_default();
+                    let img = state.render_current();
+                    let (in_w, in_h) = state.playback.input_dimensions().unwrap_or((0, 0));
 
-                if let Some(app) = app_weak.upgrade() {
-                    app.set_files_loaded(true);
-                    app.set_calibration_path("(auto-calibrated)".into());
-                    app.set_total_frames(total as i32);
-                    app.set_current_frame(state.playback.frame_index() as i32);
-                    app.set_fps(fps as f32);
-                    app.set_status_text(
-                        format!(
-                            "Auto-calibrated - {gpu_name} - {:.1} fps - {total} frames",
-                            fps,
-                        )
-                        .into(),
-                    );
-                    if let Some(img) = img {
-                        app.set_preview_frame(img);
+                    if let Some(app) = app_weak.upgrade() {
+                        app.set_files_loaded(true);
+                        app.set_calibration_path("(auto-calibrated)".into());
+                        app.set_total_frames(total as i32);
+                        app.set_current_frame(state.playback.frame_index() as i32);
+                        app.set_fps(fps as f32);
+                        app.set_status_text(
+                            format!(
+                                "Auto-calibrated - {gpu_name} - {:.1} fps - {total} frames",
+                                fps,
+                            )
+                            .into(),
+                        );
+                        if let Some(img) = img {
+                            app.set_preview_frame(img);
+                        }
+                        set_lens_profile_props(&app, left_profile, right_profile, in_w, in_h);
+                    }
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    log::error!("Post-calibration init: {e}");
+                    if let Some(app) = app_weak.upgrade() {
+                        app.set_status_text(format!("Error: {e}").into());
                     }
                 }
             }
-            Ok(false) => {}
-            Err(e) => {
-                log::error!("Post-calibration init: {e}");
-                if let Some(app) = app_weak.upgrade() {
-                    app.set_status_text(format!("Error: {e}").into());
-                }
-            }
-        },
+        }
         Err(e) => {
             log::error!("Auto-calibration failed: {e}");
             if let Some(app) = app_weak.upgrade() {

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -152,6 +152,25 @@ export component RecoApp inherits Window {
     in-out property <string> ai-status: "AI: unknown";
     in-out property <bool> ai-gpu-available: false;
 
+    // Lens profile info. Populated after auto-calibration so the user
+    // can see which lens the detector resolved to. Empty strings render
+    // as "Unknown" via the Lens card below; `lens-info-available` flips
+    // when there's anything worth showing.
+    in-out property <string> lens-left-camera: "";
+    in-out property <string> lens-left-lens: "";
+    in-out property <string> lens-left-source: "";
+    in-out property <string> lens-right-camera: "";
+    in-out property <string> lens-right-lens: "";
+    in-out property <string> lens-right-source: "";
+    in-out property <int> lens-candidates-count: 0;
+    in-out property <bool> lens-info-available: false;
+
+    // Opt-in use of IMU-derived camera orientation as initial seeds
+    // for the bundle-adjustment optimizer. Helpful on clips whose first
+    // frame is pointed off-axis; harmful if the IMU is noisy. Default
+    // off because the feature-matching seed is reliable on most footage.
+    in-out property <bool> use-imu-seeds: false;
+
     // ── Callbacks into Rust ──
 
     callback pick-left-video();
@@ -262,6 +281,16 @@ export component RecoApp inherits Window {
                     text: root.calibrating ? "Calibrating..." : "Auto Calibrate";
                     enabled: root.has-both-videos && !root.calibrating && !root.files-loaded;
                     clicked => { root.auto-calibrate(); }
+                }
+
+                // IMU-seed opt-in. Most clips work best without it
+                // (feature matcher seeds the bundle-adjustment fine on
+                // its own), so this stays off by default. User can flip
+                // it on for clips where the first frame is aimed oddly.
+                CheckBox {
+                    text: "IMU seeds";
+                    checked <=> root.use-imu-seeds;
+                    enabled: root.has-both-videos && !root.calibrating && !root.files-loaded;
                 }
 
                 if root.calibrating: Text {
@@ -414,6 +443,100 @@ export component RecoApp inherits Window {
                     Button {
                         text: "Reset View";
                         clicked => { root.reset-view(); }
+                    }
+
+                    Rectangle { height: 1px; background: #333; }
+
+                    // ── Lens profile info (read-only) ──
+                    // Displayed after auto-calibrate. Shows which lens the
+                    // database/telemetry resolved to for each camera, plus
+                    // a hint about how many alternate profiles exist for
+                    // this video resolution. Functional override lives in
+                    // a later tier once the calibrate API supports passing
+                    // a chosen profile directly.
+                    Text {
+                        text: "Lens profiles";
+                        color: #fff;
+                        font-size: 14px;
+                        font-weight: 600;
+                    }
+
+                    if !root.lens-info-available: Text {
+                        text: "Run auto-calibrate to detect lens profiles.";
+                        color: #777;
+                        font-size: 11px;
+                        wrap: word-wrap;
+                    }
+
+                    if root.lens-info-available: VerticalLayout {
+                        spacing: 6px;
+
+                        // Left camera card
+                        Rectangle {
+                            border-radius: 6px;
+                            background: #242424;
+                            VerticalLayout {
+                                padding: 8px;
+                                spacing: 2px;
+                                Text {
+                                    text: "Left  " + root.lens-left-source;
+                                    color: #8ae68a;
+                                    font-size: 11px;
+                                    font-weight: 600;
+                                }
+                                Text {
+                                    text: root.lens-left-camera;
+                                    color: #eee;
+                                    font-size: 12px;
+                                    overflow: elide;
+                                }
+                                Text {
+                                    text: root.lens-left-lens;
+                                    color: #aaa;
+                                    font-size: 11px;
+                                    overflow: elide;
+                                }
+                            }
+                        }
+
+                        // Right camera card
+                        Rectangle {
+                            border-radius: 6px;
+                            background: #242424;
+                            VerticalLayout {
+                                padding: 8px;
+                                spacing: 2px;
+                                Text {
+                                    text: "Right  " + root.lens-right-source;
+                                    color: #8ae68a;
+                                    font-size: 11px;
+                                    font-weight: 600;
+                                }
+                                Text {
+                                    text: root.lens-right-camera;
+                                    color: #eee;
+                                    font-size: 12px;
+                                    overflow: elide;
+                                }
+                                Text {
+                                    text: root.lens-right-lens;
+                                    color: #aaa;
+                                    font-size: 11px;
+                                    overflow: elide;
+                                }
+                            }
+                        }
+
+                        Text {
+                            text: root.lens-candidates-count == 0
+                                ? "No alternate profiles for this resolution."
+                                : (root.lens-candidates-count == 1
+                                    ? "1 alternate profile available for this resolution."
+                                    : root.lens-candidates-count + " alternate profiles available for this resolution.");
+                            color: #777;
+                            font-size: 10px;
+                            wrap: word-wrap;
+                        }
                     }
 
                     Rectangle { height: 1px; background: #333; }


### PR DESCRIPTION
## Summary

First of four tiers making reco-gui a full-featured main interface for the stitcher (per umbrella issue planning). Tier 1 is about **robustness and information density** - the user needs to see what the pipeline actually does before we start adding power features.

- **Runtime AI probe** (replaces compile-time summary). Calls `reco_detect::probe_execution_providers()` from Batch E, so the AI chip reflects what actually loaded on this machine, not what was compiled in. A cuda-enabled build on a box without CUDA libraries no longer lies.
- **Lens profile display**. After auto-calibrate, shows which lens profile the database or telemetry resolved to for Left and Right (camera model, lens mode, source tag). Also shows the count of alternate profiles available for the current resolution so the user knows whether there are options. Uses `LensProfileInfo` and `LensDatabase::candidates()` from Batch B.
- **IMU rotation seeds toggle**. A checkbox next to Auto Calibrate opts in to `CalibrationConfig::use_imu_rotation_seeds`. Off by default because the feature-matching seed is reliable on most footage; on for clips where the first frame is aimed oddly.

Kept read-only for now. A functional picker that re-runs calibration against a chosen profile is a good Tier 2 candidate once `CalibrateVideosOptions` learns how to accept a `LensProfileSummary` directly.

## Changes

- `crates/reco-gui/Cargo.toml` - add `reco-detect` dep (runtime probe).
- `crates/reco-gui/src/main.rs`:
  - `ai_capability_summary()` now uses the runtime probe.
  - `CalibrationResult` widened to carry lens info through the worker channel.
  - New `set_lens_profile_props()` helper + `profile_source_label()`.
  - Auto-calibrate reads `use_imu_seeds` from Slint and injects into the config.
  - Manual match.json loads clear the lens display (no metadata available).
- `crates/reco-gui/ui/main.slint`:
  - New properties: `lens-left-camera/lens/source`, `lens-right-*`, `lens-candidates-count`, `lens-info-available`, `use-imu-seeds`.
  - Lens cards in the calibration panel (hidden until info is available).
  - IMU seeds checkbox in the file-picker bar, disabled while calibrating or after load.
- `crates/reco-calibrate/src/lib.rs` - re-export `LensProfileInfo`, `LensProfileSummary`, `ProfileSource` (required by the GUI without pulling in `::types::`).

## Test plan

- [ ] Open two clips, run Auto Calibrate, verify left/right lens cards populate with camera model + "Auto-detected" tag.
- [ ] Load a match.json directly (bypass auto-calibrate) - lens cards should stay hidden, candidates count still shown as resolution permits.
- [ ] Toggle **IMU seeds**, re-run Auto Calibrate, verify config respected (log line in calibrator).
- [ ] Build without `cuda`/`tensorrt` features - AI chip reads "CPU-only path" or similar from the probe.
- [ ] Verify workspace `cargo clippy -- -D warnings` and `cargo test --all` stay green.