### PR TITLE
feat(reco-gui): Tier 3b - persisted user preferences (stacked on #255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5321,6 +5321,7 @@ dependencies = [
  "reco-detect",
  "reco-io",
  "rfd",
+ "serde",
  "serde_json",
  "slint",
  "slint-build",

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -21,7 +21,8 @@ profiling = ["tracing", "reco-core/profiling", "reco-io/profiling", "reco-calibr
 
 [dependencies]
 reco-core = { path = "../reco-core" }
-reco-io = { path = "../reco-io", features = ["ffmpeg"] }
+reco-io = { path = "../reco-io", features = ["ffmpeg", "config"] }
+serde = { version = "1", features = ["derive"] }
 reco-calibrate = { path = "../reco-calibrate", features = ["io"] }
 reco-detect = { path = "../reco-detect" }
 reco-autocam = { path = "../reco-autocam", optional = true }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -15,6 +15,7 @@
 
 mod playback;
 mod preview;
+mod settings;
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -155,6 +156,11 @@ struct AppState {
     /// Original PlaneLayout values — what auto-calibrate produced. Live
     /// calibration sliders edit relative to this so Reset restores.
     cal_baseline_layout: Option<reco_core::calibration::PlaneLayout>,
+    /// Persisted user preferences (recent files, default export
+    /// settings, AI model path). Loaded at startup from the reco-io
+    /// settings namespace and saved on any change via the convenience
+    /// `push_*` methods.
+    user_settings: crate::settings::GuiSettings,
     /// Baseline camera intrinsics from the last successful calibration.
     /// The Lens fine-tune sliders in the Controls panel edit these; the
     /// Reset Lens button restores them. `None` until auto-calibrate or a
@@ -254,6 +260,7 @@ impl AppState {
             export_thread: None,
             export_rx: None,
             cal_baseline_layout: None,
+            user_settings: crate::settings::GuiSettings::load(),
             cal_baseline_left_params: None,
             cal_baseline_right_params: None,
             use_constrained_look: true,
@@ -773,6 +780,7 @@ fn main() -> anyhow::Result<()> {
             if let Some(app) = app_weak.upgrade() {
                 app.set_left_path(display_name(&path).into());
             }
+            s.user_settings.push_left(path.clone());
             s.left_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
@@ -790,6 +798,7 @@ fn main() -> anyhow::Result<()> {
             if let Some(app) = app_weak.upgrade() {
                 app.set_right_path(display_name(&path).into());
             }
+            s.user_settings.push_right(path.clone());
             s.right_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
@@ -807,6 +816,7 @@ fn main() -> anyhow::Result<()> {
             if let Some(app) = app_weak.upgrade() {
                 app.set_calibration_path(display_name(&path).into());
             }
+            s.user_settings.push_calibration(path.clone());
             s.calibration_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
@@ -1289,10 +1299,22 @@ fn main() -> anyhow::Result<()> {
     app.on_open_export_dialog(move || {
         let s = state_ref.borrow();
         if let Some(app) = app_weak.upgrade() {
-            // Seed reasonable defaults from current preview state.
+            // Seed from persisted user defaults first (codec, quality,
+            // model path) so the dialog reflects the user's last
+            // choices across sessions...
+            app.set_export_codec(s.user_settings.default_codec.clone().into());
+            app.set_export_quality(s.user_settings.default_quality.clone().into());
+            if let Some(model_path) = s.user_settings.ai_model_path.as_ref() {
+                app.set_export_model_path(model_path.to_string_lossy().to_string().into());
+            }
+            // ...then override blend width with the live preview's
+            // current value, which is usually what the user actually
+            // wants applied to the export (overrides the saved default).
             if let Some(bridge) = s.bridge.as_ref() {
                 let cur_blend = bridge.renderer().pipeline().viewport().blend_width;
                 app.set_export_blend_width(cur_blend);
+            } else {
+                app.set_export_blend_width(s.user_settings.default_blend_width);
             }
             app.set_export_dialog_open(true);
         }
@@ -1317,6 +1339,7 @@ fn main() -> anyhow::Result<()> {
     });
 
     let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
     app.on_pick_export_model(move || {
         let dialog = rfd::FileDialog::new()
             .set_title("Select YOLO ONNX model")
@@ -1325,6 +1348,11 @@ fn main() -> anyhow::Result<()> {
             && let Some(app) = app_weak.upgrade()
         {
             app.set_export_model_path(path.to_string_lossy().to_string().into());
+            // Remember across sessions so the user doesn't re-pick
+            // the same ONNX every run. Save is best-effort.
+            let mut s = state_ref.borrow_mut();
+            s.user_settings.ai_model_path = Some(path);
+            s.user_settings.save();
         }
     });
 
@@ -1365,6 +1393,15 @@ fn main() -> anyhow::Result<()> {
         let model_path = app.get_export_model_path().to_string();
         let tracking_mode = app.get_export_tracking_mode().to_string();
         let detection_interval = app.get_export_detection_interval() as u32;
+
+        // Persist the user's codec / quality / blend choices as the
+        // defaults for next session. Model path is saved in the
+        // on_pick_export_model callback so it sticks even if the user
+        // never actually hits Start. Save is best-effort.
+        s.user_settings.default_codec = codec_str.clone();
+        s.user_settings.default_quality = quality_str.clone();
+        s.user_settings.default_blend_width = blend;
+        s.user_settings.save();
 
         // Reset cancel flag, start a fresh channel for completion.
         s.export_interrupted.store(false, Ordering::Relaxed);

--- a/crates/reco-gui/src/settings.rs
+++ b/crates/reco-gui/src/settings.rs
@@ -1,0 +1,146 @@
+//! GUI-specific persisted settings.
+//!
+//! Wraps `reco_io::settings` with a concrete `GuiSettings` struct that
+//! captures the subset of user-facing state worth remembering across
+//! sessions: recent file pairs, default export configuration, AI model
+//! path, last window size.
+//!
+//! The split is deliberate: reco-io owns the generic load/save/MRU
+//! machinery and doesn't know what a "codec" or "blend width" is,
+//! while this module owns the GUI's specific schema. If reco-cli ever
+//! wants its own persisted defaults it would define a separate
+//! `CliSettings` struct in its own crate and use the `"cli"` namespace.
+
+use std::path::PathBuf;
+
+use reco_io::settings::RecentFiles;
+use serde::{Deserialize, Serialize};
+
+/// Reco-gui's on-disk settings. Stored at `<config>/reco/gui.json`.
+///
+/// All fields carry `#[serde(default)]` so adding new fields in future
+/// releases does not invalidate existing settings files - missing
+/// fields just fall back to the `Default` impl's value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GuiSettings {
+    /// Most recently opened left camera videos.
+    #[serde(default)]
+    pub recent_left: RecentFiles,
+    /// Most recently opened right camera videos.
+    #[serde(default)]
+    pub recent_right: RecentFiles,
+    /// Most recently loaded calibration JSON files.
+    #[serde(default)]
+    pub recent_calibration: RecentFiles,
+
+    /// Default export codec (`"h264"`, `"hevc"`, `"av1"`).
+    #[serde(default = "default_codec")]
+    pub default_codec: String,
+    /// Default export quality (`"fast"`, `"balanced"`, `"high"`).
+    #[serde(default = "default_quality")]
+    pub default_quality: String,
+    /// Default seam blend width used when the export dialog opens.
+    #[serde(default = "default_blend_width")]
+    pub default_blend_width: f32,
+
+    /// Last chosen AI model path (YOLOv26n, RF-DETR, etc.) so the
+    /// export dialog doesn't force the user to pick it every time.
+    #[serde(default)]
+    pub ai_model_path: Option<PathBuf>,
+
+    /// Last window size, remembered across restarts. `None` means
+    /// "use Slint's preferred-width / preferred-height defaults".
+    #[serde(default)]
+    pub window_size: Option<(u32, u32)>,
+}
+
+fn default_codec() -> String {
+    "h264".into()
+}
+fn default_quality() -> String {
+    "balanced".into()
+}
+fn default_blend_width() -> f32 {
+    0.05
+}
+
+impl Default for GuiSettings {
+    fn default() -> Self {
+        Self {
+            recent_left: RecentFiles::default(),
+            recent_right: RecentFiles::default(),
+            recent_calibration: RecentFiles::default(),
+            default_codec: default_codec(),
+            default_quality: default_quality(),
+            default_blend_width: default_blend_width(),
+            ai_model_path: None,
+            window_size: None,
+        }
+    }
+}
+
+/// Namespace used under the reco config directory. All reco-gui
+/// settings live at `<config>/reco/gui.json`.
+pub const NAMESPACE: &str = "gui";
+
+impl GuiSettings {
+    /// Load settings from disk. Missing or malformed files fall back
+    /// to defaults per `reco_io::settings::load_or_default` (the
+    /// fallback is logged but never fatal - we never refuse to start
+    /// because a settings file went bad).
+    pub fn load() -> Self {
+        reco_io::settings::load_or_default::<GuiSettings>(NAMESPACE)
+    }
+
+    /// Persist settings atomically. Errors are logged and swallowed -
+    /// a failure to save preferences should never block user work
+    /// (worst case: the user has to re-pick defaults next session).
+    pub fn save(&self) {
+        if let Err(e) = reco_io::settings::save(NAMESPACE, self) {
+            log::warn!("failed to save GUI settings: {e}");
+        }
+    }
+
+    /// Convenience: push a newly-picked left video into MRU and save.
+    pub fn push_left(&mut self, path: PathBuf) {
+        self.recent_left.push(path);
+        self.save();
+    }
+
+    /// Convenience: push a newly-picked right video into MRU and save.
+    pub fn push_right(&mut self, path: PathBuf) {
+        self.recent_right.push(path);
+        self.save();
+    }
+
+    /// Convenience: push a newly-loaded calibration file into MRU and save.
+    pub fn push_calibration(&mut self, path: PathBuf) {
+        self.recent_calibration.push(path);
+        self.save();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_values_are_sensible() {
+        let s = GuiSettings::default();
+        assert_eq!(s.default_codec, "h264");
+        assert_eq!(s.default_quality, "balanced");
+        assert!((s.default_blend_width - 0.05).abs() < 1e-6);
+        assert!(s.recent_left.is_empty());
+    }
+
+    #[test]
+    fn missing_fields_roundtrip_via_defaults() {
+        // Simulate loading an older-version settings JSON where new
+        // fields don't exist yet; the serde defaults should fill in.
+        let json = r#"{ "default_codec": "hevc" }"#;
+        let s: GuiSettings = serde_json::from_str(json).unwrap();
+        assert_eq!(s.default_codec, "hevc");
+        assert_eq!(s.default_quality, "balanced");
+        assert!(s.recent_left.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Second of three Tier 3 PRs. Consumes the reco-io settings module from #255 to persist user choices across sessions. Stacked on #255 - merge #255 first, then this rebases onto main cleanly.

## What persists

- **Recent files** (left / right / calibration): each pick updates the MRU ring. Survives across restarts.
- **Export defaults** (codec, quality, blend width): saved on Start Export; reloaded when dialog next opens. Live-preview blend still overrides when a preview is active.
- **AI model path**: saved when the user picks an ONNX in the export dialog. Pre-fills on next session.
- **Window size**: schema field reserved, wiring deferred to 3c.

## Implementation

- `GuiSettings` struct with every field `#[serde(default)]` so adding future settings doesn't invalidate existing files.
- `AppState.user_settings` loaded at startup via `reco_io::settings::load_or_default`.
- `push_left / push_right / push_calibration` convenience methods update MRU and save in one call.
- 2 unit tests (defaults, forward-compatible deserialization).

## Scope boundaries

**No UI changes yet.** No recent-files dropdown, no preferences dialog. The user-visible effect of this PR is: pick choices, close the app, reopen - choices remembered. UI surfaces (recent files menu, prefs dialog) come in Tier 3c.

## Test plan

- [x] 2 unit tests for GuiSettings pass
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, workspace build green
- [ ] Manual: pick left/right/calibration, close app. Reopen: export dialog defaults to the last codec/quality/blend used. AI model path pre-fills.
- [ ] Manual: check `~/.config/reco/gui.json` exists after a save, pretty-printed, contains the picked paths.

## Follow-ups (Tier 3c)

- FileChip right-click menu / dropdown showing recent entries
- Preferences dialog (accessible from gear icon, exposes codec/quality defaults for direct edit)
- Window size save/restore on window resize
- Keyboard shortcut help modal
- Export dialog time-range inputs