### PR TITLE
feat(reco-core): Batch F - update_camera_params for live lens tweaking

### DIFF
--- a/crates/reco-core/src/pipeline.rs
+++ b/crates/reco-core/src/pipeline.rs
@@ -263,6 +263,41 @@ impl StitchPipeline {
         self.update_calibration(cal);
     }
 
+    /// Update per-camera intrinsics (focal, principal point, distortion)
+    /// for one or both cameras without touching the plane layout or rig
+    /// orientation.
+    ///
+    /// Intended for interactive lens tweaking in a GUI: each `CameraParams`
+    /// change is written into the shader's per-frame uniform buffer, so the
+    /// next render call reflects the new values. No GPU pipeline or scene
+    /// recreation is needed - cheap enough (~microseconds) to call on
+    /// every slider drag.
+    ///
+    /// `left`/`right` are `None` to leave that side untouched. If both are
+    /// `None` this is a no-op. Passing `Some` for a side replaces that
+    /// side's `CameraParams` on the stored calibration; the next render
+    /// picks it up automatically.
+    ///
+    /// Does not recompute `SceneGeometry` because the plane layout is
+    /// unchanged; only the camera intrinsics (which live on the stored
+    /// calibration and are re-read each frame) need updating.
+    pub fn update_camera_params(
+        &mut self,
+        left: Option<crate::calibration::CameraParams>,
+        right: Option<crate::calibration::CameraParams>,
+    ) {
+        if left.is_none() && right.is_none() {
+            return;
+        }
+        if let Some(l) = left {
+            self.calibration.left = l;
+        }
+        if let Some(r) = right {
+            self.calibration.right = r;
+        }
+        log::debug!("Pipeline camera params updated");
+    }
+
     /// Set up bind groups for GPU-resident zero-copy input.
     ///
     /// Creates bind groups for the provided shared textures (Y + UV per slot

--- a/crates/reco-core/src/stitch_renderer.rs
+++ b/crates/reco-core/src/stitch_renderer.rs
@@ -373,6 +373,23 @@ impl StitchRenderer {
             CoverageBoundary::from_calibration(self.pipeline.calibration(), &self.pipeline.scene);
     }
 
+    /// Replace one or both cameras' intrinsics (focal, principal point,
+    /// distortion) without rebuilding the pipeline or touching the layout.
+    ///
+    /// Intended for interactive lens-parameter tweaking in a GUI. See
+    /// [`StitchPipeline::update_camera_params`] for the full contract.
+    /// Coverage boundary is not recomputed because the layout (and thus
+    /// the panorama extent) is unchanged - only the per-camera undistort
+    /// uniforms shift, which affects what each camera "sees" through its
+    /// lens but not how the stitched planes are arranged in world space.
+    pub fn update_camera_params(
+        &mut self,
+        left: Option<crate::calibration::CameraParams>,
+        right: Option<crate::calibration::CameraParams>,
+    ) {
+        self.pipeline.update_camera_params(left, right);
+    }
+
     /// Set the seam blend width (0.0 = hard edge, 0.15 = default smooth blend).
     pub fn set_blend_width(&mut self, w: f32) {
         self.pipeline.viewport.blend_width = w;


### PR DESCRIPTION
## Summary

Single-method addition to unblock Tier 2b GUI live-lens-tweak sliders.

**New**: `StitchPipeline::update_camera_params(left, right)` and matching method on `StitchRenderer`. Replaces per-camera intrinsics (focal, principal point, distortion) without rebuilding the pipeline or recomputing the plane layout.

## Why not `update_calibration`?

`update_calibration(MatchCalibration)` works but forces the caller to clone the full struct and rebuilds `SceneGeometry` from the layout even when only intrinsics changed. For interactive slider drags (Tier 2b lens tab), that's wasteful. The new method:
- Takes `Option<CameraParams>` per side so the caller updates just what changed.
- Does not touch `SceneGeometry` because the layout is unchanged.
- Skips the coverage-boundary recomputation that intrinsic changes don't invalidate (panorama extent is a function of rig layout, not lens params).

## Why this is cheap

The shader already reads camera params from a per-frame uniform buffer populated from `self.calibration.{left,right}`. Updating the stored calibration is enough - no LUT textures to regenerate, no pipeline state to recreate.

## FRICTION.md update

Resolves A3 (reco-gui/FRICTION.md). A4 (CoverageBoundary::clamp) turned out to already be resolved: `CoverageBoundary::safe_clamp` has been there all along and is exactly what the constrained-look toggle needs. Will correct the FRICTION entry in the Tier 2b reco-gui PR that consumes this.

## Test plan

- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, `cargo test --all` stay green.
- [ ] Tier 2b reco-gui PR wires lens-tab sliders to this method and verifies the preview updates in real time on slider drag.

## Follow-up

Tier 2b (reco-gui): lens tab with fx/fy/cx/cy/k1-k4 sliders, constrained-look toggle (uses `safe_clamp`), projection-mode dropdown (may need reco-core `ProjectionMode` enum from issue #196's "Material" concept, but that is deferred until we have a specific use case driving it).