### PR TITLE
feat(reco-core, reco-io, reco-calibrate): Batch H - consumer API ergonomics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5314,7 +5314,6 @@ dependencies = [
  "anyhow",
  "env_logger",
  "log",
- "pollster",
  "reco-autocam",
  "reco-calibrate",
  "reco-core",
@@ -5337,7 +5336,6 @@ dependencies = [
  "gstreamer",
  "gstreamer-app",
  "log",
- "pollster",
  "reco-core",
  "serde",
  "serde_json",
@@ -5352,7 +5350,6 @@ version = "0.1.0"
 dependencies = [
  "env_logger",
  "log",
- "pollster",
  "reco-core",
  "serde",
  "serde_json",

--- a/crates/reco-calibrate/Cargo.toml
+++ b/crates/reco-calibrate/Cargo.toml
@@ -30,11 +30,10 @@ serde_json = "1"
 thiserror = "2"
 tracing = { version = "0.1", optional = true }
 reco-io = { path = "../reco-io", optional = true }
-pollster = { version = "0.4", optional = true }
 
 [features]
 profiling = ["dep:tracing", "reco-core/profiling"]
-io = ["dep:reco-io", "dep:pollster"]
+io = ["dep:reco-io"]
 
 [dev-dependencies]
 approx = "0.5"

--- a/crates/reco-calibrate/src/video.rs
+++ b/crates/reco-calibrate/src/video.rs
@@ -26,6 +26,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+use reco_core::calibration::CameraParams;
 use reco_core::gpu::{GpuContext, GpuError};
 use reco_io::ffmpeg::calibration_io::{self, CalibrationIoError};
 
@@ -36,6 +37,11 @@ use crate::types::{CalibrationConfig, CalibrationProgress, CalibrationResult, Ca
 /// Options for [`calibrate_videos`].
 ///
 /// All fields are optional with sensible defaults.
+///
+/// Lens profile resolution order (first match wins):
+/// 1. `left_params` + `right_params` (both must be set)
+/// 2. `left_profile` path (+ optional `right_profile`)
+/// 3. auto-detect from video metadata
 #[derive(Debug, Clone, Default)]
 pub struct CalibrateVideosOptions {
     /// Calibration algorithm config. Uses [`CalibrationConfig::default()`] if `None`.
@@ -44,6 +50,14 @@ pub struct CalibrateVideosOptions {
     pub left_profile: Option<PathBuf>,
     /// Path to the right lens profile. Uses left profile if `None`.
     pub right_profile: Option<PathBuf>,
+    /// Pre-loaded left camera params. Wins over `left_profile` when both are
+    /// set. Must be set together with `right_params`.
+    ///
+    /// Lets consumers that already resolved profiles (e.g. via
+    /// `LensDatabase::candidates()`) skip the file round-trip.
+    pub left_params: Option<CameraParams>,
+    /// Pre-loaded right camera params. See [`Self::left_params`].
+    pub right_params: Option<CameraParams>,
     /// Manual sync offset in frames. Auto-detects via IMU/audio if `None`.
     pub sync_offset: Option<i64>,
 }
@@ -147,11 +161,24 @@ pub fn calibrate_videos(
 
     let mut pipeline = CalibrationPipeline::new(left_info, right_info, config);
 
-    // Lens profiles
-    if let Some(ref lp) = options.left_profile {
-        pipeline.load_profiles(lp, options.right_profile.as_deref())?;
-    } else {
-        pipeline.detect_profiles()?;
+    // Lens profiles: direct params > path > auto-detect.
+    match (options.left_params.clone(), options.right_params.clone()) {
+        (Some(lp), Some(rp)) => pipeline.set_profiles(lp, rp),
+        (left_params, right_params) => {
+            if left_params.is_some() || right_params.is_some() {
+                log::warn!(
+                    "CalibrateVideosOptions: left_params/right_params must both \
+                     be set (got left={}, right={}); falling back to path / auto-detect",
+                    left_params.is_some(),
+                    right_params.is_some(),
+                );
+            }
+            if let Some(ref lp) = options.left_profile {
+                pipeline.load_profiles(lp, options.right_profile.as_deref())?;
+            } else {
+                pipeline.detect_profiles()?;
+            }
+        }
     }
 
     // Sync: manual > IMU > audio > default (0)
@@ -207,7 +234,7 @@ pub fn calibrate_videos(
         CalibrationStep::FeatureMatching,
         "GPU init and feature matching",
     );
-    let gpu = pollster::block_on(GpuContext::new())?;
+    let gpu = GpuContext::new_blocking()?;
     log::info!("GPU: {}", gpu.gpu_name());
 
     let result = pipeline.calibrate(&gpu, &frame_pairs)?;

--- a/crates/reco-cli/src/calibrate.rs
+++ b/crates/reco-cli/src/calibrate.rs
@@ -137,8 +137,7 @@ pub fn run_calibrate(
     anyhow::ensure!(pair_count > 0, "no frames could be extracted from videos");
 
     // Init GPU
-    let gpu = pollster::block_on(GpuContext::new())
-        .map_err(|e| anyhow::anyhow!("GPU init failed: {e}"))?;
+    let gpu = GpuContext::new_blocking().map_err(|e| anyhow::anyhow!("GPU init failed: {e}"))?;
     log::info!("GPU: {}", gpu.gpu_name());
 
     // Debug: save GPU-undistorted frames

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -78,7 +78,7 @@ pub fn run_camera(
         ..Default::default()
     };
 
-    let gpu = pollster::block_on(reco_core::gpu::GpuContext::new())?;
+    let gpu = reco_core::gpu::GpuContext::new_blocking()?;
 
     // Use NV12 capture on Jetson to skip the NV12->I420 conversion
     // in nvvidconv. The NVIDIA ISP natively outputs NV12.

--- a/crates/reco-cli/src/libcamera_cmd.rs
+++ b/crates/reco-cli/src/libcamera_cmd.rs
@@ -73,7 +73,7 @@ pub fn run_libcamera(
         ..Default::default()
     };
 
-    let gpu = pollster::block_on(reco_core::gpu::GpuContext::new())?;
+    let gpu = reco_core::gpu::GpuContext::new_blocking()?;
 
     let capture_width = cam_config.width;
     let capture_height = cam_config.height;

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -725,7 +725,7 @@ fn main() -> anyhow::Result<()> {
         ),
 
         Commands::Info => {
-            let gpu = pollster::block_on(reco_core::gpu::GpuContext::new())?;
+            let gpu = reco_core::gpu::GpuContext::new_blocking()?;
             println!("GPU: {}", gpu.gpu_name());
             println!("Backend: {}", gpu.backend_name());
             println!("Driver: {}", gpu.driver_info());

--- a/crates/reco-core/src/gpu.rs
+++ b/crates/reco-core/src/gpu.rs
@@ -100,6 +100,20 @@ impl GpuContext {
         Self::with_surface(None).await
     }
 
+    /// Blocking convenience wrapper for [`Self::new`].
+    ///
+    /// Uses `pollster` internally so callers in synchronous contexts
+    /// (OBS plugin callbacks, CLI entry points, test harnesses) can
+    /// construct a context without pulling pollster in themselves or
+    /// spinning up a runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`GpuError::NoAdapter`] if no compatible GPU is found.
+    pub fn new_blocking() -> Result<Self, GpuError> {
+        pollster::block_on(Self::new())
+    }
+
     /// Initialize a GPU context with an optional compatible surface.
     ///
     /// When a surface is provided, the adapter selection will prefer GPUs

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -28,7 +28,6 @@ reco-detect = { path = "../reco-detect" }
 reco-autocam = { path = "../reco-autocam", optional = true }
 
 slint = { version = "~1.15", features = ["unstable-wgpu-28"] }
-pollster = "0.4"
 rfd = "0.15"
 log = "0.4"
 env_logger = "0.11"

--- a/crates/reco-gui/FRICTION.md
+++ b/crates/reco-gui/FRICTION.md
@@ -7,53 +7,6 @@ archived at the bottom with the PR that fixed them, so we can tell
 
 ## Active
 
-### A1. CalibrateVideosOptions only accepts lens profiles via file paths
-
-**Impact**: Medium. Blocks a functional lens-profile picker in the GUI.
-
-`reco_calibrate::video::CalibrateVideosOptions::{left_profile, right_profile}`
-are `Option<PathBuf>`. A consumer that already has a `LensProfileSummary`
-from `LensDatabase::candidates()` (Batch B) cannot pass it directly.
-Workaround: look up via `find(camera, model, w, h, lens_info)` which
-returns `(CameraParams, LensProfileInfo)`, but then there's no way to
-hand `CameraParams` to `calibrate_videos` either. The consumer either
-serializes `CameraParams` to a temp JSON just to re-load it, or drops
-down to `CalibrationPipeline::set_profiles()` and reimplements the
-video-frame extraction loop.
-
-**Suggested addition**:
-```rust
-pub struct CalibrateVideosOptions {
-    // ... existing ...
-    pub left_params: Option<CameraParams>,
-    pub right_params: Option<CameraParams>,
-}
-```
-If both `_path` and `_params` are set, `_params` wins.
-
-Currently manifests in the GUI Tier 1 lens picker being read-only -
-we display the detected profile and alternates count but can't let
-the user pick a different profile and re-run from the UI.
-
-### A2. StitchJob has no start_frame option for partial exports
-
-**Impact**: Medium. Blocks the GUI Export dialog's planned time-range
-picker.
-
-`reco_io::StitchJob` exposes `.max_frames(n)` and `.duration(s)` which
-bound the END of the export, but nothing for the START. A consumer
-that wants to export "from 0:15 to 0:30" must currently decode and
-discard frames from 0:00-0:15, which is wasted work for long clips.
-
-**Suggested addition**:
-```rust
-impl StitchJob {
-    /// Skip N frames before the first output frame. Combines with
-    /// max_frames / duration to select a window.
-    pub fn start_frame(mut self, n: u64) -> Self;
-}
-```
-
 ### A3. Preview pipeline and export StitchJob share CUDA context and
 racereliably when both active
 
@@ -109,23 +62,6 @@ feedback.
 **Suggested addition**: per-frame progress emission within
 `extract_frame_pairs`, or at least a "heartbeat" event every 2s so
 consumers know the worker is still alive.
-
-### A6. GpuContext::new() is async, consumers always pollster-wrap
-
-**Impact**: Very minor, but every consumer does the exact same thing.
-
-Deliberate (wgpu adapter creation is async), but every call site in
-reco-cli, reco-gui, reco-obs wraps it in `pollster::block_on`. A
-blocking convenience constructor in reco-core would let consumers
-avoid taking a direct dep on pollster:
-
-```rust
-impl GpuContext {
-    pub fn new_blocking() -> Result<Self, PipelineError> {
-        pollster::block_on(Self::new())
-    }
-}
-```
 
 ### A7. render_to_target() still returns CommandBuffer
 
@@ -205,3 +141,19 @@ drove which upstream changes.
   config_dir, RecentFiles}` behind an opt-in `config` feature.
   Per-consumer namespacing (`gui` / `cli` / `obs`) keeps each
   consumer's settings independent.
+- **R19. CalibrateVideosOptions only accepted lens profiles via paths**
+  Resolved by Batch H: `CalibrateVideosOptions { left_params,
+  right_params: Option<CameraParams> }` added. Lens profile resolution
+  now goes params > path > auto-detect. Consumers with a pre-resolved
+  `CameraParams` (e.g. from `LensDatabase::candidates()`) can skip the
+  file round-trip.
+- **R20. StitchJob had no start_frame for partial exports**
+  Resolved by Batch H: `StitchJob::start_frame(u64)` builder. Combines
+  with `max_frames`/`duration` to select a time window. Implemented as
+  drain-and-discard (no seek), so exports like "0:15 - 0:30" decode
+  from 0:00 but session progress reflects only the exported window.
+- **R21. GpuContext::new() was async, consumers had to pollster-wrap**
+  Resolved by Batch H: `GpuContext::new_blocking()`. reco-cli, reco-io,
+  reco-calibrate, reco-obs, and reco-gui dropped their direct `pollster`
+  deps (except reco-cli, which still needs it for
+  `GpuContext::for_surface` on the preview path).

--- a/crates/reco-io/Cargo.toml
+++ b/crates/reco-io/Cargo.toml
@@ -22,7 +22,6 @@ config = ["dep:serde", "dep:serde_json", "dep:directories"]
 [dependencies]
 reco-core = { path = "../reco-core" }
 log = "0.4"
-pollster = "0.4"
 thiserror = "2"
 tracing = { workspace = true, optional = true }
 

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -13,7 +13,7 @@
 //! ```rust,ignore
 //! use reco_io::SmartFileSource;
 //!
-//! let gpu = pollster::block_on(reco_core::gpu::GpuContext::new())?;
+//! let gpu = reco_core::gpu::GpuContext::new_blocking()?;
 //! let mut source = SmartFileSource::open("left.mp4", "right.mp4", &gpu, 0)?;
 //! // source implements FrameSource - pass to session.run()
 //! ```

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::output::{AudioMode, Bitrate, Codec, Format, Quality};
@@ -50,6 +50,7 @@ pub struct StitchJob {
     // Processing settings
     max_frames: Option<u64>,
     duration: Option<f64>,
+    start_frame: u64,
     sync_offset: Option<i64>,
     blend_width: f32,
 
@@ -207,6 +208,7 @@ impl StitchJob {
             preset: None,
             max_frames: None,
             duration: None,
+            start_frame: 0,
             sync_offset: None,
             blend_width: 0.15,
             on_progress: None,
@@ -296,6 +298,19 @@ impl StitchJob {
         self
     }
 
+    /// Skip `n` frames from each input before the first output frame.
+    ///
+    /// Combine with [`max_frames`](Self::max_frames) or
+    /// [`duration`](Self::duration) to select a time window, e.g. export
+    /// "0:15 - 0:30" as `.start_frame(450).duration(15.0)` at 30fps.
+    ///
+    /// Skipped frames are decoded and dropped (no seek), so latency is
+    /// proportional to decode rate. Default: `0`.
+    pub fn start_frame(mut self, n: u64) -> Self {
+        self.start_frame = n;
+        self
+    }
+
     /// Override the temporal sync offset between cameras (frames).
     /// Positive: right camera started first. Negative: left started first.
     /// Default: use the value from calibration.
@@ -369,7 +384,7 @@ impl StitchJob {
         }
 
         // Initialize GPU
-        let gpu = pollster::block_on(reco_core::gpu::GpuContext::new())?;
+        let gpu = reco_core::gpu::GpuContext::new_blocking()?;
         let gpu_name = gpu.gpu_name().to_string();
 
         // Open source with auto GPU detection
@@ -465,6 +480,32 @@ impl StitchJob {
         )?;
         let enc_name = encoder.encoder_name().to_string();
         session.set_encoder(Box::new(encoder), 2);
+
+        // Drain-and-discard frames up to start_frame.
+        // Done here (before session.run) so the session's frame counter
+        // and progress callback reflect the exported window, not the skip.
+        if self.start_frame > 0 {
+            log::info!("skipping first {} frames before export", self.start_frame);
+            use reco_core::source::FrameSource as _;
+            for skipped in 0..self.start_frame {
+                if interrupted.load(Ordering::Relaxed) {
+                    return Err(StitchError::Other(
+                        "cancelled during start_frame skip".into(),
+                    ));
+                }
+                match source.next_frame()? {
+                    Some(_) => {} // drop the frame
+                    None => {
+                        log::warn!(
+                            "start_frame={} exceeded source length (stopped at {})",
+                            self.start_frame,
+                            skipped,
+                        );
+                        break;
+                    }
+                }
+            }
+        }
 
         // Compute frame limit
         let frame_limit =

--- a/crates/reco-obs/Cargo.toml
+++ b/crates/reco-obs/Cargo.toml
@@ -16,7 +16,6 @@ profiling = ["reco-core/profiling", "tracing"]
 [dependencies]
 reco-core = { path = "../reco-core" }
 log = "0.4"
-pollster = "0.4"
 env_logger = "0.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -40,14 +40,6 @@ pub struct StridedYuvPlanes<'a> {
 ```
 Plus a conversion helper that copies stride → tight for the slow path.
 
-### A2. GpuContext::new() is async
-
-**Impact**: Very minor. Noted across all consumers (also in
-reco-gui/FRICTION.md A6). OBS plugin callbacks are synchronous C
-functions, so standalone `GpuContext::new` requires pulling in
-pollster. `GpuContext::from_device_queue` is the right sync escape
-hatch when you already have a wgpu device.
-
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.
@@ -93,6 +85,10 @@ logic, just with source pulled out.
   + `flush_rgba()` with triple-buffered staging, same pattern as
   `Nv12Converter`. Earlier ~40 lines of boilerplate in
   `reco-obs/source.rs` can be replaced.
+- **R2. GpuContext::new() was async**
+  Resolved by Batch H: `GpuContext::new_blocking()` added in reco-core.
+  `reco-obs` dropped its direct `pollster` dep; plugin callbacks can
+  now init the GPU synchronously without a runtime.
 
 ## Notes on plugin status
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -138,7 +138,7 @@ impl RecoSource {
 
         // Initialize GPU context if we don't have one yet.
         if self.gpu.is_none() {
-            match pollster::block_on(GpuContext::new()) as Result<GpuContext, _> {
+            match GpuContext::new_blocking() as Result<GpuContext, _> {
                 Ok(gpu) => {
                     log::info!("reco-obs: GPU initialized: {}", gpu.gpu_name());
                     self.gpu = Some(gpu);


### PR DESCRIPTION
## Summary

Three consumer-API additions driven by reco-gui and reco-obs FRICTION.md. All additive — no breaking changes.

- **H1**: `GpuContext::new_blocking()` — sync wrapper around `GpuContext::new()`. Lets consumers in synchronous contexts (OBS plugin callbacks, CLI entry, tests) drop their direct `pollster` dep. reco-io, reco-obs, reco-gui, and reco-calibrate now use it; reco-cli keeps pollster for `GpuContext::for_surface` on the preview path.
- **H2**: `CalibrateVideosOptions { left_params, right_params: Option<CameraParams> }` — pre-resolved lens params (e.g. from `LensDatabase::candidates()`) can skip the file round-trip. Resolution order: params > path > auto-detect.
- **H3**: `StitchJob::start_frame(u64)` — drain-and-discard N frames before first output. Combines with `max_frames` / `duration` to select an export window. Session progress reflects the exported window, not the skipped prefix.

## FRICTION archived

- reco-gui: R19 (CalibrateVideosOptions params), R20 (StitchJob start_frame), R21 (GpuContext async)
- reco-obs: R2 (GpuContext async)

Remaining active items: reco-gui A3 (CUDA preview/export race), A4 (pipeline unload helper), A5 (calibration heartbeat), A7 (CommandBuffer); reco-obs A1 (YuvPlanes stride), A3 (wgpu interop), A4 (LiveStitchSession). Batch I targets obs/A1 and obs/A4 next.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features profiling -- -D warnings`
- [x] `cargo test -p reco-core -p reco-io -p reco-calibrate --lib` (all green)
- [ ] Manual: export a clip with `.start_frame(30).duration(2.0)` and verify output starts at 1.0s mark
- [ ] Manual: pass `left_params`/`right_params` to `calibrate_videos` and confirm no file load for profiles