### PR TITLE
feat(reco-gui): Tier 3a - error toast stack

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -15,6 +15,7 @@
 
 mod playback;
 mod preview;
+mod toast;
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -31,6 +32,7 @@ use reco_core::wgpu;
 
 use crate::playback::{PlayState, Playback};
 use crate::preview::PreviewBridge;
+use crate::toast::{Severity, ToastManager};
 
 /// wgpu handles captured from Slint's rendering notifier. Populated once
 /// on `RenderingSetup`; used to build `PreviewBridge` when files load.
@@ -167,6 +169,11 @@ struct AppState {
     /// calibration debug where the user wants to see beyond the stitched
     /// region. Bound to the Slint `use-constrained-look` checkbox.
     use_constrained_look: bool,
+    /// Toast notification manager. Events across the app (calibration
+    /// failures, export errors, invalid file picks) push into this,
+    /// the main timer expires aged entries, and both push a refreshed
+    /// model into the Slint `toasts` property.
+    toasts: ToastManager,
 }
 
 /// Runtime AI capability summary.
@@ -257,6 +264,7 @@ impl AppState {
             cal_baseline_left_params: None,
             cal_baseline_right_params: None,
             use_constrained_look: true,
+            toasts: ToastManager::default(),
         }
     }
 
@@ -1094,15 +1102,26 @@ fn main() -> anyhow::Result<()> {
     let app_weak = app.as_weak();
     let state_ref = Rc::clone(&state);
     app.on_save_calibration(move || {
-        let s = state_ref.borrow();
-        if let Err(e) = s.save_calibration() {
-            log::error!("Save calibration: {e}");
-            if let Some(app) = app_weak.upgrade() {
-                app.set_status_text(format!("Save failed: {e}").into());
+        let save_result = state_ref.borrow().save_calibration();
+        match save_result {
+            Err(e) => {
+                log::error!("Save calibration: {e}");
+                let mut s = state_ref.borrow_mut();
+                if let Some(app) = app_weak.upgrade() {
+                    app.set_status_text("Save failed".into());
+                    s.toasts.push(Severity::Error, "Save failed", e);
+                    crate::toast::sync_to_ui(&s.toasts, &app);
+                }
             }
-        } else if let Some(app) = app_weak.upgrade() {
-            app.set_status_text("Calibration saved".into());
-            app.set_cal_dirty(false);
+            Ok(()) => {
+                let mut s = state_ref.borrow_mut();
+                if let Some(app) = app_weak.upgrade() {
+                    app.set_status_text("Calibration saved".into());
+                    app.set_cal_dirty(false);
+                    s.toasts.push(Severity::Info, "Calibration saved", "");
+                    crate::toast::sync_to_ui(&s.toasts, &app);
+                }
+            }
         }
     });
 
@@ -1274,6 +1293,21 @@ fn main() -> anyhow::Result<()> {
             s.clamp_targets();
         }
         s.preview_dirty = true;
+    });
+
+    // ── Toast dismissal ──
+    //
+    // Slint's ToastStack fires `toast-dismissed(id)` when the user
+    // clicks the × on a card. Rust removes the matching entry and
+    // pushes the refreshed list back to Slint.
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_toast_dismissed(move |id| {
+        let mut s = state_ref.borrow_mut();
+        s.toasts.dismiss(id);
+        if let Some(app) = app_weak.upgrade() {
+            crate::toast::sync_to_ui(&s.toasts, &app);
+        }
     });
 
     // ── Export dialog callbacks ──
@@ -1457,6 +1491,12 @@ fn main() -> anyhow::Result<()> {
                                 format!("Export complete: {frames} frames -> {}", path.display(),)
                                     .into(),
                             );
+                            s.toasts.push(
+                                Severity::Info,
+                                "Export complete",
+                                format!("{frames} frames to {}", path.display()),
+                            );
+                            crate::toast::sync_to_ui(&s.toasts, &app);
                         }
                         ExportOutcome::Cancelled => {
                             app.set_export_status_text("".into());
@@ -1464,7 +1504,22 @@ fn main() -> anyhow::Result<()> {
                         }
                         ExportOutcome::Failed(msg) => {
                             app.set_export_status_text("".into());
-                            app.set_status_text(format!("Export failed: {msg}").into());
+                            app.set_status_text("Export failed".into());
+                            // Detect the empty-output sanity-check hit
+                            // (Batch G) so we can give a codec-specific
+                            // nudge instead of the raw ffmpeg error.
+                            let is_empty_output =
+                                msg.contains("encoder produced no video frames");
+                            let (title, body) = if is_empty_output {
+                                (
+                                    "Export produced no video",
+                                    "The selected codec may not be supported on this hardware. Try H.264 or HEVC.".to_string(),
+                                )
+                            } else {
+                                ("Export failed", msg.clone())
+                            };
+                            s.toasts.push(Severity::Error, title, body);
+                            crate::toast::sync_to_ui(&s.toasts, &app);
                         }
                     }
                 }
