### PR TITLE
feat(reco-gui): Tier 3c - Recent Files + Shortcuts modals (stacked on #257)

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -672,6 +672,21 @@ fn display_name(path: &std::path::Path) -> String {
         .unwrap_or_else(|| path.display().to_string())
 }
 
+/// Push the current MRU lists into the Slint properties that back the
+/// Recent-files dialog. Called at startup and after every file pick.
+fn sync_recent_paths(settings: &settings::GuiSettings, app: &RecoApp) {
+    fn to_model(paths: &[std::path::PathBuf]) -> slint::ModelRc<slint::SharedString> {
+        let v: Vec<slint::SharedString> = paths
+            .iter()
+            .map(|p| slint::SharedString::from(p.to_string_lossy().as_ref()))
+            .collect();
+        slint::ModelRc::new(slint::VecModel::from(v))
+    }
+    app.set_recent_left_paths(to_model(settings.recent_left.entries()));
+    app.set_recent_right_paths(to_model(settings.recent_right.entries()));
+    app.set_recent_calibration_paths(to_model(settings.recent_calibration.entries()));
+}
+
 fn main() -> anyhow::Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
 
@@ -696,6 +711,11 @@ fn main() -> anyhow::Result<()> {
     log::info!("{ai_status}");
     app.set_ai_status(ai_status.into());
     app.set_ai_gpu_available(ai_gpu_ok);
+
+    // Seed the Recent-files dialog with the persisted MRU lists. If
+    // the user never loaded anything before, these are empty and the
+    // Recent button in the file bar stays disabled.
+    sync_recent_paths(&state.borrow().user_settings, &app);
 
     // Capture Slint's wgpu device and queue on RenderingSetup. These
     // are reused by PreviewBridge so reco-core's stitch output lands
@@ -781,6 +801,9 @@ fn main() -> anyhow::Result<()> {
                 app.set_left_path(display_name(&path).into());
             }
             s.user_settings.push_left(path.clone());
+            if let Some(app) = app_weak.upgrade() {
+                sync_recent_paths(&s.user_settings, &app);
+            }
             s.left_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
@@ -799,6 +822,9 @@ fn main() -> anyhow::Result<()> {
                 app.set_right_path(display_name(&path).into());
             }
             s.user_settings.push_right(path.clone());
+            if let Some(app) = app_weak.upgrade() {
+                sync_recent_paths(&s.user_settings, &app);
+            }
             s.right_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
@@ -817,9 +843,82 @@ fn main() -> anyhow::Result<()> {
                 app.set_calibration_path(display_name(&path).into());
             }
             s.user_settings.push_calibration(path.clone());
+            if let Some(app) = app_weak.upgrade() {
+                sync_recent_paths(&s.user_settings, &app);
+            }
             s.calibration_path = Some(path);
             drop(s);
             try_init_and_update(&state_ref, &app_weak);
+        }
+    });
+
+    // ── Recent-files dialog callbacks ──
+    //
+    // Clicking an entry in the dialog is functionally equivalent to
+    // picking that file via the native dialog: update the MRU (so it
+    // moves to front), push to the Slint label property, and try to
+    // initialize if all three slots are now filled.
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_load_recent_left(move |entry| {
+        let path = PathBuf::from(entry.as_str());
+        let mut s = state_ref.borrow_mut();
+        if let Some(app) = app_weak.upgrade() {
+            app.set_left_path(display_name(&path).into());
+        }
+        s.user_settings.push_left(path.clone());
+        if let Some(app) = app_weak.upgrade() {
+            sync_recent_paths(&s.user_settings, &app);
+        }
+        s.left_path = Some(path);
+        drop(s);
+        try_init_and_update(&state_ref, &app_weak);
+    });
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_load_recent_right(move |entry| {
+        let path = PathBuf::from(entry.as_str());
+        let mut s = state_ref.borrow_mut();
+        if let Some(app) = app_weak.upgrade() {
+            app.set_right_path(display_name(&path).into());
+        }
+        s.user_settings.push_right(path.clone());
+        if let Some(app) = app_weak.upgrade() {
+            sync_recent_paths(&s.user_settings, &app);
+        }
+        s.right_path = Some(path);
+        drop(s);
+        try_init_and_update(&state_ref, &app_weak);
+    });
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_load_recent_calibration(move |entry| {
+        let path = PathBuf::from(entry.as_str());
+        let mut s = state_ref.borrow_mut();
+        if let Some(app) = app_weak.upgrade() {
+            app.set_calibration_path(display_name(&path).into());
+        }
+        s.user_settings.push_calibration(path.clone());
+        if let Some(app) = app_weak.upgrade() {
+            sync_recent_paths(&s.user_settings, &app);
+        }
+        s.calibration_path = Some(path);
+        drop(s);
+        try_init_and_update(&state_ref, &app_weak);
+    });
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_clear_recent_files(move || {
+        let mut s = state_ref.borrow_mut();
+        s.user_settings.recent_left.clear();
+        s.user_settings.recent_right.clear();
+        s.user_settings.recent_calibration.clear();
+        s.user_settings.save();
+        if let Some(app) = app_weak.upgrade() {
+            sync_recent_paths(&s.user_settings, &app);
         }
     });
 

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -177,6 +177,19 @@ export component RecoApp inherits Window {
     // useful for calibration debug.
     in-out property <bool> use-constrained-look: true;
 
+    // Recent-files dialog state. Rust pushes the three MRU lists here
+    // on startup and after every pick; the dialog reads them when the
+    // user opens it from the Recent button in the file bar.
+    in-out property <bool> recent-dialog-open: false;
+    in-out property <[string]> recent-left-paths: [];
+    in-out property <[string]> recent-right-paths: [];
+    in-out property <[string]> recent-calibration-paths: [];
+
+    // Keyboard shortcut help modal. The body is rendered inside the
+    // modal; the Controls panel also shows an abbreviated copy so
+    // users who never open the modal still see the hints.
+    in-out property <bool> shortcuts-dialog-open: false;
+
     // Per-camera lens intrinsics (populated by Rust after auto-calibrate
     // from `CalibrationResult.left_lens_profile` / `right_lens_profile`).
     // The Lens tab binds sliders to these properties; changes flow back
@@ -250,6 +263,12 @@ export component RecoApp inherits Window {
     // (Slint's <=> binding updates the property but Rust needs a notify
     // to act on the new value).
     callback changed-constrained-look();
+    // Recent-files modal: load a specific path into one of the three
+    // file slots. Same effect as picking it from the native dialog.
+    callback load-recent-left(string);
+    callback load-recent-right(string);
+    callback load-recent-calibration(string);
+    callback clear-recent-files();
     // Export dialog actions.
     callback open-export-dialog();
     callback pick-export-output();
@@ -367,6 +386,23 @@ export component RecoApp inherits Window {
 
                 // Right-align spacer
                 Rectangle { horizontal-stretch: 1; }
+
+                // Recent button. Only interactive if at least one MRU
+                // list has entries - otherwise there's nothing to show.
+                Button {
+                    text: "Recent…";
+                    enabled: root.recent-left-paths.length > 0
+                           || root.recent-right-paths.length > 0
+                           || root.recent-calibration-paths.length > 0;
+                    clicked => { root.recent-dialog-open = true; }
+                }
+
+                // Keyboard shortcut help. "?" is small and recognizable
+                // as help in dozens of apps; shorter than "Help".
+                Button {
+                    text: "?";
+                    clicked => { root.shortcuts-dialog-open = true; }
+                }
 
                 Button {
                     text: "Export…";
@@ -1034,6 +1070,261 @@ export component RecoApp inherits Window {
             }
         }
         }  // close VerticalBox
+
+        // ── Recent files dialog (modal) ──
+        // Three columns (Left / Right / Calibration). Each entry is a
+        // clickable row; click loads that path into the corresponding
+        // file slot. Rendered as a sibling of the main layout so it
+        // overlays everything.
+        if root.recent-dialog-open: Rectangle {
+            background: #000000aa;
+            TouchArea {
+                clicked => { root.recent-dialog-open = false; }
+            }
+
+            Rectangle {
+                width: 720px;
+                height: 460px;
+                background: #222;
+                border-radius: 12px;
+                border-width: 1px;
+                border-color: #444;
+                // Block click-through so clicks inside the panel do
+                // not close the dialog.
+                TouchArea {}
+
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 12px;
+
+                    HorizontalLayout {
+                        alignment: space-between;
+                        Text {
+                            text: "Recent files";
+                            color: #fff;
+                            font-size: 16px;
+                            font-weight: 600;
+                        }
+                        Button {
+                            text: "Clear all";
+                            clicked => {
+                                root.clear-recent-files();
+                                root.recent-dialog-open = false;
+                            }
+                        }
+                    }
+
+                    HorizontalLayout {
+                        spacing: 10px;
+                        padding: 0;
+                        vertical-stretch: 1;
+
+                        // Three column wrappers share the same structure
+                        // so the styling stays consistent.
+                        Rectangle {
+                            border-radius: 6px;
+                            background: #1a1a1a;
+                            horizontal-stretch: 1;
+                            VerticalLayout {
+                                padding: 10px;
+                                spacing: 4px;
+                                Text {
+                                    text: "Left videos";
+                                    color: #aaa;
+                                    font-size: 12px;
+                                    font-weight: 600;
+                                }
+                                ScrollView {
+                                    VerticalLayout {
+                                        spacing: 2px;
+                                        for entry in root.recent-left-paths: Rectangle {
+                                            height: 28px;
+                                            border-radius: 4px;
+                                            background: row-l.has-hover ? #2d2d2d : transparent;
+                                            Text {
+                                                text: entry;
+                                                color: #ccc;
+                                                font-size: 11px;
+                                                vertical-alignment: center;
+                                                overflow: elide;
+                                                x: 6px;
+                                                width: parent.width - 12px;
+                                            }
+                                            row-l := TouchArea {
+                                                clicked => {
+                                                    root.load-recent-left(entry);
+                                                    root.recent-dialog-open = false;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            border-radius: 6px;
+                            background: #1a1a1a;
+                            horizontal-stretch: 1;
+                            VerticalLayout {
+                                padding: 10px;
+                                spacing: 4px;
+                                Text {
+                                    text: "Right videos";
+                                    color: #aaa;
+                                    font-size: 12px;
+                                    font-weight: 600;
+                                }
+                                ScrollView {
+                                    VerticalLayout {
+                                        spacing: 2px;
+                                        for entry in root.recent-right-paths: Rectangle {
+                                            height: 28px;
+                                            border-radius: 4px;
+                                            background: row-r.has-hover ? #2d2d2d : transparent;
+                                            Text {
+                                                text: entry;
+                                                color: #ccc;
+                                                font-size: 11px;
+                                                vertical-alignment: center;
+                                                overflow: elide;
+                                                x: 6px;
+                                                width: parent.width - 12px;
+                                            }
+                                            row-r := TouchArea {
+                                                clicked => {
+                                                    root.load-recent-right(entry);
+                                                    root.recent-dialog-open = false;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        Rectangle {
+                            border-radius: 6px;
+                            background: #1a1a1a;
+                            horizontal-stretch: 1;
+                            VerticalLayout {
+                                padding: 10px;
+                                spacing: 4px;
+                                Text {
+                                    text: "Calibrations";
+                                    color: #aaa;
+                                    font-size: 12px;
+                                    font-weight: 600;
+                                }
+                                ScrollView {
+                                    VerticalLayout {
+                                        spacing: 2px;
+                                        for entry in root.recent-calibration-paths: Rectangle {
+                                            height: 28px;
+                                            border-radius: 4px;
+                                            background: row-c.has-hover ? #2d2d2d : transparent;
+                                            Text {
+                                                text: entry;
+                                                color: #ccc;
+                                                font-size: 11px;
+                                                vertical-alignment: center;
+                                                overflow: elide;
+                                                x: 6px;
+                                                width: parent.width - 12px;
+                                            }
+                                            row-c := TouchArea {
+                                                clicked => {
+                                                    root.load-recent-calibration(entry);
+                                                    root.recent-dialog-open = false;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    HorizontalLayout {
+                        alignment: end;
+                        Button {
+                            text: "Close";
+                            clicked => { root.recent-dialog-open = false; }
+                        }
+                    }
+                }
+            }
+        }
+
+        // ── Keyboard shortcuts dialog (modal) ──
+        if root.shortcuts-dialog-open: Rectangle {
+            background: #000000aa;
+            TouchArea {
+                clicked => { root.shortcuts-dialog-open = false; }
+            }
+
+            Rectangle {
+                width: 420px;
+                height: 360px;
+                background: #222;
+                border-radius: 12px;
+                border-width: 1px;
+                border-color: #444;
+                TouchArea {}
+
+                VerticalLayout {
+                    padding: 20px;
+                    spacing: 8px;
+
+                    Text {
+                        text: "Keyboard shortcuts";
+                        color: #fff;
+                        font-size: 16px;
+                        font-weight: 600;
+                    }
+
+                    Rectangle { height: 1px; background: #333; }
+
+                    // Explicit two-column rows for alignment: the key
+                    // column is fixed width, the description fills.
+                    for row in [
+                        { k: "Space", v: "Play / pause" },
+                        { k: "Arrows", v: "Pan camera (hold) or step 1 frame (with playback paused)" },
+                        { k: "+  /  -", v: "Zoom in / out" },
+                        { k: "Scroll", v: "Zoom in / out" },
+                        { k: "Drag", v: "Pan preview with mouse" },
+                        { k: "[  /  ]", v: "Seek backward / forward 5 seconds" },
+                        { k: "R", v: "Reset camera view (yaw, pitch, FOV)" },
+                    ]: HorizontalLayout {
+                        spacing: 12px;
+                        Text {
+                            text: row.k;
+                            color: #a0e8a0;
+                            font-size: 12px;
+                            font-weight: 600;
+                            width: 80px;
+                        }
+                        Text {
+                            text: row.v;
+                            color: #ccc;
+                            font-size: 12px;
+                            wrap: word-wrap;
+                            horizontal-stretch: 1;
+                        }
+                    }
+
+                    Rectangle { vertical-stretch: 1; }
+
+                    HorizontalLayout {
+                        alignment: end;
+                        Button {
+                            text: "Close";
+                            clicked => { root.shortcuts-dialog-open = false; }
+                        }
+                    }
+                }
+            }
+        }
 
         // ── Export dialog (modal overlay) ──
         //


### PR DESCRIPTION
## Summary

Third of four Tier 3 PRs. UI surface for the persistence added in Tier 3b (#257). Two new modals in the file bar:

- **Recent…** button (disabled until an MRU list has entries): three-column modal (Left videos / Right videos / Calibrations). Click any entry to load it into the corresponding slot.
- **?** button: keyboard shortcut reference modal. Data-driven list so adding a shortcut is one line.

## Implementation notes

- 3 new Slint `[string]` properties backing the MRU lists; `sync_recent_paths` Rust helper builds fresh `ModelRc<SharedString>` on startup and after each pick.
- 5 new Slint callbacks: `load-recent-{left,right,calibration}`, `clear-recent-files`, plus the two modal-open booleans.
- Same code path for Recent click as native file dialog pick: MRU update → push to label → `try_init_and_update`.

## Stacked on

- #255 (reco-io settings)
- #257 (Tier 3b persistence)

Merge #255 → #257 → this.

## Test plan

- [x] Workspace build + clippy green, settings unit tests pass
- [ ] Manual: pick 2-3 left videos in sequence, then open Recent dialog → all three appear in Left column, most recent first
- [ ] Manual: click an entry → file loads, dialog dismisses
- [ ] Manual: "Clear all" empties all three columns and saves
- [ ] Manual: ? button opens shortcut list, Close dismisses
- [ ] Manual: click outside either modal dismisses

## Tier 3d (follow-up)

- Preferences dialog (editable defaults accessible from a gear icon)
- Export dialog time-range inputs
- Window size save/restore