### PR TITLE
feat(reco-core, reco-obs): Batch I - live push-based stitching + stride-aware input

### DIFF
--- a/crates/reco-core/src/pipeline.rs
+++ b/crates/reco-core/src/pipeline.rs
@@ -46,6 +46,88 @@ pub struct YuvPlanes<'a> {
     pub v: &'a [u8],
 }
 
+/// A single stride-aware plane view.
+///
+/// External frameworks (OBS `obs_source_frame`, V4L2, GStreamer buffers)
+/// typically expose planes as a pointer plus a row stride that may exceed
+/// the plane width (padding). [`YuvPlanes`] assumes tight packing, so a
+/// consumer that receives padded data has to repack before calling
+/// [`StitchPipeline::render_to_target`]. [`StridedYuvPlanes::copy_into`]
+/// does the repack into a caller-owned buffer without reallocating on
+/// every frame.
+pub struct FramePlaneView<'a> {
+    /// Plane pixel bytes. Must have length at least `stride * height`.
+    pub data: &'a [u8],
+    /// Bytes per row, including any trailing padding.
+    pub stride: u32,
+    /// Plane width in pixels (bytes per row of usable data).
+    pub width: u32,
+    /// Plane height in rows.
+    pub height: u32,
+}
+
+/// Stride-aware YUV420P planes, suitable for hardware-decoded frames
+/// or framework callbacks that expose raw pointers + strides.
+///
+/// Use [`Self::copy_into`] to produce a tightly packed [`YuvPlanes`]
+/// view ready for [`StitchPipeline::render_to_target`].
+pub struct StridedYuvPlanes<'a> {
+    /// Y (luma) plane, full resolution.
+    pub y: FramePlaneView<'a>,
+    /// U (Cb) plane, half resolution per dimension.
+    pub u: FramePlaneView<'a>,
+    /// V (Cr) plane, half resolution per dimension.
+    pub v: FramePlaneView<'a>,
+}
+
+impl StridedYuvPlanes<'_> {
+    /// Repack the strided planes into a caller-owned tight buffer and
+    /// return a [`YuvPlanes`] view into it.
+    ///
+    /// The `buffer` is resized to `y_len + u_len + v_len` bytes. Cache
+    /// the buffer across frames to avoid per-frame allocation.
+    pub fn copy_into<'b>(&self, buffer: &'b mut Vec<u8>) -> YuvPlanes<'b> {
+        let y_len = (self.y.width as usize) * (self.y.height as usize);
+        let u_len = (self.u.width as usize) * (self.u.height as usize);
+        let v_len = (self.v.width as usize) * (self.v.height as usize);
+        buffer.resize(y_len + u_len + v_len, 0);
+        {
+            let (y_dst, rest) = buffer.split_at_mut(y_len);
+            let (u_dst, v_dst) = rest.split_at_mut(u_len);
+            copy_plane_tight(&self.y, y_dst);
+            copy_plane_tight(&self.u, u_dst);
+            copy_plane_tight(&self.v, v_dst);
+        }
+        let (y, rest) = buffer.split_at(y_len);
+        let (u, v) = rest.split_at(u_len);
+        YuvPlanes { y, u, v }
+    }
+}
+
+/// Copy `src` rows into `dst`, skipping stride padding.
+///
+/// `dst` must be exactly `src.width * src.height` bytes long.
+/// Rows where `stride == width` are copied in a single `copy_from_slice`.
+fn copy_plane_tight(src: &FramePlaneView<'_>, dst: &mut [u8]) {
+    let width = src.width as usize;
+    let height = src.height as usize;
+    let stride = src.stride as usize;
+    debug_assert_eq!(dst.len(), width * height);
+    debug_assert!(src.data.len() >= stride.saturating_mul(height));
+
+    if stride == width {
+        // Fast path: source is already tight; one memcpy.
+        dst.copy_from_slice(&src.data[..width * height]);
+        return;
+    }
+
+    for row in 0..height {
+        let src_start = row * stride;
+        let dst_start = row * width;
+        dst[dst_start..dst_start + width].copy_from_slice(&src.data[src_start..src_start + width]);
+    }
+}
+
 /// Borrowed NV12 plane references for pipeline input.
 ///
 /// Tightly packed (no stride padding):
