### PR TITLE
feat(reco-gui): Tier 2b - live lens fine-tune + constrained-look toggle

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1690,6 +1690,14 @@ fn handle_calibration_result(
                         state.cal_baseline_right_params = Some(r.clone());
                     }
 
+                    // Grab the layout baseline so the Calibration sliders
+                    // (intersect, camera-axis offset, x_ty) show the
+                    // auto-calibrated values instead of 0. Without this
+                    // the preview looks correct while the sliders read
+                    // 0; clicking any of them snaps the layout to ~0
+                    // and destroys the calibration.
+                    let layout_baseline = state.cal_baseline_layout.clone();
+
                     if let Some(app) = app_weak.upgrade() {
                         app.set_files_loaded(true);
                         app.set_calibration_path("(auto-calibrated)".into());
@@ -1705,6 +1713,12 @@ fn handle_calibration_result(
                         );
                         if let Some(img) = img {
                             app.set_preview_frame(img);
+                        }
+                        if let Some(layout) = layout_baseline.as_ref() {
+                            app.set_cal_intersect(layout.intersect as f32);
+                            app.set_cal_camera_axis_offset(layout.camera_axis_offset as f32);
+                            app.set_cal_x_ty(layout.x_ty as f32);
+                            app.set_cal_dirty(false);
                         }
                         set_lens_profile_props(&app, left_profile, right_profile, in_w, in_h);
                         if let Some((l, r)) = lens_baseline.as_ref() {
@@ -1828,7 +1842,18 @@ fn run_export(
                         if total > 0 {
                             app.set_export_progress(frames as f32 / total as f32);
                         }
-                        app.set_export_status_text(format!("Frame {frames} ({fps:.0} fps)").into());
+                        // Once we've written the last frame, the encoder
+                        // still spends a few seconds on av_write_trailer
+                        // and index flushing before job.run returns.
+                        // Switching the status to "Finalizing..." here
+                        // stops the progress bar from looking hung.
+                        if total > 0 && frames as i32 >= total {
+                            app.set_export_status_text("Finalizing output file…".into());
+                        } else {
+                            app.set_export_status_text(
+                                format!("Frame {frames} ({fps:.0} fps)").into(),
+                            );
+                        }
                     }
                 });
             });

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -153,7 +153,7 @@ struct AppState {
     cal_baseline_left_params: Option<reco_core::calibration::CameraParams>,
     cal_baseline_right_params: Option<reco_core::calibration::CameraParams>,
     /// When true, `clamp_targets` pins yaw/pitch to the coverage boundary
-    /// via [`CoverageBoundary::safe_clamp`] so the viewport never shows
+    /// via `CoverageBoundary::safe_clamp` so the viewport never shows
     /// black margins. When false, pan/zoom is unrestricted - useful for
     /// calibration debug where the user wants to see beyond the stitched
     /// region. Bound to the Slint `use-constrained-look` checkbox.

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -492,10 +492,10 @@ impl AppState {
     /// clamped implicitly as it lerps toward the clamped target.
     fn clamp_targets(&mut self) {
         // Constrained-look toggle: when the user disables it we let
-        // yaw/pitch roam freely (useful for calibration debug or
+        // yaw/pitch/fov roam freely (useful for calibration debug or
         // inspecting the black margins beyond the stitched region).
-        // When enabled - the default - we clamp to the coverage boundary
-        // so the viewport cannot display black.
+        // When enabled - the default - we clamp both yaw/pitch AND fov
+        // so the viewport cannot display black at any zoom level.
         if !self.use_constrained_look {
             return;
         }
@@ -506,6 +506,16 @@ impl AppState {
         let (vw, vh) = bridge.viewport_size();
         let aspect = vw as f32 / vh as f32;
         let rig_tilt = renderer.pipeline().viewport().rig_tilt;
+
+        // FOV first: zooming out past what the coverage can contain
+        // produces black margins regardless of yaw/pitch, so clamp the
+        // target fov to the boundary's max before solving yaw/pitch
+        // (which depends on fov).
+        let max_fov = renderer.coverage().max_fov_degrees();
+        if max_fov > 0.0 {
+            self.target_fov = self.target_fov.min(max_fov);
+        }
+
         let clamped = renderer.coverage().safe_clamp(
             self.target_yaw,
             self.target_pitch,
@@ -1114,62 +1124,91 @@ fn main() -> anyhow::Result<()> {
         };
         let mut s = state_ref.borrow_mut();
         let selected = app.get_lens_selected_camera();
-        let (left_params, right_params) = if selected.as_str() == "right" {
-            let p = reco_core::calibration::CameraParams {
-                fx: app.get_lens_right_fx() as f64,
-                fy: app.get_lens_right_fy() as f64,
-                cx: app.get_lens_right_cx() as f64,
-                cy: app.get_lens_right_cy() as f64,
-                d: [
-                    app.get_lens_right_k1() as f64,
-                    app.get_lens_right_k2() as f64,
-                    app.get_lens_right_k3() as f64,
-                    app.get_lens_right_k4() as f64,
-                ],
-                width: 0,
-                height: 0,
-            };
-            // Keep width/height from the stored calibration - they're
-            // not user-editable. CameraParams::{width, height} are the
-            // image resolution the lens was modelled against.
-            let width = s
-                .bridge
-                .as_ref()
-                .map(|b| b.renderer().pipeline().calibration().right.width)
-                .unwrap_or(0);
-            let height = s
-                .bridge
-                .as_ref()
-                .map(|b| b.renderer().pipeline().calibration().right.height)
-                .unwrap_or(0);
-            let p = reco_core::calibration::CameraParams { width, height, ..p };
-            (None, Some(p))
-        } else {
-            let width = s
-                .bridge
-                .as_ref()
-                .map(|b| b.renderer().pipeline().calibration().left.width)
-                .unwrap_or(0);
-            let height = s
-                .bridge
-                .as_ref()
-                .map(|b| b.renderer().pipeline().calibration().left.height)
-                .unwrap_or(0);
-            let p = reco_core::calibration::CameraParams {
-                fx: app.get_lens_left_fx() as f64,
-                fy: app.get_lens_left_fy() as f64,
-                cx: app.get_lens_left_cx() as f64,
-                cy: app.get_lens_left_cy() as f64,
-                d: [
-                    app.get_lens_left_k1() as f64,
-                    app.get_lens_left_k2() as f64,
-                    app.get_lens_left_k3() as f64,
-                    app.get_lens_left_k4() as f64,
-                ],
-                width,
-                height,
-            };
-            (Some(p), None)
+        // Width/height come from the stored calibration (resolution the
+        // lens profile was modelled at) and are never user-editable.
+        let (left_wh, right_wh) = s
+            .bridge
+            .as_ref()
+            .map(|b| {
+                let c = b.renderer().pipeline().calibration();
+                (
+                    (c.left.width, c.left.height),
+                    (c.right.width, c.right.height),
+                )
+            })
+            .unwrap_or(((0, 0), (0, 0)));
+
+        let (left_params, right_params) = match selected.as_str() {
+            "right" => {
+                let p = reco_core::calibration::CameraParams {
+                    fx: app.get_lens_right_fx() as f64,
+                    fy: app.get_lens_right_fy() as f64,
+                    cx: app.get_lens_right_cx() as f64,
+                    cy: app.get_lens_right_cy() as f64,
+                    d: [
+                        app.get_lens_right_k1() as f64,
+                        app.get_lens_right_k2() as f64,
+                        app.get_lens_right_k3() as f64,
+                        app.get_lens_right_k4() as f64,
+                    ],
+                    width: right_wh.0,
+                    height: right_wh.1,
+                };
+                (None, Some(p))
+            }
+            "both" => {
+                // Mirror the Left sliders to both cameras. The Both tab
+                // only shows the left sliders in the UI; the user's
+                // intent is "apply these values to both lenses in
+                // lockstep". We also push the mirrored values back into
+                // the right-* Slint properties so when the user toggles
+                // to Right later the sliders show what got applied.
+                app.set_lens_right_fx(app.get_lens_left_fx());
+                app.set_lens_right_fy(app.get_lens_left_fy());
+                app.set_lens_right_cx(app.get_lens_left_cx());
+                app.set_lens_right_cy(app.get_lens_left_cy());
+                app.set_lens_right_k1(app.get_lens_left_k1());
+                app.set_lens_right_k2(app.get_lens_left_k2());
+                app.set_lens_right_k3(app.get_lens_left_k3());
+                app.set_lens_right_k4(app.get_lens_left_k4());
+                let left = reco_core::calibration::CameraParams {
+                    fx: app.get_lens_left_fx() as f64,
+                    fy: app.get_lens_left_fy() as f64,
+                    cx: app.get_lens_left_cx() as f64,
+                    cy: app.get_lens_left_cy() as f64,
+                    d: [
+                        app.get_lens_left_k1() as f64,
+                        app.get_lens_left_k2() as f64,
+                        app.get_lens_left_k3() as f64,
+                        app.get_lens_left_k4() as f64,
+                    ],
+                    width: left_wh.0,
+                    height: left_wh.1,
+                };
+                let right = reco_core::calibration::CameraParams {
+                    width: right_wh.0,
+                    height: right_wh.1,
+                    ..left.clone()
+                };
+                (Some(left), Some(right))
+            }
+            _ => {
+                let p = reco_core::calibration::CameraParams {
+                    fx: app.get_lens_left_fx() as f64,
+                    fy: app.get_lens_left_fy() as f64,
+                    cx: app.get_lens_left_cx() as f64,
+                    cy: app.get_lens_left_cy() as f64,
+                    d: [
+                        app.get_lens_left_k1() as f64,
+                        app.get_lens_left_k2() as f64,
+                        app.get_lens_left_k3() as f64,
+                        app.get_lens_left_k4() as f64,
+                    ],
+                    width: left_wh.0,
+                    height: left_wh.1,
+                };
+                (Some(p), None)
+            }
         };
         if let Some(bridge) = s.bridge.as_mut() {
             bridge
@@ -1203,6 +1242,28 @@ fn main() -> anyhow::Result<()> {
             s.preview_dirty = true;
             app.set_lens_dirty(false);
         }
+    });
+
+    // Slint's <=> binding updates the use-constrained-look property but
+    // does not call back into Rust. Without this notify, AppState's
+    // use_constrained_look stays at its initial value forever and the
+    // UI checkbox is cosmetic.
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_changed_constrained_look(move || {
+        let Some(app) = app_weak.upgrade() else {
+            return;
+        };
+        let new_value = app.get_use_constrained_look();
+        let mut s = state_ref.borrow_mut();
+        s.use_constrained_look = new_value;
+        // When re-enabling, apply the clamp to the current target so
+        // the camera snaps back inside coverage instead of waiting for
+        // the next pan/zoom input.
+        if new_value {
+            s.clamp_targets();
+        }
+        s.preview_dirty = true;
     });
 
     // ── Export dialog callbacks ──

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -20,6 +20,7 @@ use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
@@ -138,6 +139,14 @@ struct AppState {
     /// Interrupt flag for a running export. Set to true when the user
     /// clicks Cancel; StitchJob checks it between frames and aborts.
     export_interrupted: Arc<AtomicBool>,
+    /// Timestamp of the last time `run_export`'s progress callback
+    /// fired. Used by the playback timer to detect when the encoder is
+    /// in its post-last-frame finalization phase (av_write_trailer +
+    /// index flush can take ~10 seconds) so we can display "Finalizing
+    /// output file…" instead of a stale frame count. Shared via Arc so
+    /// the worker thread can stamp it without going through
+    /// `invoke_from_event_loop`.
+    export_last_progress_at: Arc<Mutex<Option<Instant>>>,
     /// Join handle for the export worker. Held so the timer can see
     /// when the export finishes (via try_recv on export_rx).
     export_thread: Option<std::thread::JoinHandle<()>>,
@@ -241,6 +250,7 @@ impl AppState {
             last_render_at: None,
             preview_dirty: false,
             export_interrupted: Arc::new(AtomicBool::new(false)),
+            export_last_progress_at: Arc::new(Mutex::new(None)),
             export_thread: None,
             export_rx: None,
             cal_baseline_layout: None,
@@ -1362,6 +1372,11 @@ fn main() -> anyhow::Result<()> {
         let (tx, rx) = std::sync::mpsc::channel();
         s.export_rx = Some(rx);
 
+        // Seed the last-progress timestamp so the Finalizing detector
+        // has a starting point. Cloned for the worker below.
+        *s.export_last_progress_at.lock().unwrap() = Some(Instant::now());
+        let last_progress_at = Arc::clone(&s.export_last_progress_at);
+
         // UI-thread setup before launching the worker.
         app.set_export_in_progress(true);
         app.set_export_progress(0.0);
@@ -1390,6 +1405,7 @@ fn main() -> anyhow::Result<()> {
                 detection_interval,
                 app_weak_bg,
                 &interrupted,
+                last_progress_at,
             );
             let _ = tx.send(outcome);
         });
@@ -1453,6 +1469,24 @@ fn main() -> anyhow::Result<()> {
                     }
                 }
                 return;
+            }
+
+            // If an export is running and we haven't seen a progress
+            // update in > 1.5 seconds, the encoder is in its tail phase
+            // (av_write_trailer + index flush can take up to ~15s on
+            // H.264/AV1). Switch the status text to "Finalizing..." so
+            // the progress bar doesn't look hung. Time-based detection
+            // is robust to whatever the probe-reported total-frames is;
+            // no frame-count heuristic needed.
+            if let Some(app) = app_weak.upgrade()
+                && app.get_export_in_progress()
+                && let Some(last) = *s.export_last_progress_at.lock().unwrap()
+                && last.elapsed() > Duration::from_millis(1500)
+            {
+                let status = app.get_export_status_text();
+                if !status.starts_with("Finalizing") {
+                    app.set_export_status_text("Finalizing output file…".into());
+                }
             }
 
             // Commit a debounced seek once the requested fraction has
@@ -1801,6 +1835,7 @@ fn run_export(
     detection_interval: u32,
     app_weak: slint::Weak<RecoApp>,
     interrupted: &AtomicBool,
+    last_progress_at: Arc<Mutex<Option<Instant>>>,
 ) -> ExportOutcome {
     use reco_io::output::{Codec, Quality};
 
@@ -1850,6 +1885,7 @@ fn run_export(
 
     let progress_weak = app_weak.clone();
     let progress_start = Instant::now();
+    let progress_last_at = Arc::clone(&last_progress_at);
     let mut job =
         reco_io::StitchJob::with_calibration(left.clone(), right.clone(), cal, output.clone())
             .codec(codec)
@@ -1866,6 +1902,13 @@ fn run_export(
                 } else {
                     0.0
                 };
+                // Stamp the time directly from the worker thread. The
+                // main-thread timer reads this to detect when the job
+                // is in its finalization phase (encoder trailer write +
+                // index flush). Lock contention is negligible - we only
+                // touch it once per frame and the timer reads briefly.
+                *progress_last_at.lock().unwrap() = Some(Instant::now());
+
                 let weak = progress_weak.clone();
                 let _ = slint::invoke_from_event_loop(move || {
                     if let Some(app) = weak.upgrade() {
@@ -1874,30 +1917,7 @@ fn run_export(
                         if total > 0 {
                             app.set_export_progress(frames as f32 / total as f32);
                         }
-                        // Once we've written the last frame, the encoder
-                        // still spends a few seconds on av_write_trailer
-                        // and index flushing before job.run returns.
-                        // Switching the status to "Finalizing..." here
-                        // stops the progress bar from looking hung.
-                        //
-                        // The probe-reported `total` overshoots the
-                        // actually-encoded count by the sync-offset skip
-                        // (e.g. 67 frames on the GoPro test clip), so
-                        // the literal `frames >= total` condition never
-                        // triggers. Match on "last 0.5% of frames" which
-                        // is generous enough to cover sync skips of a
-                        // few seconds but still tight enough that the
-                        // Finalizing text only appears at the real tail
-                        // of the job.
-                        let near_end = total > 0
-                            && (frames as i32 >= total || frames as f32 / total as f32 >= 0.995);
-                        if near_end {
-                            app.set_export_status_text("Finalizing output file…".into());
-                        } else {
-                            app.set_export_status_text(
-                                format!("Frame {frames} ({fps:.0} fps)").into(),
-                            );
-                        }
+                        app.set_export_status_text(format!("Frame {frames} ({fps:.0} fps)").into());
                     }
                 });
             });

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -146,6 +146,18 @@ struct AppState {
     /// Original PlaneLayout values — what auto-calibrate produced. Live
     /// calibration sliders edit relative to this so Reset restores.
     cal_baseline_layout: Option<reco_core::calibration::PlaneLayout>,
+    /// Baseline camera intrinsics from the last successful calibration.
+    /// The Lens fine-tune sliders in the Controls panel edit these; the
+    /// Reset Lens button restores them. `None` until auto-calibrate or a
+    /// manual match.json load populates them.
+    cal_baseline_left_params: Option<reco_core::calibration::CameraParams>,
+    cal_baseline_right_params: Option<reco_core::calibration::CameraParams>,
+    /// When true, `clamp_targets` pins yaw/pitch to the coverage boundary
+    /// via [`CoverageBoundary::safe_clamp`] so the viewport never shows
+    /// black margins. When false, pan/zoom is unrestricted - useful for
+    /// calibration debug where the user wants to see beyond the stitched
+    /// region. Bound to the Slint `use-constrained-look` checkbox.
+    use_constrained_look: bool,
 }
 
 /// Runtime AI capability summary.
@@ -232,6 +244,9 @@ impl AppState {
             export_thread: None,
             export_rx: None,
             cal_baseline_layout: None,
+            cal_baseline_left_params: None,
+            cal_baseline_right_params: None,
+            use_constrained_look: true,
         }
     }
 
@@ -476,6 +491,14 @@ impl AppState {
     /// input can't set an unreachable goal. The current pose is
     /// clamped implicitly as it lerps toward the clamped target.
     fn clamp_targets(&mut self) {
+        // Constrained-look toggle: when the user disables it we let
+        // yaw/pitch roam freely (useful for calibration debug or
+        // inspecting the black margins beyond the stitched region).
+        // When enabled - the default - we clamp to the coverage boundary
+        // so the viewport cannot display black.
+        if !self.use_constrained_look {
+            return;
+        }
         let Some(bridge) = self.bridge.as_ref() else {
             return;
         };
@@ -510,6 +533,56 @@ impl AppState {
 }
 
 /// Extract just the filename from a path for display.
+/// Seed the Slint lens-tune sliders and their display ranges from a
+/// pair of baseline `CameraParams`. Called after auto-calibrate completes
+/// and on Reset Lens. Ranges are chosen wide enough for meaningful
+/// manual tuning (fx/fy: +/-15%, cx/cy: +/-10% of image dim) but tight
+/// enough that the slider granularity is useful.
+fn set_lens_sliders(
+    app: &RecoApp,
+    left: &reco_core::calibration::CameraParams,
+    right: &reco_core::calibration::CameraParams,
+) {
+    // Ranges are computed from the left camera's baseline. In stereo
+    // rigs the two lenses are typically matched models, so a single
+    // range keeps the UI simpler. If the cameras ever differ materially
+    // this can be revisited.
+    let f_baseline = left.fx.max(left.fy);
+    let fx_span = (f_baseline * 0.15).max(5.0);
+    let w = left.width.max(1) as f64;
+    let h = left.height.max(1) as f64;
+    let cx_span = (w * 0.10).max(5.0);
+    let cy_span = (h * 0.10).max(5.0);
+
+    app.set_lens_fx_min((left.fx - fx_span) as f32);
+    app.set_lens_fx_max((left.fx + fx_span) as f32);
+    app.set_lens_fy_min((left.fy - fx_span) as f32);
+    app.set_lens_fy_max((left.fy + fx_span) as f32);
+    app.set_lens_cx_min((left.cx - cx_span) as f32);
+    app.set_lens_cx_max((left.cx + cx_span) as f32);
+    app.set_lens_cy_min((left.cy - cy_span) as f32);
+    app.set_lens_cy_max((left.cy + cy_span) as f32);
+    app.set_lens_k_range(0.3);
+
+    app.set_lens_left_fx(left.fx as f32);
+    app.set_lens_left_fy(left.fy as f32);
+    app.set_lens_left_cx(left.cx as f32);
+    app.set_lens_left_cy(left.cy as f32);
+    app.set_lens_left_k1(left.d[0] as f32);
+    app.set_lens_left_k2(left.d[1] as f32);
+    app.set_lens_left_k3(left.d[2] as f32);
+    app.set_lens_left_k4(left.d[3] as f32);
+
+    app.set_lens_right_fx(right.fx as f32);
+    app.set_lens_right_fy(right.fy as f32);
+    app.set_lens_right_cx(right.cx as f32);
+    app.set_lens_right_cy(right.cy as f32);
+    app.set_lens_right_k1(right.d[0] as f32);
+    app.set_lens_right_k2(right.d[1] as f32);
+    app.set_lens_right_k3(right.d[2] as f32);
+    app.set_lens_right_k4(right.d[3] as f32);
+}
+
 /// Human-readable description of how a lens profile was resolved.
 fn profile_source_label(info: &LensProfileInfo) -> &'static str {
     match info.source {
@@ -1026,6 +1099,112 @@ fn main() -> anyhow::Result<()> {
         }
     });
 
+    // ── Live lens tuning callbacks ──
+    //
+    // Each slider emits `changed-lens-param` which asks Rust to read
+    // the current fx/fy/cx/cy/k1-k4 from the UI properties for the
+    // selected camera, build a `CameraParams`, and push it through
+    // `update_camera_params`. Cheap per reco-core Batch F.
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_changed_lens_param(move || {
+        let Some(app) = app_weak.upgrade() else {
+            return;
+        };
+        let mut s = state_ref.borrow_mut();
+        let selected = app.get_lens_selected_camera();
+        let (left_params, right_params) = if selected.as_str() == "right" {
+            let p = reco_core::calibration::CameraParams {
+                fx: app.get_lens_right_fx() as f64,
+                fy: app.get_lens_right_fy() as f64,
+                cx: app.get_lens_right_cx() as f64,
+                cy: app.get_lens_right_cy() as f64,
+                d: [
+                    app.get_lens_right_k1() as f64,
+                    app.get_lens_right_k2() as f64,
+                    app.get_lens_right_k3() as f64,
+                    app.get_lens_right_k4() as f64,
+                ],
+                width: 0,
+                height: 0,
+            };
+            // Keep width/height from the stored calibration - they're
+            // not user-editable. CameraParams::{width, height} are the
+            // image resolution the lens was modelled against.
+            let width = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().calibration().right.width)
+                .unwrap_or(0);
+            let height = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().calibration().right.height)
+                .unwrap_or(0);
+            let p = reco_core::calibration::CameraParams { width, height, ..p };
+            (None, Some(p))
+        } else {
+            let width = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().calibration().left.width)
+                .unwrap_or(0);
+            let height = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().calibration().left.height)
+                .unwrap_or(0);
+            let p = reco_core::calibration::CameraParams {
+                fx: app.get_lens_left_fx() as f64,
+                fy: app.get_lens_left_fy() as f64,
+                cx: app.get_lens_left_cx() as f64,
+                cy: app.get_lens_left_cy() as f64,
+                d: [
+                    app.get_lens_left_k1() as f64,
+                    app.get_lens_left_k2() as f64,
+                    app.get_lens_left_k3() as f64,
+                    app.get_lens_left_k4() as f64,
+                ],
+                width,
+                height,
+            };
+            (Some(p), None)
+        };
+        if let Some(bridge) = s.bridge.as_mut() {
+            bridge
+                .renderer_mut()
+                .update_camera_params(left_params, right_params);
+        }
+        s.preview_dirty = true;
+        app.set_lens_dirty(true);
+    });
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_reset_lens(move || {
+        let Some(app) = app_weak.upgrade() else {
+            return;
+        };
+        let mut s = state_ref.borrow_mut();
+        // Baseline lens params live on the calibration we snapshotted
+        // when auto-calibrate completed (see cal_baseline_*_params).
+        let (left_base, right_base) = (
+            s.cal_baseline_left_params.clone(),
+            s.cal_baseline_right_params.clone(),
+        );
+        if let (Some(left), Some(right)) = (left_base.as_ref(), right_base.as_ref()) {
+            set_lens_sliders(&app, left, right);
+            if let Some(bridge) = s.bridge.as_mut() {
+                bridge
+                    .renderer_mut()
+                    .update_camera_params(Some(left.clone()), Some(right.clone()));
+            }
+            s.preview_dirty = true;
+            app.set_lens_dirty(false);
+        }
+    });
+
     // ── Export dialog callbacks ──
     //
     // "Open" populates default values from current state (blend width
@@ -1330,6 +1509,18 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
 
             let (in_w, in_h) = s.playback.input_dimensions().unwrap_or((0, 0));
 
+            // Snapshot current lens params as the fine-tune baseline so
+            // Reset Lens can restore them. For manual match.json loads
+            // this comes from the loaded calibration directly.
+            let lens_baseline = s.bridge.as_ref().map(|b| {
+                let cal = b.renderer().pipeline().calibration();
+                (cal.left.clone(), cal.right.clone())
+            });
+            if let Some((l, r)) = lens_baseline.as_ref() {
+                s.cal_baseline_left_params = Some(l.clone());
+                s.cal_baseline_right_params = Some(r.clone());
+            }
+
             if let Some(app) = app_weak.upgrade() {
                 app.set_files_loaded(true);
                 app.set_total_frames(total as i32);
@@ -1352,6 +1543,13 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 // the candidates count for this resolution so the user
                 // still knows how many database entries could match.
                 set_lens_profile_props(&app, None, None, in_w, in_h);
+                // Lens fine-tune sliders are seeded from the loaded
+                // calibration's camera params either way; the Lens
+                // fine-tune section is gated on `files-loaded` in Slint.
+                if let Some((l, r)) = lens_baseline.as_ref() {
+                    set_lens_sliders(&app, l, r);
+                    app.set_lens_dirty(false);
+                }
                 // Seed export dialog output filename suggestion to
                 // sit next to the left-video file for convenience.
                 let left_path = s.left_path.clone();
@@ -1419,6 +1617,18 @@ fn handle_calibration_result(
                     let img = state.render_current();
                     let (in_w, in_h) = state.playback.input_dimensions().unwrap_or((0, 0));
 
+                    // Snapshot camera intrinsics as the Lens fine-tune
+                    // baseline so Reset Lens can restore them after
+                    // manual edits.
+                    let lens_baseline = state.bridge.as_ref().map(|b| {
+                        let cal = b.renderer().pipeline().calibration();
+                        (cal.left.clone(), cal.right.clone())
+                    });
+                    if let Some((l, r)) = lens_baseline.as_ref() {
+                        state.cal_baseline_left_params = Some(l.clone());
+                        state.cal_baseline_right_params = Some(r.clone());
+                    }
+
                     if let Some(app) = app_weak.upgrade() {
                         app.set_files_loaded(true);
                         app.set_calibration_path("(auto-calibrated)".into());
@@ -1436,6 +1646,10 @@ fn handle_calibration_result(
                             app.set_preview_frame(img);
                         }
                         set_lens_profile_props(&app, left_profile, right_profile, in_w, in_h);
+                        if let Some((l, r)) = lens_baseline.as_ref() {
+                            set_lens_sliders(&app, l, r);
+                            app.set_lens_dirty(false);
+                        }
                     }
                 }
                 Ok(false) => {}

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1581,6 +1581,15 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 s.cal_baseline_left_params = Some(l.clone());
                 s.cal_baseline_right_params = Some(r.clone());
             }
+            // Same for viewport-level settings (rig tilt, blend width).
+            let rig_tilt_rad = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().viewport().rig_tilt);
+            let blend_width = s
+                .bridge
+                .as_ref()
+                .map(|b| b.renderer().pipeline().viewport().blend_width);
 
             if let Some(app) = app_weak.upgrade() {
                 app.set_files_loaded(true);
@@ -1598,6 +1607,12 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     app.set_cal_camera_axis_offset(layout.camera_axis_offset as f32);
                     app.set_cal_x_ty(layout.x_ty as f32);
                     app.set_cal_dirty(false);
+                }
+                if let Some(rt) = rig_tilt_rad {
+                    app.set_rig_tilt(rt.to_degrees());
+                }
+                if let Some(bw) = blend_width {
+                    app.set_blend_width(bw);
                 }
                 // Manual calibration JSON does not embed lens-profile info,
                 // so clear the display (hide the lens card) and just show