@@ -1487,6 +1542,16 @@ fn main() -> anyhow::Result<()> {
                 if !status.starts_with("Finalizing") {
                     app.set_export_status_text("Finalizing output file…".into());
                 }
+            }
+
+            // Expire aged toasts. When the list changes, push the new
+            // model into Slint. Skip the work entirely when empty so
+            // a toast-free session incurs ~no overhead.
+            if !s.toasts.is_empty()
+                && s.toasts.expire(Instant::now())
+                && let Some(app) = app_weak.upgrade()
+            {
+                crate::toast::sync_to_ui(&s.toasts, &app);
             }
 
             // Commit a debounced seek once the requested fraction has
@@ -1694,10 +1759,41 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
         Err(e) => {
             log::error!("Init error: {e}");
             if let Some(app) = app_weak.upgrade() {
-                app.set_status_text(format!("Error: {e}").into());
+                // Batch G emits "invalid input path (...): <reason>" for
+                // validation failures. Classify so the toast carries a
+                // reason-specific title; fall back to generic "Init
+                // failed" otherwise.
+                let (title, body) = classify_init_error(&e);
+                app.set_status_text(title.clone().into());
                 app.set_files_loaded(false);
+                s.toasts.push(Severity::Error, title, body);
+                crate::toast::sync_to_ui(&s.toasts, &app);
             }
         }
+    }
+}
+
+/// Inspect an init error string and decide what to show the user.
+///
+/// Batch G's `SourceError::InvalidPath` display format is
+/// `"invalid input path (path): reason"`. We substring-match to pick
+/// a friendlier title; the full stringified error becomes the body.
+fn classify_init_error(err: &str) -> (String, String) {
+    if err.contains("invalid input path") {
+        let title = if err.contains("file not found") {
+            "File not found"
+        } else if err.contains("permission denied") {
+            "Permission denied"
+        } else if err.contains("file is empty") {
+            "Empty file"
+        } else if err.contains("not a regular file") {
+            "Not a video file"
+        } else {
+            "Invalid file"
+        };
+        (title.to_string(), err.to_string())
+    } else {
+        ("Init failed".to_string(), err.to_string())
     }
 }
 
@@ -1797,7 +1893,9 @@ fn handle_calibration_result(
                 Err(e) => {
                     log::error!("Post-calibration init: {e}");
                     if let Some(app) = app_weak.upgrade() {
-                        app.set_status_text(format!("Error: {e}").into());
+                        app.set_status_text("Post-calibration init failed".into());
+                        state.toasts.push(Severity::Error, "Init failed", e.clone());
+                        crate::toast::sync_to_ui(&state.toasts, &app);
                     }
                 }
             }
@@ -1805,7 +1903,11 @@ fn handle_calibration_result(
         Err(e) => {
             log::error!("Auto-calibration failed: {e}");
             if let Some(app) = app_weak.upgrade() {
-                app.set_status_text(format!("Calibration failed: {e}").into());
+                app.set_status_text("Calibration failed".into());
+                state
+                    .toasts
+                    .push(Severity::Error, "Auto-calibration failed", e.clone());
+                crate::toast::sync_to_ui(&state.toasts, &app);
             }
         }
     }

--- a/crates/reco-gui/src/toast.rs
+++ b/crates/reco-gui/src/toast.rs
@@ -1,7 +1,7 @@
 //! Toast notification state for the GUI.
 //!
 //! Maintains the set of currently-visible toast cards and their
-//! expiration timestamps. The main playback timer calls [`tick`] each
+//! expiration timestamps. The main playback timer calls `expire` each
 //! cycle to drop expired entries and push the updated list into Slint.
 //!
 //! Toasts are keyed by a monotonic `id` so the UI can dismiss one by

