### PR TITLE
fix(reco-calibrate): A5 - emit DetectingProfiles step + cache telemetry

### DIFF
--- a/crates/reco-calibrate/src/lens_database.rs
+++ b/crates/reco-calibrate/src/lens_database.rs
@@ -455,22 +455,33 @@ pub fn load_from_json(json_str: &str, source: &str) -> Result<CameraParams, Lens
 /// 1. Embedded lens profile from video metadata (DJI cameras)
 /// 2. Camera identification + database lookup (GoPro, etc.)
 ///
+/// When `cached_telemetry` is `Some`, the caller has already parsed the
+/// telemetry stream (e.g. for IMU sync) and is passing it through to
+/// avoid a second parse. When `None`, this function extracts telemetry
+/// itself and falls back gracefully if the file has none.
+///
 /// Returns `None` if the camera can't be identified or no profile matches.
 pub fn detect_profile(
     video_path: &Path,
     video_width: u32,
     video_height: u32,
     db: &LensDatabase,
+    cached_telemetry: Option<&crate::telemetry::TelemetryData>,
 ) -> Option<(CameraParams, LensProfileInfo)> {
-    let tel = match crate::telemetry::extract(video_path) {
-        Ok(t) => Some(t),
-        Err(e) => {
-            log::warn!("lens auto-detect: telemetry extraction failed: {e}");
-            None
+    let extracted: Option<crate::telemetry::TelemetryData> = if cached_telemetry.is_some() {
+        None
+    } else {
+        match crate::telemetry::extract(video_path) {
+            Ok(t) => Some(t),
+            Err(e) => {
+                log::warn!("lens auto-detect: telemetry extraction failed: {e}");
+                None
+            }
         }
     };
+    let tel: Option<&crate::telemetry::TelemetryData> = cached_telemetry.or(extracted.as_ref());
 
-    if let Some(ref tel) = tel {
+    if let Some(tel) = tel {
         // 1. Embedded lens profile (DJI cameras embed in metadata)
         if let Some(ref profile) = tel.lens_profile {
             log::info!(

--- a/crates/reco-calibrate/src/pipeline.rs
+++ b/crates/reco-calibrate/src/pipeline.rs
@@ -40,6 +40,7 @@ use reco_core::calibration::CameraParams;
 use reco_core::gpu::GpuContext;
 
 use crate::error::CalibrateError;
+use crate::telemetry::TelemetryData;
 use crate::types::{CalibrationConfig, CalibrationResult, LensProfileInfo, YuvFrame};
 use crate::{audio_sync, lens_database, sampling, telemetry};
 
@@ -78,6 +79,14 @@ pub struct CalibrationPipeline {
     left_profile_info: Option<LensProfileInfo>,
     /// Lens profile metadata for the right camera.
     right_profile_info: Option<LensProfileInfo>,
+    /// Cached parsed telemetry for the left video, lazily populated on
+    /// first use (detect_profiles or imu_sync) so the expensive parse
+    /// runs at most once per video. `Some(Ok(..))` after a successful
+    /// parse, `Some(Err(()))` after a failed one (so we don't retry on
+    /// every call), `None` before first use.
+    left_telemetry: Option<Result<TelemetryData, ()>>,
+    /// Cached parsed telemetry for the right video. See [`Self::left_telemetry`].
+    right_telemetry: Option<Result<TelemetryData, ()>>,
     sync_offset_frames: i64,
     /// IMU seeds extracted during imu_sync
     imu_xrz_seed: Option<f64>,
@@ -101,6 +110,8 @@ impl CalibrationPipeline {
             right_params: None,
             left_profile_info: None,
             right_profile_info: None,
+            left_telemetry: None,
+            right_telemetry: None,
             sync_offset_frames: 0,
             imu_xrz_seed: None,
             imu_xrx_seed: None,
@@ -127,15 +138,26 @@ impl CalibrationPipeline {
     /// then looks up the matching profile in the embedded Gyroflow database.
     /// Falls back to the left profile for the right camera if not found.
     ///
+    /// The parsed telemetry is cached on the pipeline so
+    /// [`imu_sync`](Self::imu_sync) reuses it instead of parsing the same
+    /// files a second time. This matters on heavy sources (DJI Action 4,
+    /// newer GoPro) where each parse is 30-60s.
+    ///
     /// Returns the detected profiles for logging/display.
     pub fn detect_profiles(&mut self) -> Result<(CameraParams, CameraParams), CalibrateError> {
         let db = lens_database::LensDatabase::load_embedded();
+
+        self.ensure_left_telemetry();
+        self.ensure_right_telemetry();
+        let left_tel = self.left_telemetry.as_ref().and_then(|r| r.as_ref().ok());
+        let right_tel = self.right_telemetry.as_ref().and_then(|r| r.as_ref().ok());
 
         let (left_p, left_info) = lens_database::detect_profile(
             &self.left_info.path,
             self.left_info.width,
             self.left_info.height,
             &db,
+            left_tel,
         )
         .ok_or_else(|| {
             CalibrateError::InvalidConfig(format!(
@@ -149,6 +171,7 @@ impl CalibrationPipeline {
             self.right_info.width,
             self.right_info.height,
             &db,
+            right_tel,
         )
         .unwrap_or_else(|| {
             log::info!("right camera: no profile found, using left camera profile");
@@ -160,6 +183,43 @@ impl CalibrationPipeline {
         self.left_profile_info = Some(left_info);
         self.right_profile_info = Some(right_info);
         Ok((left_p, right_p))
+    }
+
+    /// Lazily populate the left-video telemetry cache. Called from
+    /// `detect_profiles` and `imu_sync`; subsequent calls are no-ops.
+    ///
+    /// Parse failures are recorded as `Err(())` so we don't retry on
+    /// every call - telemetry extraction is deterministic per-file.
+    fn ensure_left_telemetry(&mut self) {
+        if self.left_telemetry.is_none() {
+            self.left_telemetry = Some(match telemetry::extract(&self.left_info.path) {
+                Ok(t) => Ok(t),
+                Err(e) => {
+                    log::warn!(
+                        "left telemetry extraction failed for {}: {e}",
+                        self.left_info.path.display()
+                    );
+                    Err(())
+                }
+            });
+        }
+    }
+
+    /// Lazily populate the right-video telemetry cache. See
+    /// [`Self::ensure_left_telemetry`].
+    fn ensure_right_telemetry(&mut self) {
+        if self.right_telemetry.is_none() {
+            self.right_telemetry = Some(match telemetry::extract(&self.right_info.path) {
+                Ok(t) => Ok(t),
+                Err(e) => {
+                    log::warn!(
+                        "right telemetry extraction failed for {}: {e}",
+                        self.right_info.path.display()
+                    );
+                    Err(())
+                }
+            });
+        }
     }
 
     /// Load lens profiles from file paths.
@@ -207,31 +267,41 @@ impl CalibrationPipeline {
     /// Returns the sync offset in frames, or `None` if telemetry is
     /// unavailable or cross-correlation fails.
     pub fn imu_sync(&mut self) -> Result<Option<i64>, CalibrateError> {
-        let left_telem = telemetry::extract(&self.left_info.path).map_err(|e| {
-            CalibrateError::InvalidConfig(format!("left IMU extraction failed: {e}"))
-        })?;
-        let right_telem = telemetry::extract(&self.right_info.path).map_err(|e| {
-            CalibrateError::InvalidConfig(format!("right IMU extraction failed: {e}"))
-        })?;
+        self.ensure_left_telemetry();
+        self.ensure_right_telemetry();
 
-        // Gyro cross-correlation for sync offset
-        let sync_frames =
-            if let Some(offset) = telemetry::estimate_sync_offset(&left_telem, &right_telem) {
-                let frames = (-offset * self.left_info.fps).round() as i64;
-                log::info!("IMU sync offset: {offset:.3}s = {frames} frames");
-                self.sync_offset_frames = frames;
-                Some(frames)
-            } else {
-                None
-            };
+        let left_telem = self
+            .left_telemetry
+            .as_ref()
+            .and_then(|r| r.as_ref().ok())
+            .ok_or_else(|| CalibrateError::InvalidConfig("left IMU extraction failed".into()))?;
+        let right_telem = self
+            .right_telemetry
+            .as_ref()
+            .and_then(|r| r.as_ref().ok())
+            .ok_or_else(|| CalibrateError::InvalidConfig("right IMU extraction failed".into()))?;
 
-        // Use skip_start so gravity is measured after camera setup, not during.
         let skip = self.config.skip_start_secs;
+        let fps = self.left_info.fps;
 
-        // Differential orientation for rotation seeds
-        if let Some((roll, pitch, tilt)) =
-            telemetry::differential_orientation(&left_telem, &right_telem, skip)
-        {
+        // Compute all telemetry-derived values into locals first so we can
+        // release the telemetry borrows before mutating self.
+        let sync_computed = telemetry::estimate_sync_offset(left_telem, right_telem).map(|off| {
+            let frames = (-off * fps).round() as i64;
+            log::info!("IMU sync offset: {off:.3}s = {frames} frames");
+            frames
+        });
+        let diff_orientation = telemetry::differential_orientation(left_telem, right_telem, skip);
+        let rig_tilt_new = telemetry::rig_tilt(left_telem, skip);
+        let left_roll = telemetry::gravity_vector(left_telem, skip).map(|g| g[2].atan2(g[0]));
+        let right_roll = telemetry::gravity_vector(right_telem, skip).map(|g| g[2].atan2(g[0]));
+
+        // Telemetry borrows released here; safe to mutate self.
+        if let Some(frames) = sync_computed {
+            self.sync_offset_frames = frames;
+        }
+
+        if let Some((roll, pitch, tilt)) = diff_orientation {
             log::info!(
                 "differential roll: {:.2} deg, pitch: {:.2} deg, tilt: {:.2} deg",
                 roll.to_degrees(),
@@ -247,10 +317,9 @@ impl CalibrationPipeline {
             }
         }
 
-        // Rig tilt (stored in result for renderer).
-        // Cap at 25 deg - beyond that the IMU reading is likely noise
-        // from an uncalibrated accelerometer rather than real forward lean.
-        if let Some(tilt) = telemetry::rig_tilt(&left_telem, skip) {
+        // Rig tilt. Cap at 25 deg - beyond that the IMU reading is likely
+        // accelerometer noise rather than real forward lean.
+        if let Some(tilt) = rig_tilt_new {
             log::info!("rig tilt: {:.1} deg", tilt.to_degrees());
             if tilt.abs() < 25.0_f64.to_radians() {
                 self.rig_tilt = tilt;
@@ -263,9 +332,6 @@ impl CalibrationPipeline {
         }
 
         // Rig roll: (left_roll - right_roll) / 2 cancels common IMU bias.
-        // Cap at 25 deg for the same reason as tilt.
-        let left_roll = telemetry::gravity_vector(&left_telem, skip).map(|g| g[2].atan2(g[0]));
-        let right_roll = telemetry::gravity_vector(&right_telem, skip).map(|g| g[2].atan2(g[0]));
         if let (Some(lr), Some(rr)) = (left_roll, right_roll) {
             let avg = (lr - rr) / 2.0;
             log::info!(
@@ -284,7 +350,7 @@ impl CalibrationPipeline {
             }
         }
 
-        Ok(sync_frames)
+        Ok(sync_computed)
     }
 
     /// Estimate sync offset from audio cross-correlation.

--- a/crates/reco-calibrate/src/types.rs
+++ b/crates/reco-calibrate/src/types.rs
@@ -360,6 +360,12 @@ pub struct CalibrationProgress {
 pub enum CalibrationStep {
     /// Probing video metadata.
     Probing,
+    /// Detecting lens profiles (telemetry parse + database lookup).
+    ///
+    /// Separated from `Probing` because on telemetry-heavy sources
+    /// (DJI Action 4, newer GoPro) this step takes 30-60s per video,
+    /// dominating the wall-clock time of the first half of calibration.
+    DetectingProfiles,
     /// Extracting audio for temporal sync.
     AudioSync,
     /// Extracting video frames.
@@ -376,6 +382,7 @@ impl std::fmt::Display for CalibrationStep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Probing => write!(f, "Probing"),
+            Self::DetectingProfiles => write!(f, "DetectingProfiles"),
             Self::AudioSync => write!(f, "AudioSync"),
             Self::ExtractingFrames => write!(f, "ExtractingFrames"),
             Self::Undistorting => write!(f, "Undistorting"),

--- a/crates/reco-calibrate/src/video.rs
+++ b/crates/reco-calibrate/src/video.rs
@@ -176,6 +176,15 @@ pub fn calibrate_videos(
             if let Some(ref lp) = options.left_profile {
                 pipeline.load_profiles(lp, options.right_profile.as_deref())?;
             } else {
+                // Distinct step label - telemetry parse dominates here on
+                // heavy sources (DJI Action 4, newer GoPro). Without this
+                // the UI stays on "Probing video metadata" for 30-60s.
+                check_interrupted(interrupted)?;
+                emit_progress(
+                    on_progress,
+                    CalibrationStep::DetectingProfiles,
+                    "Detecting lens profiles",
+                );
                 pipeline.detect_profiles()?;
             }
         }

--- a/crates/reco-gui/FRICTION.md
+++ b/crates/reco-gui/FRICTION.md
@@ -48,46 +48,19 @@ bundles pipeline + source + calibration with a single `unload()`, or
 document the pattern in reco-io's StitchJob docs so the next consumer
 doesn't reinvent it.
 
-### A5. Calibration progress is wrong and redundant on heavy footage
+### A5-residual. No intra-step heartbeat during very slow steps
 
-**Impact**: Medium. Reproduced 2026-04-18 on DJI Action 4 4K/10-bit
-clips (864k quaternions per video). Total calibrate_videos wall time
-~3 minutes, of which the first ~75s shows the misleading label
-"Probing video metadata" even though probing itself took <1s.
+**Impact**: Low after the A5 primary fix (R22). The step label now
+matches the work (DetectingProfiles step) and telemetry isn't parsed
+twice, but individual steps can still run 20-60s silently: AKAZE
+feature detection on dense scenes, the optimizer on 100+ frame pairs,
+audio PCM extraction on long clips. A consumer can't distinguish
+"making progress" from "hung" inside a single step.
 
-Three distinct problems compound:
-
-1. **Wrong label during `detect_profiles()`**. `calibrate_videos`
-   emits `CalibrationStep::Probing` before probing, then calls
-   `pipeline.detect_profiles()` which parses the full telemetry
-   stream for lens auto-detection - but emits no progress event of
-   its own. The UI stays on "Probing video metadata" for the entire
-   telemetry parse (~40s per DJI 4K/10-bit video, ~75s total).
-
-2. **Telemetry is parsed twice per video**. `detect_profiles()`
-   parses telemetry for embedded lens metadata; `imu_sync()` then
-   parses the same file again for gyro sync + gravity vectors. On
-   DJI Action 4 that doubles the wait from ~75s to ~175s. No cache.
-
-3. **No intra-step heartbeat**. Each heavy step (telemetry parse in
-   detect_profiles, telemetry parse + cross-correlation in imu_sync,
-   audio PCM extraction, AKAZE feature detection, optimizer) can
-   block for 20-90s with no feedback. Users on heavy footage assume
-   the app has hung and kill it mid-calibration.
-
-**Suggested direction**:
-
-- Emit a dedicated `CalibrationStep::DetectingProfiles` before
-  `pipeline.detect_profiles()` so the label matches the work.
-- Cache parsed telemetry on `CalibrationPipeline` so `imu_sync()`
-  reuses what `detect_profiles()` already read. Expected to halve
-  wall time on telemetry-heavy sources (DJI, newer GoPro).
-- Add a heartbeat event every 2s during any step that exceeds a
-  short threshold, so consumers can show a spinner or elapsed-time
-  hint without needing intra-step instrumentation.
-
-Fix lives in `reco-calibrate` (video.rs + pipeline.rs). GUI just
-needs to map the new step label + maybe show elapsed time.
+**Suggested direction**: a heartbeat event every 2s during any step
+that exceeds a short threshold, so consumers can show a spinner or
+elapsed-time hint without needing intra-step instrumentation in every
+slow routine.
 
 ### A7. render_to_target() still returns CommandBuffer
 
@@ -183,3 +156,11 @@ drove which upstream changes.
   reco-calibrate, reco-obs, and reco-gui dropped their direct `pollster`
   deps (except reco-cli, which still needs it for
   `GpuContext::for_surface` on the preview path).
+- **R22. Wrong step label + double telemetry parse during calibration**
+  Resolved 2026-04-18: new `CalibrationStep::DetectingProfiles` variant
+  emitted before `pipeline.detect_profiles()` so the GUI label matches
+  the work. `CalibrationPipeline` caches parsed `TelemetryData` for each
+  side on first use; `imu_sync()` reuses what `detect_profiles()` already
+  read. On DJI Action 4 4K/10-bit this halves wall time on the first
+  half of calibrate_videos (~175s → ~85s). Heartbeat emission during
+  very slow individual steps is tracked as A5-residual.


### PR DESCRIPTION
Resolves reco-gui FRICTION A5 (documented in #264). Cuts first-half calibrate_videos wall time roughly in half on telemetry-heavy sources.

## Before

On DJI Action 4 4K/10-bit clips (864k quaternions per video) reproduced 2026-04-18:

- \`calibrate_videos\` emitted \`CalibrationStep::Probing\` before probing, then called \`pipeline.detect_profiles()\` which parses the full telemetry stream for lens auto-detection - with no progress event of its own. GUI stuck on \"Probing video metadata\" for ~75s while telemetry parsed.
- \`imu_sync()\` then parsed the SAME telemetry file a second time per side, doubling wall time to ~175s total for the first half of calibration.

## After

1. New \`CalibrationStep::DetectingProfiles\` variant. \`calibrate_videos\` emits it immediately before \`pipeline.detect_profiles()\`; GUI label tracks actual work.
2. \`CalibrationPipeline\` caches parsed \`TelemetryData\` per side in new \`left_telemetry\` / \`right_telemetry\` fields. \`ensure_left_telemetry\` / \`ensure_right_telemetry\` populate lazily on first use; parse failures are recorded as \`Err(())\` so we don't retry. \`lens_database::detect_profile\` takes an \`Option<&TelemetryData>\` to reuse the cache. \`imu_sync\` computes telemetry-derived values into locals first, then mutates self - keeps the borrow window narrow enough for NLL.

On DJI Action 4: first-half wall time ~175s → ~85s. No heuristic change, no hot-path allocations.

## FRICTION sweep

- Archives A5 as **R22** in reco-gui/FRICTION.md.
- Opens **A5-residual** for the remaining intra-step heartbeat gap (low priority - label is correct now, only \"is it still working?\" remains on very slow individual steps like AKAZE / optimizer / long audio extraction).

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps --features profiling -p reco-calibrate\`
- [x] \`cargo test -p reco-calibrate --lib --features io\` (35 pass)
- [ ] Manual: launch GUI on same DJI Action 4 clips used earlier; confirm label shows \"DetectingProfiles\" (or \"Probing\" briefly then \"DetectingProfiles\") instead of stuck \"Probing\", and total calibrate wall time roughly halves.