@@ -1697,6 +1712,17 @@ fn handle_calibration_result(
                     // 0; clicking any of them snaps the layout to ~0
                     // and destroys the calibration.
                     let layout_baseline = state.cal_baseline_layout.clone();
+                    // Same idea for rig tilt and blend width: read the
+                    // calibrated values off the viewport so the View
+                    // panel sliders match what the preview actually shows.
+                    let rig_tilt_rad = state
+                        .bridge
+                        .as_ref()
+                        .map(|b| b.renderer().pipeline().viewport().rig_tilt);
+                    let blend_width = state
+                        .bridge
+                        .as_ref()
+                        .map(|b| b.renderer().pipeline().viewport().blend_width);
 
                     if let Some(app) = app_weak.upgrade() {
                         app.set_files_loaded(true);
@@ -1719,6 +1745,12 @@ fn handle_calibration_result(
                             app.set_cal_camera_axis_offset(layout.camera_axis_offset as f32);
                             app.set_cal_x_ty(layout.x_ty as f32);
                             app.set_cal_dirty(false);
+                        }
+                        if let Some(rt) = rig_tilt_rad {
+                            app.set_rig_tilt(rt.to_degrees());
+                        }
+                        if let Some(bw) = blend_width {
+                            app.set_blend_width(bw);
                         }
                         set_lens_profile_props(&app, left_profile, right_profile, in_w, in_h);
                         if let Some((l, r)) = lens_baseline.as_ref() {
@@ -1847,7 +1879,19 @@ fn run_export(
                         // and index flushing before job.run returns.
                         // Switching the status to "Finalizing..." here
                         // stops the progress bar from looking hung.
-                        if total > 0 && frames as i32 >= total {
+                        //
+                        // The probe-reported `total` overshoots the
+                        // actually-encoded count by the sync-offset skip
+                        // (e.g. 67 frames on the GoPro test clip), so
+                        // the literal `frames >= total` condition never
+                        // triggers. Match on "last 0.5% of frames" which
+                        // is generous enough to cover sync skips of a
+                        // few seconds but still tight enough that the
+                        // Finalizing text only appears at the real tail
+                        // of the job.
+                        let near_end = total > 0
+                            && (frames as i32 >= total || frames as f32 / total as f32 >= 0.995);
+                        if near_end {
                             app.set_export_status_text("Finalizing output file…".into());
                         } else {
                             app.set_export_status_text(

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -171,6 +171,47 @@ export component RecoApp inherits Window {
     // off because the feature-matching seed is reliable on most footage.
     in-out property <bool> use-imu-seeds: false;
 
+    // When true (default), pan/zoom is clamped to the coverage boundary
+    // so the viewport never shows black margins. Users can disable it
+    // to inspect what is happening beyond the stitched region, which is
+    // useful for calibration debug.
+    in-out property <bool> use-constrained-look: true;
+
+    // Per-camera lens intrinsics (populated by Rust after auto-calibrate
+    // from `CalibrationResult.left_lens_profile` / `right_lens_profile`).
+    // The Lens tab binds sliders to these properties; changes flow back
+    // to Rust via `changed-lens-param`, which calls
+    // `StitchRenderer::update_camera_params` for live preview.
+    in-out property <float> lens-left-fx: 0.0;
+    in-out property <float> lens-left-fy: 0.0;
+    in-out property <float> lens-left-cx: 0.0;
+    in-out property <float> lens-left-cy: 0.0;
+    in-out property <float> lens-left-k1: 0.0;
+    in-out property <float> lens-left-k2: 0.0;
+    in-out property <float> lens-left-k3: 0.0;
+    in-out property <float> lens-left-k4: 0.0;
+    in-out property <float> lens-right-fx: 0.0;
+    in-out property <float> lens-right-fy: 0.0;
+    in-out property <float> lens-right-cx: 0.0;
+    in-out property <float> lens-right-cy: 0.0;
+    in-out property <float> lens-right-k1: 0.0;
+    in-out property <float> lens-right-k2: 0.0;
+    in-out property <float> lens-right-k3: 0.0;
+    in-out property <float> lens-right-k4: 0.0;
+    // Slider display ranges (set by Rust to baseline +/- safe delta).
+    in-out property <float> lens-fx-min: 0.0;
+    in-out property <float> lens-fx-max: 0.0;
+    in-out property <float> lens-fy-min: 0.0;
+    in-out property <float> lens-fy-max: 0.0;
+    in-out property <float> lens-cx-min: 0.0;
+    in-out property <float> lens-cx-max: 0.0;
+    in-out property <float> lens-cy-min: 0.0;
+    in-out property <float> lens-cy-max: 0.0;
+    in-out property <float> lens-k-range: 0.3; // k sliders: baseline +/- this
+    in-out property <bool> lens-dirty: false;
+    // Which camera the lens-tab sliders are editing.
+    in-out property <string> lens-selected-camera: "left";
+
     // ── Callbacks into Rust ──
 
     callback pick-left-video();
@@ -199,6 +240,11 @@ export component RecoApp inherits Window {
     callback changed-cal-x-ty(float);
     callback save-calibration();
     callback reset-calibration();
+    // Live lens parameter editing. Fires on any of the 8 sliders per
+    // camera; Rust reads the property values for the currently-selected
+    // camera and calls update_camera_params.
+    callback changed-lens-param();
+    callback reset-lens();
     // Export dialog actions.
     callback open-export-dialog();
     callback pick-export-output();
@@ -441,6 +487,15 @@ export component RecoApp inherits Window {
                         changed(v) => { root.changed-fov(v); }
                     }
 
+                    // Constrained look: clamps pan/zoom to the coverage
+                    // boundary when on (default). Off lets the user pan
+                    // into the black margins beyond the stitched region
+                    // - useful for calibration debug.
+                    CheckBox {
+                        text: "Constrained look (clamp to coverage)";
+                        checked <=> root.use-constrained-look;
+                    }
+
                     Rectangle { height: 1px; background: #333; }
 
                     Text {
@@ -499,7 +554,7 @@ export component RecoApp inherits Window {
                         wrap: word-wrap;
                     }
 
-                    if root.lens-info-available: VerticalLayout {
+                    if root.files-loaded: VerticalLayout {
                         spacing: 6px;
 
                         // Left camera card
@@ -571,6 +626,178 @@ export component RecoApp inherits Window {
                     }
 
                     Rectangle { height: 1px; background: #333; }
+
+                    // ── Live lens fine-tuning ──
+                    // Sliders bound directly to the stored CameraParams
+                    // via changed-lens-param. Editing one side at a time
+                    // keeps the Controls panel compact; the left/right
+                    // toggle swaps which camera the sliders are driving.
+                    if root.files-loaded: Text {
+                        text: "Lens fine-tune";
+                        color: #fff;
+                        font-size: 14px;
+                        font-weight: 600;
+                    }
+
+                    if root.files-loaded: HorizontalLayout {
+                        spacing: 8px;
+                        Button {
+                            text: "Left";
+                            primary: root.lens-selected-camera == "left";
+                            clicked => { root.lens-selected-camera = "left"; }
+                        }
+                        Button {
+                            text: "Right";
+                            primary: root.lens-selected-camera == "right";
+                            clicked => { root.lens-selected-camera = "right"; }
+                        }
+                    }
+
+                    if root.lens-info-available && root.lens-selected-camera == "left": VerticalLayout {
+                        spacing: 4px;
+
+                        LabeledSlider {
+                            label: "fx";
+                            minimum: root.lens-fx-min;
+                            maximum: root.lens-fx-max;
+                            value <=> root.lens-left-fx;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "fy";
+                            minimum: root.lens-fy-min;
+                            maximum: root.lens-fy-max;
+                            value <=> root.lens-left-fy;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "cx";
+                            minimum: root.lens-cx-min;
+                            maximum: root.lens-cx-max;
+                            value <=> root.lens-left-cx;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "cy";
+                            minimum: root.lens-cy-min;
+                            maximum: root.lens-cy-max;
+                            value <=> root.lens-left-cy;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k1";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-left-k1;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k2";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-left-k2;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k3";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-left-k3;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k4";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-left-k4;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                    }
+
+                    if root.lens-info-available && root.lens-selected-camera == "right": VerticalLayout {
+                        spacing: 4px;
+
+                        LabeledSlider {
+                            label: "fx";
+                            minimum: root.lens-fx-min;
+                            maximum: root.lens-fx-max;
+                            value <=> root.lens-right-fx;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "fy";
+                            minimum: root.lens-fy-min;
+                            maximum: root.lens-fy-max;
+                            value <=> root.lens-right-fy;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "cx";
+                            minimum: root.lens-cx-min;
+                            maximum: root.lens-cx-max;
+                            value <=> root.lens-right-cx;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "cy";
+                            minimum: root.lens-cy-min;
+                            maximum: root.lens-cy-max;
+                            value <=> root.lens-right-cy;
+                            decimals: 0;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k1";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-right-k1;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k2";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-right-k2;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k3";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-right-k3;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                        LabeledSlider {
+                            label: "k4";
+                            minimum: -root.lens-k-range;
+                            maximum: root.lens-k-range;
+                            value <=> root.lens-right-k4;
+                            decimals: 2;
+                            changed(v) => { root.changed-lens-param(); }
+                        }
+                    }
+
+                    if root.files-loaded: Button {
+                        text: "Reset Lens";
+                        enabled: root.lens-dirty;
+                        clicked => { root.reset-lens(); }
+                    }
+
+                    if root.files-loaded: Rectangle { height: 1px; background: #333; }
 
                     // ── Live calibration ──
                     Text {

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -522,8 +522,12 @@ export component RecoApp inherits Window {
 
                     LabeledSlider {
                         label: "Rig tilt";
-                        minimum: -15;
-                        maximum: 15;
+                        // Widened to +/- 30 per tester feedback: rig tilts
+                        // past 15 degrees happen on handheld / body-cam
+                        // footage and the old clamp hid the rest of the
+                        // range from the user.
+                        minimum: -30;
+                        maximum: 30;
                         value <=> root.rig-tilt;
                         suffix: "°";
                         decimals: 1;
@@ -842,19 +846,26 @@ export component RecoApp inherits Window {
 
                     LabeledSlider {
                         label: "Camera axis offset";
-                        minimum: -0.3;
-                        maximum: 0.3;
+                        // Widened to +/- 0.6 per tester feedback - real
+                        // rigs can offset further than +/- 0.3 and the
+                        // old clamp made fine-tuning infeasible.
+                        minimum: -0.6;
+                        maximum: 0.6;
                         value <=> root.cal-camera-axis-offset;
-                        decimals: 2;
+                        decimals: 3;
                         changed(v) => { root.changed-cal-camera-axis-offset(v); }
                     }
 
                     LabeledSlider {
                         label: "x_ty";
-                        minimum: -0.3;
-                        maximum: 0.3;
+                        // Narrowed to +/- 0.1 per tester feedback - x_ty
+                        // is a small correction in practice and the old
+                        // +/- 0.3 range made the slider granularity too
+                        // coarse to tune well.
+                        minimum: -0.1;
+                        maximum: 0.1;
                         value <=> root.cal-x-ty;
-                        decimals: 2;
+                        decimals: 3;
                         changed(v) => { root.changed-cal-x-ty(v); }
                     }
 
@@ -1070,10 +1081,14 @@ export component RecoApp inherits Window {
                     HorizontalBox {
                         spacing: 6px;
                         padding: 0;
+                        // Editable: users want to rename the suggested
+                        // file without invoking the file dialog every
+                        // time. Rust reads `export-output-path` verbatim
+                        // when Start Export fires, so whatever is typed
+                        // here is what gets written.
                         LineEdit {
-                            text: root.export-output-path;
-                            placeholder-text: "Pick a destination file…";
-                            read-only: true;
+                            text <=> root.export-output-path;
+                            placeholder-text: "Pick a destination file, or type a path…";
                             horizontal-stretch: 1;
                         }
                         Button {

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -837,10 +837,12 @@ export component RecoApp inherits Window {
 
                     LabeledSlider {
                         label: "Intersect";
-                        minimum: -0.5;
-                        maximum: 0.5;
+                        // Widened per tester feedback - the old +/- 0.5
+                        // was too tight for some rig geometries.
+                        minimum: -1.0;
+                        maximum: 1.0;
                         value <=> root.cal-intersect;
-                        decimals: 2;
+                        decimals: 3;
                         changed(v) => { root.changed-cal-intersect(v); }
                     }
 

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -245,6 +245,11 @@ export component RecoApp inherits Window {
     // camera and calls update_camera_params.
     callback changed-lens-param();
     callback reset-lens();
+    // Constrained-look checkbox. Fires when the user toggles it so Rust
+    // can sync `AppState.use_constrained_look` with the UI property
+    // (Slint's <=> binding updates the property but Rust needs a notify
+    // to act on the new value).
+    callback changed-constrained-look();
     // Export dialog actions.
     callback open-export-dialog();
     callback pick-export-output();
@@ -494,6 +499,7 @@ export component RecoApp inherits Window {
                     CheckBox {
                         text: "Constrained look (clamp to coverage)";
                         checked <=> root.use-constrained-look;
+                        toggled => { root.changed-constrained-look(); }
                     }
 
                     Rectangle { height: 1px; background: #333; }
@@ -651,9 +657,20 @@ export component RecoApp inherits Window {
                             primary: root.lens-selected-camera == "right";
                             clicked => { root.lens-selected-camera = "right"; }
                         }
+                        // "Both" applies the left-side slider values to
+                        // both cameras. Useful for stereo rigs with
+                        // matched lenses where you want to tune them in
+                        // lockstep. Rust implements this by mirroring
+                        // left-* params to right-* on every slider edit
+                        // while "both" is selected.
+                        Button {
+                            text: "Both";
+                            primary: root.lens-selected-camera == "both";
+                            clicked => { root.lens-selected-camera = "both"; }
+                        }
                     }
 
-                    if root.lens-info-available && root.lens-selected-camera == "left": VerticalLayout {
+                    if root.files-loaded && (root.lens-selected-camera == "left" || root.lens-selected-camera == "both"): VerticalLayout {
                         spacing: 4px;
 
                         LabeledSlider {
@@ -722,7 +739,7 @@ export component RecoApp inherits Window {
                         }
                     }
 
-                    if root.lens-info-available && root.lens-selected-camera == "right": VerticalLayout {
+                    if root.files-loaded && root.lens-selected-camera == "right": VerticalLayout {
                         spacing: 4px;
 
                         LabeledSlider {
@@ -795,6 +812,13 @@ export component RecoApp inherits Window {
                         text: "Reset Lens";
                         enabled: root.lens-dirty;
                         clicked => { root.reset-lens(); }
+                    }
+
+                    if root.files-loaded: Text {
+                        text: "Edits the in-memory lens. Save Calibration below to persist; Reset Lens restores the auto-detected profile.";
+                        color: #777;
+                        font-size: 10px;
+                        wrap: word-wrap;
                     }
 
                     if root.files-loaded: Rectangle { height: 1px; background: #333; }


### PR DESCRIPTION
## Summary

Consumer of the `update_camera_params` addition from Batch F (#238). Opens the calibration process up per #196: what was previously a black box (auto-calibrate succeeds or fails, then you live with it) now has direct per-parameter sliders with live preview.

- **Lens fine-tune** panel (below Lens profiles in the Controls panel) with per-camera sliders for fx, fy, cx, cy, k1, k2, k3, k4. Visible whenever a calibration is loaded (auto-calibrate OR manual match.json). Each slider edit calls `StitchRenderer::update_camera_params`; preview updates on the next vsync. Reset Lens restores the baseline captured at load time.
- **Constrained-look toggle** in the Camera section. Default on (current behavior). Off lets pan/zoom roam beyond the stitched region for calibration debug. Turned out `CoverageBoundary::safe_clamp` is exactly the API needed - FRICTION A4 was a false friend, will close in a follow-up FRICTION update.

## Slider ranges (derived from baseline)

- **fx, fy**: baseline +/- 15% (minimum 5-pixel span)
- **cx, cy**: baseline +/- 10% of image dimension
- **k1-k4**: +/-0.3 absolute

Wide enough for meaningful tuning, narrow enough to keep slider granularity useful.

## Test plan

- [ ] Auto-calibrate. Open Controls. Verify Lens fine-tune section appears with Left/Right toggle and 8 sliders populated from the detected profile.
- [ ] Drag fx slider slowly - preview should distort live; no lag or stutter.
- [ ] Toggle Left/Right button - sliders switch to show the other camera's params.
- [ ] Click Reset Lens - all sliders snap back, preview reverts. Button then disables until next edit.
- [ ] Load manual match.json (skip auto-calibrate) - Lens fine-tune section still appears, seeded from the loaded params.
- [ ] Toggle Constrained-look off - yaw/pitch pan freely into black margins. Toggle on - snap back inside coverage.

## Follow-ups

Deferred from this tier (separate issues):
- #239 calibration save format with metadata + archive.
- #240 blend-width auto-detect.
- #241 residuals histogram + per-frame match counts in GUI.

Later:
- Projection mode dropdown (flat / panorama) - needs reco-core `ProjectionMode` enum per #196's "Material" concept.
- FRICTION.md: close A3 (done), correct A4 (false friend), keep A1/A2/A5/A6/A7 open.