--- a/crates/reco-gui/src/toast.rs
+++ b/crates/reco-gui/src/toast.rs
@@ -1,0 +1,226 @@
+//! Toast notification state for the GUI.
+//!
+//! Maintains the set of currently-visible toast cards and their
+//! expiration timestamps. The main playback timer calls [`tick`] each
+//! cycle to drop expired entries and push the updated list into Slint.
+//!
+//! Toasts are keyed by a monotonic `id` so the UI can dismiss one by
+//! its handle without the Rust state and Slint model drifting on
+//! insertion order.
+
+use std::time::{Duration, Instant};
+
+use slint::{ModelRc, SharedString, VecModel};
+
+use crate::Toast;
+
+/// Severity categorizes the toast's visual accent and default lifetime.
+///
+/// `Warn` is not consumed yet but is part of the public surface so
+/// future call sites can use it without a signature change.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Severity {
+    Info,
+    Warn,
+    Error,
+}
+
+impl Severity {
+    /// Lowercase string form matching the Slint `toast.severity` field.
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+
+    /// How long a toast of this severity stays visible by default.
+    /// Errors linger the longest so the user can actually read them.
+    fn default_ttl(&self) -> Duration {
+        match self {
+            Self::Info => Duration::from_secs(4),
+            Self::Warn => Duration::from_secs(7),
+            Self::Error => Duration::from_secs(10),
+        }
+    }
+}
+
+/// One live toast with its expiration timestamp.
+#[derive(Debug, Clone)]
+struct Entry {
+    id: i32,
+    severity: Severity,
+    title: String,
+    body: String,
+    expires_at: Instant,
+}
+
+/// Toast stack state. Owned by `AppState`.
+pub struct ToastManager {
+    entries: Vec<Entry>,
+    next_id: i32,
+    /// Hard cap on visible toasts. Oldest gets evicted when we exceed.
+    max_visible: usize,
+}
+
+impl Default for ToastManager {
+    fn default() -> Self {
+        Self {
+            entries: Vec::new(),
+            next_id: 1,
+            max_visible: 4,
+        }
+    }
+}
+
+impl ToastManager {
+    /// Push a toast with the default lifetime for its severity.
+    /// Returns the assigned id so the caller can dismiss programmatically.
+    pub fn push(
+        &mut self,
+        severity: Severity,
+        title: impl Into<String>,
+        body: impl Into<String>,
+    ) -> i32 {
+        self.push_with_ttl(severity, title, body, severity.default_ttl())
+    }
+
+    /// Push a toast with an explicit lifetime.
+    pub fn push_with_ttl(
+        &mut self,
+        severity: Severity,
+        title: impl Into<String>,
+        body: impl Into<String>,
+        ttl: Duration,
+    ) -> i32 {
+        let id = self.next_id;
+        self.next_id = self.next_id.wrapping_add(1);
+        if self.next_id == 0 {
+            // 0 would collide with "uninitialized" sentinels in a
+            // future redesign; skip it defensively.
+            self.next_id = 1;
+        }
+
+        let entry = Entry {
+            id,
+            severity,
+            title: title.into(),
+            body: body.into(),
+            expires_at: Instant::now() + ttl,
+        };
+        self.entries.push(entry);
+
+        // Evict oldest if we exceed the visible cap.
+        if self.entries.len() > self.max_visible {
+            let overflow = self.entries.len() - self.max_visible;
+            self.entries.drain(..overflow);
+        }
+        id
+    }
+
+    /// Remove a toast by id (no-op if it isn't in the list).
+    pub fn dismiss(&mut self, id: i32) {
+        self.entries.retain(|e| e.id != id);
+    }
+
+    /// Drop any entries past their expiration. Returns `true` if the
+    /// list changed, so the caller knows whether to push the new model
+    /// back into Slint.
+    pub fn expire(&mut self, now: Instant) -> bool {
+        let before = self.entries.len();
+        self.entries.retain(|e| e.expires_at > now);
+        self.entries.len() != before
+    }
+
+    /// Build a fresh Slint model reflecting current state. Cheap - we
+    /// only call this when the list actually changed (see `expire` and
+    /// the push/dismiss callers).
+    pub fn to_model(&self) -> ModelRc<Toast> {
+        let toasts: Vec<Toast> = self
+            .entries
+            .iter()
+            .map(|e| Toast {
+                id: e.id,
+                severity: SharedString::from(e.severity.as_str()),
+                title: SharedString::from(e.title.as_str()),
+                body: SharedString::from(e.body.as_str()),
+            })
+            .collect();
+        ModelRc::new(VecModel::from(toasts))
+    }
+
+    /// Whether there are any live toasts. Useful to skip the periodic
+    /// expiration check when the stack is empty.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// For test + debug: number of currently-live toasts.
+    #[cfg(test)]
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+/// Push the current toast list into the Slint model property. Called
+/// after any operation that changed the list.
+pub fn sync_to_ui(manager: &ToastManager, app: &crate::RecoApp) {
+    app.set_toasts(manager.to_model());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slint::Model;
+
+    #[test]
+    fn push_increments_id_monotonically() {
+        let mut m = ToastManager::default();
+        let a = m.push(Severity::Info, "A", "");
+        let b = m.push(Severity::Info, "B", "");
+        let c = m.push(Severity::Info, "C", "");
+        assert_eq!((a, b, c), (1, 2, 3));
+        assert_eq!(m.len(), 3);
+    }
+
+    #[test]
+    fn dismiss_removes_by_id() {
+        let mut m = ToastManager::default();
+        let a = m.push(Severity::Info, "A", "");
+        let _b = m.push(Severity::Info, "B", "");
+        m.dismiss(a);
+        assert_eq!(m.len(), 1);
+        // Dismissing something not in the list is fine.
+        m.dismiss(999);
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn expire_drops_past_ttl() {
+        let mut m = ToastManager::default();
+        let _a = m.push_with_ttl(Severity::Info, "quick", "", Duration::from_millis(1));
+        let _b = m.push_with_ttl(Severity::Info, "slow", "", Duration::from_secs(60));
+        std::thread::sleep(Duration::from_millis(20));
+        let changed = m.expire(Instant::now());
+        assert!(changed);
+        assert_eq!(m.len(), 1);
+    }
+
+    #[test]
+    fn cap_evicts_oldest() {
+        let mut m = ToastManager {
+            max_visible: 2,
+            ..Default::default()
+        };
+        m.push(Severity::Info, "1", "");
+        m.push(Severity::Info, "2", "");
+        m.push(Severity::Info, "3", "");
+        assert_eq!(m.len(), 2);
+        let model = m.to_model();
+        assert_eq!(model.row_count(), 2);
+        assert_eq!(model.row_data(0).unwrap().title.as_str(), "2");
+        assert_eq!(model.row_data(1).unwrap().title.as_str(), "3");
+    }
+}

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -79,6 +79,113 @@ component LabeledSlider inherits VerticalLayout {
     }
 }
 
+// Toast notification payload. Kept flat (no nested structs) so the
+// Rust side can push via the generated `VecModel<Toast>` without
+// wrapping ceremony. `id` is an opaque Rust-side counter used as the
+// dismissal handle; UI code doesn't interpret it.
+export struct Toast {
+    id: int,
+    severity: string, // "info" | "warn" | "error"
+    title: string,
+    body: string,
+}
+
+/// A single dismissible toast card. Stacked vertically by `ToastStack`.
+///
+/// Severity drives the left-border accent color:
+/// - info: blue-grey
+/// - warn: amber
+/// - error: red
+/// All three share the same dark card background to match the app chrome.
+component ToastCard inherits Rectangle {
+    in property <Toast> toast;
+    callback dismissed(int);
+
+    height: content.preferred-height + 16px;
+    width: 360px;
+    border-radius: 6px;
+    background: #1f1f1f;
+    border-width: 1px;
+    border-color: #333;
+    // Severity accent via left-edge bar (drawn with a clipped child
+    // rectangle below). Also shifts the main border color subtly.
+    drop-shadow-blur: 6px;
+    drop-shadow-color: #000000aa;
+
+    Rectangle {
+        x: 0; y: 0;
+        width: 4px;
+        height: parent.height;
+        background: root.toast.severity == "error" ? #e06060
+                  : root.toast.severity == "warn"  ? #e0c060
+                  : #6080c0;
+    }
+
+    content := HorizontalLayout {
+        padding-left: 14px;
+        padding-right: 10px;
+        padding-top: 8px;
+        padding-bottom: 8px;
+        spacing: 8px;
+
+        VerticalLayout {
+            horizontal-stretch: 1;
+            spacing: 2px;
+            Text {
+                text: root.toast.title;
+                color: #fff;
+                font-size: 12px;
+                font-weight: 600;
+                wrap: word-wrap;
+            }
+            if root.toast.body != "": Text {
+                text: root.toast.body;
+                color: #bbb;
+                font-size: 11px;
+                wrap: word-wrap;
+            }
+        }
+
+        // Dismiss button. Kept narrow so the card body gets the space.
+        Rectangle {
+            width: 20px;
+            height: 20px;
+            border-radius: 10px;
+            background: dismiss-touch.has-hover ? #3a3a3a : transparent;
+            Text {
+                text: "×";
+                color: #888;
+                font-size: 16px;
+                horizontal-alignment: center;
+                vertical-alignment: center;
+            }
+            dismiss-touch := TouchArea {
+                clicked => { root.dismissed(root.toast.id); }
+            }
+        }
+    }
+}
+
+/// Bottom-right stack of toast cards. Spawns a `ToastCard` per entry
+/// in `toasts` and forwards dismissal back to the consumer via the
+/// `dismissed(id)` callback.
+component ToastStack inherits Rectangle {
+    in property <[Toast]> toasts;
+    callback dismissed(int);
+
+    VerticalLayout {
+        x: parent.width - self.preferred-width - 16px;
+        y: parent.height - self.preferred-height - 16px;
+        spacing: 8px;
+        alignment: end;
+
+        for toast in root.toasts: ToastCard {
+            toast: toast;
+            dismissed(id) => { root.dismissed(id); }
+        }
+    }
+}
+
 export component RecoApp inherits Window {
     title: "Reco Video Stitcher";
     preferred-width: 1280px;
@@ -176,6 +283,12 @@ export component RecoApp inherits Window {
     // to inspect what is happening beyond the stitched region, which is
     // useful for calibration debug.
     in-out property <bool> use-constrained-look: true;
+
+    // Toast notification list. Rust pushes via `set_toasts(model)` and
+    // drives auto-dismissal on its own timer; Slint renders whatever
+    // is currently in the list at the bottom-right.
+    in-out property <[Toast]> toasts: [];
+    callback toast-dismissed(int);
 
     // Per-camera lens intrinsics (populated by Rust after auto-calibrate
     // from `CalibrationResult.left_lens_profile` / `right_lens_profile`).
@@ -1034,6 +1147,16 @@ export component RecoApp inherits Window {
             }
         }
         }  // close VerticalBox
+
+        // ── Toast stack (floating overlay, bottom-right) ──
+        // Sibling of the main layout so it renders on top of everything
+        // including the preview and the transport bar. Does not block
+        // input outside the cards because ToastStack itself has no
+        // TouchArea - only the dismiss button inside each card.
+        ToastStack {
+            toasts: root.toasts;
+            dismissed(id) => { root.toast-dismissed(id); }
+        }
 
         // ── Export dialog (modal overlay) ──
         //


### PR DESCRIPTION
## Summary

First of three Tier 3 PRs. Adds a floating toast notification stack so failures stop being hidden in the status bar (easy to miss, gets overwritten by the next status line).

Renders at bottom-right of the window. Severity drives left-edge accent color (info blue, warn amber, error red). Each card has a × dismiss button. Aged toasts expire automatically on the playback tick.

## What's included

- `toast::ToastManager` (new module) with monotonic ids, severity-aware TTLs, hard cap at 4 visible, tick-based expiration.
- Slint `Toast` struct + `ToastCard` + `ToastStack` components, rendered as an overlay sibling of the main layout.
- Four unit tests: push monotonicity, dismiss, expiration, visible-cap eviction.

## Wired event sites

- **Init errors**: Batch G `SourceError::InvalidPath` → reason-specific titles ("File not found", "Permission denied", "Empty file", "Not a video file").
- **Post-calibration init error**: "Init failed" toast.
- **Auto-calibration failure**: "Auto-calibration failed" toast.
- **Export completion**: info toast with path + frame count.
- **Export failure**: error toast. If Batch G's `EmptyOutput` fires, the toast nudges toward H.264/HEVC instead of the raw ffmpeg diagnostic.
- **Save calibration**: info on success, error on fail.

## Test plan

- [x] 4 unit tests for `ToastManager` pass
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, release build green
- [ ] Manual: pick a deleted/missing file → "File not found" toast with the path shown
- [ ] Manual: AV1 export on non-Ada GPU → "Export produced no video" toast with codec suggestion
- [ ] Manual: successful export → info toast auto-dismisses after ~4s
- [ ] Manual: click × on a toast → immediate dismiss

## Follow-ups (Tier 3b, 3c)

- **Tier 3b**: recent files (backed by `reco-io::settings::RecentFiles`) + preferences dialog (backed by `reco-io::settings`). Depends on PR #255.
- **Tier 3c**: keyboard shortcut help modal + export dialog polish (time range, seed from preview).