### PR TITLE
ci(release): pin artifact actions to SHAs + pin Windows FFmpeg version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,16 +143,27 @@ jobs:
       # widely available FFmpeg development libraries for aarch64-pc-windows-msvc.
       # The CI workflow runs cargo check for Windows ARM64 (reco-core only).
       # ----------------------------------------------------------------
+      # Pinned to a specific BtbN autobuild snapshot + the n7.1 stable
+      # branch (not master/nightly) so Windows release binaries are
+      # reproducible across builds. n7.1 is ABI-compatible with
+      # ffmpeg-next 8.x. When bumping: check
+      # https://github.com/BtbN/FFmpeg-Builds/releases for a newer
+      # autobuild tag and update both the TAG and the version-specific
+      # filename together.
       - name: Install FFmpeg (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
+        env:
+          FFMPEG_TAG: autobuild-2026-04-17-13-16
+          FFMPEG_ZIP: ffmpeg-n7.1.3-45-g2d6ee37238-win64-lgpl-shared-7.1.zip
         run: |
-          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-lgpl-shared.zip"
+          $url = "https://github.com/BtbN/FFmpeg-Builds/releases/download/$env:FFMPEG_TAG/$env:FFMPEG_ZIP"
           Invoke-WebRequest -Uri $url -OutFile "$env:RUNNER_TEMP\ffmpeg.zip"
           Expand-Archive -Path "$env:RUNNER_TEMP\ffmpeg.zip" -DestinationPath "$env:RUNNER_TEMP\ffmpeg"
           $dir = (Get-ChildItem "$env:RUNNER_TEMP\ffmpeg" -Directory | Select-Object -First 1).FullName
           echo "FFMPEG_DIR=$dir" >> $env:GITHUB_ENV
           echo "FFMPEG_DLL_DIR=$dir\bin" >> $env:GITHUB_ENV
+          echo "Bundled FFmpeg: $env:FFMPEG_ZIP (tag $env:FFMPEG_TAG)"
 
       # ----------------------------------------------------------------
       # Build
@@ -187,7 +198,7 @@ jobs:
           Compress-Archive -Path $staging -DestinationPath "$staging.zip"
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4 # TODO: pin to commit SHA for supply-chain safety
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: reco-${{ matrix.name }}
           path: reco-${{ github.ref_name }}-${{ matrix.name }}.*
@@ -202,7 +213,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4 # TODO: pin to commit SHA
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Closes #211, closes #212.

## Summary

- Pin `actions/upload-artifact@v4` to `ea165f8d` (v4.6.2) and `actions/download-artifact@v4` to `d3f86a10` (v4.3.0). Matches the SHA-pinning pattern already used in rust.yml for supply-chain safety.
- Pin Windows FFmpeg download to tag `autobuild-2026-04-17-13-16` and filename `ffmpeg-n7.1.3-45-g2d6ee37238-win64-lgpl-shared-7.1.zip`. Moving off the `latest` tag (which points at master/nightly and changes on every build) to the n7.1 stable branch, which is ABI-compatible with `ffmpeg-next` 8.x and matches the version Linux distros ship.
- Log the bundled FFmpeg filename + tag at build time so release notes can cite the exact version.

## Why n7.1 instead of master

Master/nightly can introduce API-level changes between builds. FFmpeg 7.1 is a named stable release, so binaries built today and in 6 months behave the same way.

## Bump procedure

When updating:
1. Check https://github.com/BtbN/FFmpeg-Builds/releases for a newer autobuild tag
2. Update both `FFMPEG_TAG` and `FFMPEG_ZIP` env vars (the snapshot suffix `g2d6ee37238` changes per build, so they must be updated together)

## Test plan

- [x] YAML validity check
- [ ] Release workflow dry-run via a tag push (user to verify on next `v*` tag)