@@ -622,5 +704,129 @@ impl StitchPipeline {
     /// Access the rendered RGBA texture for NV12 conversion.
     pub fn render_target(&self) -> &wgpu::Texture {
         self.renderer.render_target()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a test plane where row `r` contains byte value `r` for the first
+    /// `width` bytes, followed by `0xFF` padding up to `stride`.
+    fn padded_plane(width: u32, height: u32, stride: u32) -> Vec<u8> {
+        let mut buf = vec![0xFF; (stride * height) as usize];
+        for r in 0..height {
+            for c in 0..width {
+                buf[(r * stride + c) as usize] = r as u8;
+            }
+        }
+        buf
+    }
+
+    #[test]
+    fn copy_into_strips_row_padding() {
+        // 4-pixel wide plane padded to 8-byte rows (typical OBS alignment).
+        let y_data = padded_plane(4, 3, 8);
+        let u_data = padded_plane(2, 2, 4);
+        let v_data = padded_plane(2, 2, 4);
+        let strided = StridedYuvPlanes {
+            y: FramePlaneView {
+                data: &y_data,
+                stride: 8,
+                width: 4,
+                height: 3,
+            },
+            u: FramePlaneView {
+                data: &u_data,
+                stride: 4,
+                width: 2,
+                height: 2,
+            },
+            v: FramePlaneView {
+                data: &v_data,
+                stride: 4,
+                width: 2,
+                height: 2,
+            },
+        };
+
+        let mut buffer = Vec::new();
+        let tight = strided.copy_into(&mut buffer);
+
+        assert_eq!(tight.y.len(), 12);
+        assert_eq!(tight.u.len(), 4);
+        assert_eq!(tight.v.len(), 4);
+        // Row 0 should be [0,0,0,0], row 1 [1,1,1,1], etc - no 0xFF padding.
+        assert_eq!(tight.y, &[0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2]);
+        assert_eq!(tight.u, &[0, 0, 1, 1]);
+        assert_eq!(tight.v, &[0, 0, 1, 1]);
+    }
+
+    #[test]
+    fn copy_into_fast_path_when_tight() {
+        // stride == width means no padding - fast path takes a single memcpy.
+        let y_data: Vec<u8> = (0..12).collect();
+        let u_data: Vec<u8> = (0..4).collect();
+        let v_data: Vec<u8> = (4..8).collect();
+        let strided = StridedYuvPlanes {
+            y: FramePlaneView {
+                data: &y_data,
+                stride: 4,
+                width: 4,
+                height: 3,
+            },
+            u: FramePlaneView {
+                data: &u_data,
+                stride: 2,
+                width: 2,
+                height: 2,
+            },
+            v: FramePlaneView {
+                data: &v_data,
+                stride: 2,
+                width: 2,
+                height: 2,
+            },
+        };
+        let mut buffer = Vec::new();
+        let tight = strided.copy_into(&mut buffer);
+        assert_eq!(tight.y, y_data.as_slice());
+        assert_eq!(tight.u, u_data.as_slice());
+        assert_eq!(tight.v, v_data.as_slice());
+    }
+
+    #[test]
+    fn copy_into_reuses_buffer_without_realloc() {
+        let plane = padded_plane(4, 3, 8);
+        let strided = StridedYuvPlanes {
+            y: FramePlaneView {
+                data: &plane,
+                stride: 8,
+                width: 4,
+                height: 3,
+            },
+            u: FramePlaneView {
+                data: &plane,
+                stride: 8,
+                width: 2,
+                height: 2,
+            },
+            v: FramePlaneView {
+                data: &plane,
+                stride: 8,
+                width: 2,
+                height: 2,
+            },
+        };
+
+        let mut buffer = Vec::with_capacity(64);
+        let cap_before = buffer.capacity();
+        let _tight = strided.copy_into(&mut buffer);
+        // 12 + 4 + 4 = 20 bytes needed, 64 capacity, no realloc.
+        assert_eq!(buffer.capacity(), cap_before);
+
+        // Second call with same dims: still no realloc.
+        let _tight2 = strided.copy_into(&mut buffer);
+        assert_eq!(buffer.capacity(), cap_before);
     }
 }

--- a/crates/reco-core/src/session/live.rs
+++ b/crates/reco-core/src/session/live.rs
@@ -1,0 +1,160 @@
+//! Live push-based stitching for compositor/callback consumers.
+//!
+//! [`LiveStitchSession`] bundles a [`StitchPipeline`] with an
+//! [`RgbaReadback`] helper so consumers that receive frames one at a
+//! time on a callback thread (OBS `video_tick`, V4L2 capture, WebRTC
+//! ingest) can call a single `submit_frame` and get back a tightly
+//! packed RGBA buffer ready for compositor upload.
+//!
+//! Contrast with [`StitchSession`](super::StitchSession), which drives
+//! a pull-based [`FrameSource`](crate::source::FrameSource) loop - the
+//! wrong shape when frames arrive asynchronously from a C callback.
+//!
+//! ## Usage
+//!
+//! ```rust,ignore
+//! use reco_core::session::{LiveStitchSession, LiveSessionConfig};
+//!
+//! let mut session = LiveStitchSession::new(gpu, LiveSessionConfig {
+//!     calibration,
+//!     viewport,
+//!     input_width, input_height,
+//!     output_format: wgpu::TextureFormat::Rgba8Unorm,
+//!     input_format: InputFormat::Yuv420p,
+//! })?;
+//!
+//! // Inside the OBS video_tick callback:
+//! if let Some(rgba) = session.submit_frame(&left, &right, yaw, pitch)? {
+//!     // rgba is &[u8] of length output_width * output_height * 4
+//!     compositor.upload(rgba);
+//! }
+//! ```
+
+use thiserror::Error;
+
+use crate::calibration::MatchCalibration;
+use crate::gpu::GpuContext;
+use crate::pipeline::{PipelineError, StitchPipeline, YuvPlanes};
+use crate::renderer::InputFormat;
+use crate::rgba_readback::{RgbaReadback, RgbaReadbackError};
+use crate::viewport::ViewportConfig;
+
+/// Configuration for creating a [`LiveStitchSession`].
+pub struct LiveSessionConfig {
+    /// Camera calibration data.
+    pub calibration: MatchCalibration,
+    /// Output viewport (dimensions, blend width, FOV).
+    pub viewport: ViewportConfig,
+    /// Input frame width in pixels (per camera).
+    pub input_width: u32,
+    /// Input frame height in pixels (per camera).
+    pub input_height: u32,
+    /// GPU render target format. Use `Rgba8Unorm` for most compositor
+    /// consumers; `Bgra8Unorm` matches native Windows/DirectX formats.
+    pub output_format: wgpu::TextureFormat,
+    /// Input pixel format.
+    pub input_format: InputFormat,
+}
+
+/// Errors from [`LiveStitchSession`].
+#[derive(Debug, Error)]
+pub enum LiveSessionError {
+    /// Pipeline initialization or render failed.
+    #[error("pipeline: {0}")]
+    Pipeline(#[from] PipelineError),
+    /// Readback staging/mapping failed.
+    #[error("readback: {0}")]
+    Readback(#[from] RgbaReadbackError),
+}
+
+/// High-level wrapper for push-based stitching with RGBA readback.
+///
+/// See the module-level docs for usage.
+pub struct LiveStitchSession {
+    pipeline: StitchPipeline,
+    readback: RgbaReadback,
+    output_width: u32,
+    output_height: u32,
+}
+
+impl LiveStitchSession {
+    /// Build a new session. Owns the provided [`GpuContext`].
+    pub fn new(gpu: GpuContext, config: LiveSessionConfig) -> Result<Self, LiveSessionError> {
+        let output_width = config.viewport.width;
+        let output_height = config.viewport.height;
+
+        let pipeline = StitchPipeline::with_gpu(
+            gpu,
+            config.calibration,
+            config.viewport,
+            config.input_width,
+            config.input_height,
+            config.output_format,
+            config.input_format,
+        )?;
+
+        let readback = RgbaReadback::new(pipeline.gpu(), output_width, output_height)?;
+
+        Ok(Self {
+            pipeline,
+            readback,
+            output_width,
+            output_height,
+        })
+    }
+
+    /// Submit a stereo YUV420P frame and request an RGBA render.
+    ///
+    /// Returns the tightly-packed RGBA bytes from two frames ago (triple-
+    /// buffered staging), or `None` during pipeline warmup (first two
+    /// calls). The returned slice is `output_width * output_height * 4`
+    /// bytes; it borrows from the session's internal buffers and is
+    /// valid until the next `submit_frame` call.
+    ///
+    /// `yaw` and `pitch` are in radians.
+    pub fn submit_frame(
+        &mut self,
+        left: &YuvPlanes<'_>,
+        right: &YuvPlanes<'_>,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Option<&[u8]>, LiveSessionError> {
+        let cmd = self.pipeline.render_to_target(left, right, yaw, pitch)?;
+        let rgba =
+            self.readback
+                .readback(self.pipeline.gpu(), self.pipeline.render_target(), cmd)?;
+        Ok(rgba)
+    }
+
+    /// Output dimensions in pixels.
+    pub fn output_dims(&self) -> (u32, u32) {
+        (self.output_width, self.output_height)
+    }
+
+    /// Shared access to the wrapped pipeline (for `update_camera_params`,
+    /// pose introspection, etc.).
+    pub fn pipeline(&self) -> &StitchPipeline {
+        &self.pipeline
+    }
+
+    /// Mutable access to the wrapped pipeline.
+    pub fn pipeline_mut(&mut self) -> &mut StitchPipeline {
+        &mut self.pipeline
+    }
+
+    /// Access the GPU context that owns the render resources.
+    pub fn gpu(&self) -> &GpuContext {
+        self.pipeline.gpu()
+    }
+
+    /// Drain one pending readback slot without submitting a new frame.
+    ///
+    /// Useful at shutdown to collect the 1-2 frames still in-flight in
+    /// the triple-buffered staging pipeline. Returns `None` when no
+    /// frames remain.
+    pub fn flush(&mut self) -> Result<Option<&[u8]>, LiveSessionError> {
+        let gpu = self.pipeline.gpu();
+        let rgba = self.readback.flush_pending(gpu)?;
+        Ok(rgba)
+    }
+}

--- a/crates/reco-core/src/session/live.rs
+++ b/crates/reco-core/src/session/live.rs
@@ -1,14 +1,14 @@
 //! Live push-based stitching for compositor/callback consumers.
 //!
 //! [`LiveStitchSession`] bundles a [`StitchPipeline`] with an
-//! [`RgbaReadback`] helper so consumers that receive frames one at a
+//! `RgbaReadback` helper so consumers that receive frames one at a
 //! time on a callback thread (OBS `video_tick`, V4L2 capture, WebRTC
 //! ingest) can call a single `submit_frame` and get back a tightly
 //! packed RGBA buffer ready for compositor upload.
 //!
-//! Contrast with [`StitchSession`](super::StitchSession), which drives
-//! a pull-based [`FrameSource`](crate::source::FrameSource) loop - the
-//! wrong shape when frames arrive asynchronously from a C callback.
+//! Contrast with `StitchSession`, which drives a pull-based
+//! [`FrameSource`](crate::source::FrameSource) loop - the wrong shape
+//! when frames arrive asynchronously from a C callback.
 //!
 //! ## Usage
 //!

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -18,6 +18,8 @@
 
 /// Detection pipeline - also usable standalone without StitchSession.
 pub mod detection;
+/// Live push-based stitching for compositor consumers (OBS, V4L2, WebRTC).
+pub mod live;
 #[cfg(test)]
 mod tests;
 #[cfg(target_os = "linux")]
@@ -27,6 +29,8 @@ mod zero_copy_macos;
 
 #[cfg(target_os = "linux")]
 pub use zero_copy_linux::SharedTextureSet;
+
+pub use live::{LiveSessionConfig, LiveSessionError, LiveStitchSession};
 
 use std::sync::atomic::{AtomicBool, Ordering};
 

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -6,40 +6,6 @@ resolved items archived at the bottom with the PR that fixed them.
 
 ## Active
 
-### A1. YuvPlanes requires tight packing, not stride-aware
-
-**Impact**: Medium. Every OBS-style consumer has to copy or re-pack
-incoming frames before handing to reco-core.
-
-`StitchPipeline::render_to_target()` takes `YuvPlanes<'a>` which is
-`{ y: &[u8], u: &[u8], v: &[u8] }` - three separate tightly-packed
-slice references. An OBS plugin receives frames as `obs_source_frame`
-with `data[MAX_AV_PLANES]` pointers, `linesize[MAX_AV_PLANES]`
-strides (which may include row padding), `width` / `height`, and a
-`format` enum.
-
-**Impact**: The consumer must (1) map OBS format → reco input format,
-(2) handle stride mismatches by copying tightly, (3) extract the
-right plane pointers based on format. Common code that every
-realistic live-input consumer will write.
-
-**Suggested addition**:
-```rust
-pub struct FramePlaneView<'a> {
-    pub data: &'a [u8],
-    pub stride: u32,  // bytes per row, may include padding
-    pub width: u32,
-    pub height: u32,
-}
-
-pub struct StridedYuvPlanes<'a> {
-    pub y: FramePlaneView<'a>,
-    pub u: FramePlaneView<'a>,
-    pub v: FramePlaneView<'a>,
-}
-```
-Plus a conversion helper that copies stride → tight for the slow path.
-
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.
@@ -57,27 +23,6 @@ wgpu, which it hasn't.
 Tracking here as a known limit; not actionable at the reco-core
 level without a specific interop target.
 
-### A4. Live camera input has no high-level consumer helper
-
-**Impact**: High for the "Reco as OBS input source" use case.
-
-reco-io has `FfmpegFileSource`, `SmartFileSource`, and zero-copy
-CUDA adapters - all oriented toward decoding from files. For OBS
-(and future live-camera consumers), the incoming data comes from a
-callback with frame pointers + timing, not from a file path.
-
-There is currently no reco-io type that says "I will feed you frames
-one at a time, please stitch them" without a backing source file.
-The OBS plugin will either need to (a) write a mock `FrameSource`
-impl that blocks the OBS callback thread waiting for the next
-submission, or (b) call `StitchPipeline::render_to_target` directly
-and bypass the higher-level session machinery.
-
-**Suggested direction**: a `LiveStitchSession` in reco-core that
-exposes `submit_frame(left, right) -> Result<PixelBuffer>` without
-expecting a FrameSource. Could share most of the existing session
-logic, just with source pulled out.
-
 ## Resolved (archived)
 
 - **R1. No RGBA readback helper on StitchPipeline**
@@ -89,6 +34,20 @@ logic, just with source pulled out.
   Resolved by Batch H: `GpuContext::new_blocking()` added in reco-core.
   `reco-obs` dropped its direct `pollster` dep; plugin callbacks can
   now init the GPU synchronously without a runtime.
+- **R3. YuvPlanes required tight packing, not stride-aware**
+  Resolved by Batch I: `reco_core::pipeline::{FramePlaneView,
+  StridedYuvPlanes}` added alongside the existing tight `YuvPlanes`.
+  `StridedYuvPlanes::copy_into(&mut Vec<u8>)` repacks padded rows into
+  a caller-owned buffer (tight-fast-path when `stride == width`) and
+  returns a borrowed `YuvPlanes` ready for
+  `StitchPipeline::render_to_target`. Buffer is reusable across frames
+  to avoid per-frame allocation.
+- **R4. No live camera input consumer helper**
+  Resolved by Batch I: `reco_core::session::{LiveSessionConfig,
+  LiveStitchSession}`. Bundles `StitchPipeline` + `RgbaReadback` with
+  `submit_frame(left, right, yaw, pitch) -> Option<&[u8]>` for push-
+  based compositor consumers (OBS, V4L2, WebRTC). `reco-obs/src/source.rs`
+  migrated to it - net removal of ~30 lines of per-consumer plumbing.
 
 ## Notes on plugin status
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -26,9 +26,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use reco_core::calibration::MatchCalibration;
 use reco_core::gpu::GpuContext;
-use reco_core::pipeline::{StitchPipeline, YuvPlanes};
+use reco_core::pipeline::YuvPlanes;
 use reco_core::renderer::InputFormat;
-use reco_core::rgba_readback::RgbaReadback;
+use reco_core::session::{LiveSessionConfig, LiveStitchSession};
 use reco_core::viewport::ViewportConfig;
 
 use crate::ffi;
@@ -61,15 +61,9 @@ const PROP_PITCH: &CStr = c"pitch";
 /// Allocated in `create`, freed in `destroy`. OBS passes `*mut c_void`
 /// pointing to this through all callbacks.
 struct RecoSource {
-    /// The wgpu stitching pipeline (None until calibration is loaded).
-    pipeline: Option<StitchPipeline>,
-
-    /// RGBA readback helper (triple-buffered staging + row-padding strip).
-    /// None until the pipeline is built.
-    readback: Option<RgbaReadback>,
-
-    /// The shared GPU context.
-    gpu: Option<GpuContext>,
+    /// High-level push session (bundles pipeline + RGBA readback).
+    /// None until calibration is loaded and GPU is initialized.
+    session: Option<LiveStitchSession>,
 
     /// Current calibration loaded from the config file.
     calibration: Option<MatchCalibration>,
@@ -107,9 +101,7 @@ struct RecoSource {
 impl RecoSource {
     fn new() -> Self {
         Self {
-            pipeline: None,
-            readback: None,
-            gpu: None,
+            session: None,
             calibration: None,
             config_path: String::new(),
             output_width: 1920,
@@ -136,68 +128,47 @@ impl RecoSource {
             }
         };
 
-        // Initialize GPU context if we don't have one yet.
-        if self.gpu.is_none() {
-            match GpuContext::new_blocking() as Result<GpuContext, _> {
-                Ok(gpu) => {
-                    log::info!("reco-obs: GPU initialized: {}", gpu.gpu_name());
-                    self.gpu = Some(gpu);
-                }
-                Err(e) => {
-                    log::error!("reco-obs: failed to initialize GPU: {e}");
-                    return;
-                }
+        let gpu = match GpuContext::new_blocking() {
+            Ok(g) => g,
+            Err(e) => {
+                log::error!("reco-obs: failed to initialize GPU: {e}");
+                return;
             }
-        }
+        };
+        log::info!("reco-obs: GPU initialized: {}", gpu.gpu_name());
 
-        let gpu = self.gpu.as_ref().unwrap().clone();
         let viewport = ViewportConfig {
             width: self.output_width,
             height: self.output_height,
             ..ViewportConfig::default()
         };
 
-        match StitchPipeline::with_gpu(
+        match LiveStitchSession::new(
             gpu,
-            calibration,
-            viewport,
-            self.input_width,
-            self.input_height,
-            reco_core::wgpu::TextureFormat::Rgba8Unorm,
-            InputFormat::Yuv420p,
+            LiveSessionConfig {
+                calibration,
+                viewport,
+                input_width: self.input_width,
+                input_height: self.input_height,
+                output_format: reco_core::wgpu::TextureFormat::Rgba8Unorm,
+                input_format: InputFormat::Yuv420p,
+            },
         ) {
-            Ok(pipeline) => {
+            Ok(session) => {
                 log::info!(
-                    "reco-obs: pipeline initialized ({}x{} output, {}x{} input, GPU: {})",
+                    "reco-obs: session initialized ({}x{} output, {}x{} input)",
                     self.output_width,
                     self.output_height,
                     self.input_width,
                     self.input_height,
-                    pipeline.gpu_name(),
                 );
-                // Build the RGBA readback helper alongside the pipeline.
-                // `RgbaReadback` owns the triple-buffered staging + row
-                // padding strip that used to live inline in this file.
-                match RgbaReadback::new(pipeline.gpu(), self.output_width, self.output_height) {
-                    Ok(readback) => {
-                        self.readback = Some(readback);
-                    }
-                    Err(e) => {
-                        log::error!("reco-obs: failed to create RGBA readback: {e}");
-                        self.pipeline = None;
-                        self.readback = None;
-                        return;
-                    }
-                }
-                self.pipeline = Some(pipeline);
-                // Pre-allocate the owned buffer that `video_render` reads.
+                self.session = Some(session);
                 let buf_size = (self.output_width * self.output_height * 4) as usize;
                 self.rgba_buffer.resize(buf_size, 0);
             }
             Err(e) => {
-                log::error!("reco-obs: failed to create pipeline: {e}");
-                self.pipeline = None;
-                self.readback = None;
+                log::error!("reco-obs: failed to create session: {e}");
+                self.session = None;
             }
         }
     }
@@ -206,7 +177,7 @@ impl RecoSource {
     fn load_calibration(&mut self) {
         if self.config_path.is_empty() {
             self.calibration = None;
-            self.pipeline = None;
+            self.session = None;
             return;
         }
 
@@ -222,39 +193,23 @@ impl RecoSource {
                     self.config_path
                 );
                 self.calibration = None;
-                self.pipeline = None;
+                self.session = None;
             }
         }
     }
 
-    /// Perform a render and readback cycle.
+    /// Perform a render and readback cycle via [`LiveStitchSession`].
     ///
     /// Currently renders a blank frame (all-zero YUV) since we don't have
-    /// live camera input wired up yet. The real integration will need an
-    /// `obs_source_t` reference to pull video frames from upstream OBS
-    /// sources (e.g., two V4L2 camera inputs).
+    /// live camera input wired up yet. When real OBS frame callbacks are
+    /// plumbed, the strided `obs_source_frame` planes should be wrapped
+    /// in [`reco_core::pipeline::StridedYuvPlanes`] and repacked into a
+    /// cached `Vec<u8>` via `copy_into(&mut buf)` before submission.
     fn render_and_readback(&mut self) {
-        let pipeline = match &self.pipeline {
-            Some(p) => p,
+        let session = match &mut self.session {
+            Some(s) => s,
             None => return,
         };
-        let readback = match &mut self.readback {
-            Some(r) => r,
-            None => return,
-        };
-        let gpu = match &self.gpu {
-            Some(g) => g,
-            None => return,
-        };
-
-        // FRICTION: StitchPipeline expects raw YUV plane data (&[u8]) but
-        // an OBS plugin consumer would naturally have obs_source_frame
-        // pointers or OBS texture handles. There's no way to feed OBS's
-        // frame data into the pipeline without first extracting the raw
-        // plane bytes and sizes - which requires knowing the OBS video
-        // format and stride layout. A higher-level API that accepts
-        // width/height/stride/pointers (like a "RawFrameView") would
-        // reduce this impedance mismatch.
 
         // TODO: Wire up actual camera frame data from OBS source inputs.
         // For now, render a test pattern (zero YUV = green in BT.601).
@@ -278,19 +233,7 @@ impl RecoSource {
         let yaw = (self.yaw_degrees as f32).to_radians();
         let pitch = (self.pitch_degrees as f32).to_radians();
 
-        // Render + triple-buffered RGBA readback via the shared
-        // `RgbaReadback` helper in reco-core. Returns `None` on the first
-        // two calls (pipeline warmup) and tightly-packed RGBA thereafter,
-        // so the wgpu 256-byte row padding is stripped for us.
-        let cmd_buf = match pipeline.render_to_target(&left, &right, yaw, pitch) {
-            Ok(cmd) => cmd,
-            Err(e) => {
-                log::error!("reco-obs: render failed: {e}");
-                return;
-            }
-        };
-
-        match readback.readback(gpu, pipeline.render_target(), cmd_buf) {
+        match session.submit_frame(&left, &right, yaw, pitch) {
             Ok(Some(rgba)) => {
                 self.rgba_buffer.copy_from_slice(rgba);
                 self.frame_ready.store(true, Ordering::Release);
@@ -299,7 +242,7 @@ impl RecoSource {
                 // Pipeline warmup; next tick will have data.
             }
             Err(e) => {
-                log::error!("reco-obs: RGBA readback failed: {e}");
+                log::error!("reco-obs: render/readback failed: {e}");
             }
         }
     }
@@ -536,7 +479,7 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
     }
     let src = unsafe { &mut *(data as *mut RecoSource) };
 
-    if src.pipeline.is_none() {
+    if src.session.is_none() {
         return;
     }
 


### PR DESCRIPTION
Resubmit of #262 after Batch H merged. Rebased on main; only Batch I changes remain.

## Summary

- **I1**: \`StridedYuvPlanes\` + \`FramePlaneView\` + \`copy_into(&mut Vec<u8>) -> YuvPlanes<'_>\` in \`reco_core::pipeline\`. External frameworks (OBS \`obs_source_frame\`, V4L2, GStreamer) hand planes as pointer + stride; consumers cache a \`Vec<u8>\` and call \`copy_into\` once per frame. Single-memcpy fast path when \`stride == width\`.
- **I2**: \`LiveStitchSession\` in \`reco_core::session::live\`. Bundles \`StitchPipeline\` + \`RgbaReadback\` with \`submit_frame(left, right, yaw, pitch) -> Option<&[u8]>\`. Right shape for push-based callback consumers (OBS \`video_tick\`, V4L2, WebRTC).
- **reco-obs migrated**: \`pipeline\` / \`readback\` / \`gpu\` fields collapse into one \`session\` field, ~30 lines of per-consumer plumbing removed. Test-pattern render path now goes through \`submit_frame\`, and a TODO plus pointer to \`StridedYuvPlanes\` marks where real OBS frame data will be wired in.

## FRICTION archived

- reco-obs: R3 (YuvPlanes stride), R4 (LiveStitchSession)

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo clippy --all-targets --features profiling -- -D warnings\`
- [x] \`cargo test -p reco-core --lib\` (68 passed, including 3 new StridedYuvPlanes tests)
- [x] Manual: user validated GUI calibrate + preview + exit on this branch (no regressions)