### PR TITLE
feat(reco-obs): Tier 1 - real dual-source frame ingestion (I420)

### DIFF
--- a/crates/reco-core/src/pipeline.rs
+++ b/crates/reco-core/src/pipeline.rs
@@ -711,7 +711,7 @@ impl StitchPipeline {
     /// Expects each plane as `width * height * 4` bytes in (R, G, B, A) byte
     /// order. Use [`BgraPlanes::from_bgra_swizzle_into`] when the source
     /// is BGRA. Requires the pipeline to be initialized with
-    /// [`InputFormat::Bgra`](crate::renderer::InputFormat::Bgra).
+    /// [`InputFormat::Bgra`](crate::renderer::InputFormat#variant.Bgra).
     #[cfg_attr(
         feature = "profiling",
         tracing::instrument(skip_all, name = "render_to_target_bgra")

--- a/crates/reco-core/src/pipeline.rs
+++ b/crates/reco-core/src/pipeline.rs
@@ -140,6 +140,47 @@ pub struct Nv12Planes<'a> {
     pub uv: &'a [u8],
 }
 
+/// Borrowed packed BGRA/RGBA plane for pipeline input.
+///
+/// Tightly packed, 4 bytes per pixel in (R, G, B, A) byte order - the
+/// shader samples `rgba.rgb` directly, so callers with BGRA data need
+/// to swizzle bytes at upload time (see
+/// [`BgraPlanes::from_bgra_swizzle_into`]). Used for OBS Browser
+/// Source, screen capture, WebRTC ingest, and any other consumer whose
+/// source frames are already sRGB-domain.
+pub struct BgraPlanes<'a> {
+    /// Packed RGBA bytes, length `width * height * 4`.
+    pub rgba: &'a [u8],
+}
+
+impl<'a> BgraPlanes<'a> {
+    /// Wrap an already-RGBA byte slice without copying.
+    ///
+    /// Length must be exactly `width * height * 4`; callers are expected
+    /// to match the dimensions the pipeline was constructed with.
+    pub fn from_rgba(rgba: &'a [u8]) -> Self {
+        Self { rgba }
+    }
+
+    /// Swizzle a BGRA-ordered source into a caller-owned `Vec<u8>` and
+    /// return a [`BgraPlanes`] borrowing from it.
+    ///
+    /// OBS and most desktop compositors deliver BGRA; the shader expects
+    /// RGBA, so this helper performs the cheap byte-reorder once per
+    /// frame. Cache the buffer across frames to avoid per-frame
+    /// allocation (the helper `resize`s in place).
+    pub fn from_bgra_swizzle_into(bgra: &[u8], buffer: &'a mut Vec<u8>) -> Self {
+        buffer.resize(bgra.len(), 0);
+        for (src, dst) in bgra.chunks_exact(4).zip(buffer.chunks_exact_mut(4)) {
+            dst[0] = src[2]; // R <- B
+            dst[1] = src[1]; // G
+            dst[2] = src[0]; // B <- R
+            dst[3] = src[3]; // A
+        }
+        Self { rgba: buffer }
+    }
+}
+
 /// Errors from the stitch pipeline.
 #[derive(Debug, Error)]
 pub enum PipelineError {
@@ -646,6 +687,44 @@ impl StitchPipeline {
         self.renderer.upload_left_nv12(&self.gpu, left.y, left.uv)?;
         self.renderer
             .upload_right_nv12(&self.gpu, right.y, right.uv)?;
+
+        let viewport = ResolvedViewport {
+            config: self.viewport.clone(),
+            position: ViewportPosition {
+                yaw,
+                pitch,
+                fov_degrees: None,
+            },
+        };
+
+        Ok(self.renderer.render_to_target(
+            &self.gpu,
+            &self.scene,
+            &self.calibration,
+            &viewport,
+            self.viewport.blend_width,
+        ))
+    }
+
+    /// Upload packed BGRA/RGBA frames and render to the internal target.
+    ///
+    /// Expects each plane as `width * height * 4` bytes in (R, G, B, A) byte
+    /// order. Use [`BgraPlanes::from_bgra_swizzle_into`] when the source
+    /// is BGRA. Requires the pipeline to be initialized with
+    /// [`InputFormat::Bgra`](crate::renderer::InputFormat::Bgra).
+    #[cfg_attr(
+        feature = "profiling",
+        tracing::instrument(skip_all, name = "render_to_target_bgra")
+    )]
+    pub fn render_to_target_bgra(
+        &self,
+        left: &BgraPlanes<'_>,
+        right: &BgraPlanes<'_>,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<wgpu::CommandBuffer, PipelineError> {
+        self.renderer.upload_left_bgra(&self.gpu, left.rgba)?;
+        self.renderer.upload_right_bgra(&self.gpu, right.rgba)?;
 
         let viewport = ResolvedViewport {
             config: self.viewport.clone(),

--- a/crates/reco-core/src/renderer.rs
+++ b/crates/reco-core/src/renderer.rs
@@ -155,8 +155,15 @@ pub enum InputFormat {
     /// Used with software decode or CPU-side conversion.
     Yuv420p,
     /// NV12: Y as R8 (full-res) + interleaved UV as Rg8 (half-res).
-    /// NVDEC native output format. V texture is a 1×1 dummy.
+    /// NVDEC native output format. V texture is a 1x1 dummy.
     Nv12,
+    /// Packed BGRA / RGBA: a single `Rgba8Unorm` texture at full resolution
+    /// holding pre-composited sRGB-domain RGB. Used by OBS Browser Source,
+    /// screen capture, WebRTC ingest, and other non-camera sources whose
+    /// native format is already RGB. The shader samples the single plane
+    /// and writes the RGB triple straight out (no YUV conversion).
+    /// `u_texture` / `v_texture` are 1x1 dummies in this mode.
+    Bgra,
 }
 
 /// GPU-side pixel format for NV12-family zero-copy decode output.
@@ -445,8 +452,17 @@ impl Renderer {
             })
         };
 
-        // Y plane is always R8Unorm at full resolution
-        let y_texture = create_texture("y", width, height, wgpu::TextureFormat::R8Unorm);
+        // Y plane format + u/v plane selection depend on input format.
+        // For Bgra the "Y" slot actually holds a full-res Rgba8Unorm texture;
+        // u/v are 1x1 dummies that the shader never samples.
+        let y_texture = match input_format {
+            InputFormat::Yuv420p | InputFormat::Nv12 => {
+                create_texture("y", width, height, wgpu::TextureFormat::R8Unorm)
+            }
+            InputFormat::Bgra => {
+                create_texture("rgba", width, height, wgpu::TextureFormat::Rgba8Unorm)
+            }
+        };
 
         let (u_texture, v_texture) = match input_format {
             InputFormat::Yuv420p => {
@@ -458,9 +474,16 @@ impl Renderer {
             InputFormat::Nv12 => {
                 // NV12: interleaved UV as Rg8Unorm at half resolution
                 let uv = create_texture("uv", width / 2, height / 2, wgpu::TextureFormat::Rg8Unorm);
-                // Dummy V texture — shader won't sample it in NV12 mode
+                // Dummy V texture - shader won't sample it in NV12 mode
                 let v_dummy = create_texture("v_dummy", 1, 1, wgpu::TextureFormat::R8Unorm);
                 (uv, v_dummy)
+            }
+            InputFormat::Bgra => {
+                // Shader skips u/v sampling on the Bgra path; 1x1 dummies
+                // satisfy the bind group layout without wasting memory.
+                let u_dummy = create_texture("u_dummy", 1, 1, wgpu::TextureFormat::R8Unorm);
+                let v_dummy = create_texture("v_dummy", 1, 1, wgpu::TextureFormat::R8Unorm);
+                (u_dummy, v_dummy)
             }
         };
 
@@ -580,6 +603,31 @@ impl Renderer {
             "upload_right_nv12 requires InputFormat::Nv12"
         );
         upload_nv12(gpu, &self.right, y, uv)
+    }
+
+    /// Upload a packed BGRA/RGBA plane to the left camera texture.
+    ///
+    /// Data must be `width * height * 4` bytes in (R, G, B, A) byte order.
+    /// Upload-side swizzling translates BGRA sources before calling this -
+    /// see [`pipeline::BgraPlanes`](crate::pipeline::BgraPlanes).
+    pub fn upload_left_bgra(&self, gpu: &GpuContext, rgba: &[u8]) -> Result<(), RenderError> {
+        debug_assert_eq!(
+            self.input_format,
+            InputFormat::Bgra,
+            "upload_left_bgra requires InputFormat::Bgra"
+        );
+        upload_bgra(gpu, &self.left, rgba)
+    }
+
+    /// Upload a packed BGRA/RGBA plane to the right camera texture.
+    /// See [`Self::upload_left_bgra`].
+    pub fn upload_right_bgra(&self, gpu: &GpuContext, rgba: &[u8]) -> Result<(), RenderError> {
+        debug_assert_eq!(
+            self.input_format,
+            InputFormat::Bgra,
+            "upload_right_bgra requires InputFormat::Bgra"
+        );
+        upload_bgra(gpu, &self.right, rgba)
     }
 
     /// Create a texture bind group from external textures.
@@ -818,6 +866,43 @@ impl Renderer {
 
 // ---- Helper functions ----
 
+/// Upload a packed RGBA plane (4 bytes per pixel) to a GPU texture.
+///
+/// Expects `width * height * 4` bytes in (R, G, B, A) order.
+/// Callers with BGRA source data need to swizzle to RGBA before
+/// this call - the shader samples `rgba.rgb` directly.
+fn upload_bgra(gpu: &GpuContext, plane: &PlaneResources, rgba: &[u8]) -> Result<(), RenderError> {
+    let w = plane.width;
+    let h = plane.height;
+    let expected = (w * h * 4) as usize;
+    if rgba.len() != expected {
+        return Err(RenderError::FrameSizeMismatch {
+            expected,
+            actual: rgba.len(),
+        });
+    }
+    gpu.queue.write_texture(
+        wgpu::TexelCopyTextureInfo {
+            texture: &plane.y_texture,
+            mip_level: 0,
+            origin: wgpu::Origin3d::ZERO,
+            aspect: wgpu::TextureAspect::All,
+        },
+        rgba,
+        wgpu::TexelCopyBufferLayout {
+            offset: 0,
+            bytes_per_row: Some(w * 4),
+            rows_per_image: Some(h),
+        },
+        wgpu::Extent3d {
+            width: w,
+            height: h,
+            depth_or_array_layers: 1,
+        },
+    );
+    Ok(())
+}
+
 /// Upload a single R8Unorm plane to a GPU texture.
 fn upload_plane(gpu: &GpuContext, texture: &wgpu::Texture, data: &[u8], width: u32, height: u32) {
     gpu.queue.write_texture(
@@ -1023,7 +1108,11 @@ pub(crate) fn build_gpu_uniforms(
         color_offset_blend: [0.0, 0.0, 0.0, blend_width],
         flags: [
             is_right as u32,
-            (input_format == InputFormat::Nv12) as u32,
+            match input_format {
+                InputFormat::Yuv420p => 0,
+                InputFormat::Nv12 => 1,
+                InputFormat::Bgra => 2,
+            },
             flip_180 as u32,
             0,
         ],

--- a/crates/reco-core/src/session/live.rs
+++ b/crates/reco-core/src/session/live.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 
 use crate::calibration::MatchCalibration;
 use crate::gpu::GpuContext;
-use crate::pipeline::{PipelineError, StitchPipeline, YuvPlanes};
+use crate::pipeline::{BgraPlanes, PipelineError, StitchPipeline, YuvPlanes};
 use crate::renderer::InputFormat;
 use crate::rgba_readback::{RgbaReadback, RgbaReadbackError};
 use crate::viewport::ViewportConfig;
@@ -120,6 +120,31 @@ impl LiveStitchSession {
         pitch: f32,
     ) -> Result<Option<&[u8]>, LiveSessionError> {
         let cmd = self.pipeline.render_to_target(left, right, yaw, pitch)?;
+        let rgba =
+            self.readback
+                .readback(self.pipeline.gpu(), self.pipeline.render_target(), cmd)?;
+        Ok(rgba)
+    }
+
+    /// Submit a stereo packed RGBA/BGRA frame and request an RGBA render.
+    ///
+    /// Like [`Self::submit_frame`] but for packed-RGB consumers (OBS
+    /// Browser Source, screen capture, WebRTC ingest). Requires the
+    /// session to have been built with [`InputFormat::Bgra`].
+    ///
+    /// `yaw` and `pitch` are in radians. The returned slice, when
+    /// `Some`, holds `output_width * output_height * 4` bytes of tight
+    /// RGBA valid until the next `submit_*` call.
+    pub fn submit_frame_bgra(
+        &mut self,
+        left: &BgraPlanes<'_>,
+        right: &BgraPlanes<'_>,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Option<&[u8]>, LiveSessionError> {
+        let cmd = self
+            .pipeline
+            .render_to_target_bgra(left, right, yaw, pitch)?;
         let rgba =
             self.readback
                 .readback(self.pipeline.gpu(), self.pipeline.render_target(), cmd)?;

--- a/crates/reco-core/src/shaders/fisheye.wgsl
+++ b/crates/reco-core/src/shaders/fisheye.wgsl
@@ -19,7 +19,8 @@ struct Uniforms {
     // YUV color transfer: offset.xyz (Y, U, V), blend_width
     color_offset_blend: vec4<f32>,
     // flags.x: is_right (0 or 1)
-    // flags.y: use_nv12 (0 = YUV420P: separate U,V textures; 1 = NV12: interleaved UV in t_u)
+    // flags.y: input_format (0 = YUV420P: separate U,V textures; 1 = NV12: interleaved UV
+    //          in t_u; 2 = BGRA/RGBA: t_y holds packed 4-channel RGB, skip YUV conversion)
     // flags.z: flip_180 (0 or 1) - flip UV coordinates for 180-degree rotation
     //          Used by the GPU zero-copy path where buffer reversal is not possible.
     // flags.w: reserved
@@ -88,22 +89,32 @@ fn apply_color_transfer(rgb: vec3<f32>, scale: vec3<f32>, offset: vec3<f32>) -> 
 
 // ---- YUV → RGB conversion ----
 
-/// Sample YUV textures and convert to linear RGB via BT.709.
+/// Sample the input plane(s) and return an sRGB-domain RGB triple.
 ///
-/// Supports two input layouts (selected by `u.flags.y`):
-///   0 = YUV420P: separate R8 textures for Y, U, V (software decode)
-///   1 = NV12: R8 Y texture + Rg8 UV texture with interleaved U,V (NVDEC)
+/// Supports three input layouts (selected by `u.flags.y`):
+///   0 = YUV420P: separate R8 textures for Y, U, V (software decode).
+///   1 = NV12: R8 Y texture + Rg8 UV texture with interleaved U,V (NVDEC).
+///   2 = BGRA/RGBA: t_y is an `Rgba8Unorm` texture holding packed RGB
+///       (source already sRGB-domain, skip YUV conversion).
 ///
-/// H.264 uses limited range (Y: 16–235, Cb/Cr: 16–240).
-/// After the BT.709 matrix, we get sRGB-like gamma values, which
-/// we linearize with srgb_to_linear to match the Rgba8UnormSrgb
-/// auto-decode path (identical visual output to the old RGBA upload).
+/// H.264 uses limited range (Y: 16-235, Cb/Cr: 16-240). After the
+/// BT.709 matrix we get sRGB-domain values which we write as-is to
+/// the `Rgba8Unorm` render target.
 fn sample_yuv(uv: vec2<f32>) -> vec4<f32> {
     // Apply 180-degree rotation for the GPU zero-copy path.
     // The CPU path reverses buffers in software; the GPU path flips UV coords instead.
     var sample_uv = uv;
     if u.flags.z == 1u {
         sample_uv = vec2<f32>(1.0 - uv.x, 1.0 - uv.y);
+    }
+
+    // BGRA / RGBA packed path: sample the full RGB triple in one fetch
+    // and return without YUV conversion. The upload side is responsible
+    // for delivering the triple in (R, G, B) order - swizzling BGRA is
+    // handled at upload time so the shader only sees R-in-red.
+    if u.flags.y == 2u {
+        let rgba = textureSample(t_y, s_video, sample_uv);
+        return vec4<f32>(rgba.rgb, 1.0);
     }
 
     let y_raw = textureSample(t_y, s_video, sample_uv).r;
@@ -122,7 +133,7 @@ fn sample_yuv(uv: vec2<f32>) -> vec4<f32> {
         v_raw = textureSample(t_v, s_video, sample_uv).r;
     }
 
-    // BT.709 limited-range YCbCr → full-range R'G'B'
+    // BT.709 limited-range YCbCr -> full-range R'G'B'
     let y = (y_raw - 16.0 / 255.0) * (255.0 / 219.0);
     let cb = (u_raw - 128.0 / 255.0) * (255.0 / 224.0);
     let cr = (v_raw - 128.0 / 255.0) * (255.0 / 224.0);
@@ -132,7 +143,7 @@ fn sample_yuv(uv: vec2<f32>) -> vec4<f32> {
     let b = y + 1.8556 * cb;
 
     let rgb = clamp(vec3<f32>(r, g, b), vec3<f32>(0.0), vec3<f32>(1.0));
-    // BT.709 YCbCr→R'G'B' produces sRGB-domain values directly.
+    // BT.709 YCbCr->R'G'B' produces sRGB-domain values directly.
     // Render target is Rgba8Unorm, so we write sRGB values as-is.
     return vec4<f32>(rgb, 1.0);
 }

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -195,6 +195,122 @@ Documenting here so the next person hitting this has an immediate
 answer; the pure-UX fix is small but OBS scene-graph walking is
 fiddly so it's backlog, not urgent.
 
+### A12. No keyboard / controller mapping for pan-zoom
+
+**Impact**: Medium. Drag-to-pan and scroll-to-zoom work in OBS
+"Interact" mode, but that requires opening a separate interact
+window every session. Live operators using a keyboard, or game-pad
+operators with a PS5/Xbox controller, have no fast path.
+
+**Suggested direction**:
+
+- **Keyboard (short-term)**: use OBS's `obs_hotkey_register_source`
+  API to declare hotkeys on the Reco source (yaw_left,
+  yaw_right, pitch_up, pitch_down, zoom_in, zoom_out, reset).
+  Users bind them in File -> Settings -> Hotkeys. Requires new FFI
+  bindings for the hotkey registration API; ~1 hour of work.
+- **Game pad (medium-term)**: OBS does not expose controller input
+  directly. Options: (a) a sidecar process using SDL3 that reads
+  controller axes and sends them to the plugin via a Unix socket /
+  named pipe; (b) use a general-purpose virtual-joystick-to-keyboard
+  utility (QJoyPad, antimicro) and bind to the hotkeys from path
+  (a). Plan to document the SDL3 sidecar approach in a separate
+  PR so game-pad support is reproducible.
+
+### A13. No "constrained look" toggle in the OBS plugin
+
+**Impact**: Medium. `reco_core::projection::CoverageBoundary::safe_clamp`
+exists (it's used by the GUI's constrained-look toggle, Tier 2b) but
+the OBS plugin applies raw yaw/pitch straight to the renderer. At
+extreme pan angles the view shows black borders outside the stitched
+coverage.
+
+**Suggested direction**: add a `constrained_look: bool` property to
+reco-obs, default true. When set, `render_and_readback` should clamp
+yaw/pitch via `CoverageBoundary::safe_clamp(yaw, pitch, fov, aspect,
+rig_tilt)` before passing to `submit_frame`. The calibration file
+already carries the boundary definition - just need to expose the
+clamp function through `LiveStitchSession` or plumb it at the
+reco-obs layer. Small: ~30 min including property wiring.
+
+### A14. No live calibration workflow for non-file sources
+
+**Impact**: High for production live use. The current calibration
+path (`reco_calibrate::video::calibrate_videos`) requires two video
+*files* on disk. For live OBS sources (V4L2 cameras, NDI, WebRTC)
+there's no equivalent that captures from a live source to produce
+calibration JSON.
+
+**Suggested direction** (reco-calibrate + reco-obs):
+
+- reco-calibrate already exposes the lower-level
+  `calibrate(&gpu, &frame_pairs)` that takes in-memory frame pairs -
+  the algorithmic side is ready.
+- New reco-io helper: a "capture N frame pairs from two live
+  FrameSources" utility that wraps the `StereoFrame` delivery and
+  hands back `Vec<(YuvFrame, YuvFrame)>`.
+- reco-obs UI: a "Calibrate from current sources" button in the
+  properties that grabs ~30 frame pairs from the picked async
+  sources via our existing `obs_source_get_frame` loop, feeds to
+  `calibrate()`, writes the JSON next to the configured calibration
+  path, then reloads.
+
+Estimated 3-4 hours of work across the two crates.
+
+### A15. OBS Interact window is a poor primary UX
+
+**Impact**: Medium. Users expect to pan the panorama in the main
+scene view, not a separate interact window that must be kept open.
+OBS's interaction model is designed for web source clicks, not
+continuous compositor control.
+
+**Suggested direction**: the nicer shape is an embedded dock panel
+(like Transition Override, Scene Filters) that gives a dedicated
+control surface: yaw / pitch sliders with live preview, FOV slider,
+constrained-look toggle, detector-status LED, recenter button. OBS
+exposes dock registration via `obs_frontend_add_dock_by_id` (needs
+qt bindings, typically via a small C++ shim). This is substantial
+plumbing work but dramatically better UX than per-property sliders +
+Interact mode.
+
+Alternate short-term: offer a full-screen projector ("Windowed
+Projector (Source)" in OBS, already built in) that shows just our
+panorama, and keep driving the pose via hotkeys (A12).
+
+### A16. No built-in scene / replay mode
+
+**Impact**: Low to medium. Users want to switch scenes to a playback
+view and enable replay instantly - replay isn't a plugin feature
+today, and scene switching is regular OBS behavior but OBS doesn't
+know our plugin's internal ring-buffer state.
+
+**Suggested direction** (two parts):
+
+- **Reco-core**: add an optional "rolling buffer" helper on
+  `LiveStitchSession` - a ring of the last N stitched RGBA frames
+  with timestamps, configurable duration (e.g. "keep last 30s").
+  Memory cost: 1920*1080*4 * 30fps * 30s = ~7 GB, so needs to be
+  opt-in.
+- **Reco-obs**: expose a "Replay mode" toggle + hotkey. When
+  activated, the source's `submit_frame` path switches from "stitch
+  current" to "replay from buffer", advancing the buffer pointer
+  based on wall time (or scrubbable via hotkey). Scene switch
+  orthogonal to this - the user uses standard OBS scene transitions
+  and the source just plays back from the buffer.
+
+Estimated 4-6 hours plus memory-budget discussion.
+
+### A17. No AI auto-pan access in the OBS plugin
+
+See also A10 (deeper architectural notes). Short version: reco-obs
+needs a way to plug in `reco_autocam::Director` + `reco_detect`
+execution. Requires `LiveStitchSession::set_detector` /
+`set_director` hooks in reco-core, then adding
+`reco-autocam` + `reco-detect` as reco-obs deps with a worker-thread
+inference scheduler so the 30fps tick doesn't stall on ORT
+inference. User has flagged AI access as important; worth
+prioritizing once the friction backlog is worked.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -64,6 +64,63 @@ already supports being rebuilt - but the reco-obs callback plumbing
 has to detect the size change and reset cached state (repack
 buffers, OBS texture, etc.). Tier 2 item.
 
+### A9. obs_source_get_frame only sees async video sources
+
+**Impact**: High. Discovered 2026-04-18 while trying to route an OBS
+Browser Source (VDO Ninja) into Tier 1 ingestion.
+
+OBS has two source rendering models:
+
+- **Async video sources** (Media Source / ffmpeg_source, V4L2 Device,
+  NDI, Decklink): produce frames via `obs_source_output_video()`. OBS
+  buffers them and our current ingestion path reads via
+  `obs_source_get_frame()`.
+- **Sync video sources** (Browser Source, Screen Capture, Window
+  Capture, Game Capture, Video Composite): render directly via a
+  `video_render` callback. OBS never buffers their output; there is
+  no async frame queue for `obs_source_get_frame` to pull from.
+
+Tier 1 of reco-obs uses `obs_source_get_frame`, so sync video sources
+are silently invisible - `get_frame` returns NULL forever, our diag
+log shows `submitted=0 missed_*` ticking up indefinitely with no
+warning (it looks healthy but no frames arrive).
+
+**Suggested direction** (reco-obs, not reco-core):
+
+Add a render-to-texture fallback. In `render_and_readback`, after
+`obs_source_get_frame` returns NULL for a slot, render the source to
+our own `gs_texture_t`:
+
+```c
+obs_enter_graphics();
+gs_texture_t *my_tex = /* pre-allocated per side */;
+gs_viewport_push();
+gs_projection_push();
+gs_set_render_target(my_tex, NULL);
+gs_ortho(0.0f, cx, 0.0f, cy, -100.0f, 100.0f);
+gs_clear(GS_CLEAR_COLOR, &zero, 0.0f, 0);
+obs_source_video_render(left_source);
+gs_set_render_target(NULL, NULL);
+gs_projection_pop();
+gs_viewport_pop();
+// download my_tex -> CPU staging -> BgraPlanes (Batch J)
+obs_leave_graphics();
+```
+
+Needs new FFI bindings for `gs_set_render_target`,
+`gs_viewport_push/pop`, `gs_projection_push/pop`, `gs_ortho`,
+`gs_clear`, `obs_source_video_render`, and a GPU-to-CPU texture
+readback path (staging buffer + `gs_stagesurface_map`). ~2-3 hours.
+
+Once implemented, the existing Batch J BGRA path (R5) is what
+consumes the readback, so no further reco-core work needed.
+
+**Workaround for now**: use any async source (Media Source pointed at
+a file, V4L2 camera, NDI input) while sync-source support is on
+backlog. VDO Ninja can also expose a local v4l2loopback virtual
+camera via `v4l2loopback-dkms` + an ffmpeg pipeline - that path is
+async and works with Tier 1 I420 today.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -159,6 +159,42 @@ Consumer side (reco-obs Batch L):
 Estimated ~4-6 hours minimum for a workable v1, plus meaningful
 testing time to validate tracking on real camera pairs.
 
+### A11. Visible upstream sources steal async frames from our poller
+
+**Impact**: High (UX footgun). When an upstream Media Source is
+visible in the scene (eye icon ON), OBS's scene renderer pulls its
+async frames for compositing, and our subsequent
+`obs_source_get_frame` polls return NULL every tick. Hiding the
+upstream with the eye icon (while our `inc_showing` / `inc_active`
+refs keep its decoder running) is what lets frames land in our poll.
+
+Discovered 2026-04-18 after a long debugging session where picking
+Media Sources appeared to do nothing. Toggling their visibility off
+immediately produced `first stitched frame ready` and `submitted`
+counters started growing at 30 fps.
+
+**Suggested direction** (reco-obs, plugin-level): when the user
+picks an upstream source in our properties, automatically hide its
+scene item (if any) via `obs_sceneitem_set_visible(item, false)`.
+Would need new FFI bindings for:
+
+- `obs_source_get_scene` or equivalent (walk scene graph to find the
+  scene item referencing our picked source)
+- `obs_sceneitem_set_visible`
+- Likely `obs_scene_enum_items` to locate the scene item
+
+Undo on `dec_showing` / destroy would be nice but not required - the
+user can toggle visibility back themselves if they move the source
+to a different scene.
+
+Alternate direction: surface a UI hint in the properties dialog
+("Hide upstream sources in the scene panel for correct frame
+capture"), or add a dedicated help string on each dropdown.
+
+Documenting here so the next person hitting this has an immediate
+answer; the pure-UX fix is small but OBS scene-graph walking is
+fiddly so it's backlog, not urgent.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -121,6 +121,44 @@ backlog. VDO Ninja can also expose a local v4l2loopback virtual
 camera via `v4l2loopback-dkms` + an ffmpeg pipeline - that path is
 async and works with Tier 1 I420 today.
 
+### A10. LiveStitchSession doesn't expose director / detector hooks for AI panning
+
+**Impact**: Medium. AI ball-tracking / auto-pan works in `reco-cli
+stitch --model` and in the GUI via `reco_core::session::StitchSession`
+(the file-stitching pull-based path), but `LiveStitchSession` (the
+push path used by reco-obs and any future live consumer) has no API
+to plug in a detector + director.
+
+Manual panning is live in reco-obs via the yaw/pitch property sliders
+(2026-04-18), which gives basic usability, but there's no path to
+"follow the ball automatically" in the OBS plugin today.
+
+**Suggested direction** (reco-core):
+
+Mirror `StitchSession`'s detector/director hooks on
+`LiveStitchSession`:
+
+- `LiveStitchSession::set_detector(Box<dyn Detector>)`
+- `LiveStitchSession::set_director(Box<dyn Director>)`
+- In `submit_frame` / `submit_frame_bgra`: after receiving the frame,
+  run detector -> update director -> use director's `ViewportPosition`
+  for yaw/pitch instead of the caller-provided values (or blend
+  director output with manual offsets).
+
+Consumer side (reco-obs Batch L):
+
+- Add `reco-autocam` + `reco-detect` as deps (plugin binary grows
+  ~30-50 MB with ORT bundled).
+- New properties: "Auto-pan model" (path to .onnx), "Tracking mode"
+  (ball / field), "Detection interval" (every N frames).
+- Run detection on a worker thread (not the video_tick thread) so
+  inference latency doesn't stall frame submission at 30fps+.
+- Expose tracking-quality feedback somehow (overlay? log? status
+  indicator?) so users see why auto-pan landed somewhere.
+
+Estimated ~4-6 hours minimum for a workable v1, plus meaningful
+testing time to validate tracking on real camera pairs.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -64,6 +64,48 @@ already supports being rebuilt - but the reco-obs callback plumbing
 has to detect the size change and reset cached state (repack
 buffers, OBS texture, etc.). Tier 2 item.
 
+### A8. reco-core only accepts YUV input formats (blocks OBS Browser Source, screen capture, WebRTC)
+
+**Impact**: High for live-streaming setups. Hit 2026-04-18 while
+trying to wire an OBS Browser Source (VDO Ninja WebRTC feed) as an
+input for Tier 1 frame ingestion.
+
+`reco_core::renderer::InputFormat` has exactly two variants:
+`Yuv420p` and `Nv12`. Any OBS source whose native format is a packed
+RGB variety delivers frames in `VIDEO_FORMAT_BGRA` /
+`VIDEO_FORMAT_RGBA` / `VIDEO_FORMAT_BGRX`:
+
+- Browser Source (Chromium renders in BGRA)
+- Screen capture / Window capture
+- Desktop recording with DXGI / PipeWire
+- WebRTC ingest in general
+
+Our Tier 1 gate rejects these with the "unsupported video format"
+warning, so none of them can be stitched today.
+
+**Suggested direction** (reco-core):
+
+Add an `InputFormat::Bgra` variant (and maybe `InputFormat::Rgba` /
+`Bgrx`) to the renderer. Touch points:
+
+- `renderer.rs`: new shader path that samples a single `Rgba8Unorm`
+  texture and skips the YUV→RGB conversion. Bind group shrinks from
+  3 textures down to 1.
+- `StitchPipeline::with_gpu`: accept the new variant.
+- New `upload_left_bgra` / `upload_right_bgra` helpers (or just a
+  `BgraPlane` input struct for `render_to_target`).
+- `LiveSessionConfig::input_format` already threads through, no
+  additional API surface.
+
+Estimated ~2-3 hours of shader + plumbing work.
+
+**Why not convert in reco-obs**: BGRA is a common compositor format
+across use cases (OBS browser, screen capture, WebRTC, whiteboard
+overlays). Having every consumer reimplement the CPU-side BGRA→YUV
+conversion duplicates code and burns CPU that the GPU could absorb
+for free. Keeping conversion in reco-core shader means one
+implementation, zero CPU overhead.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -64,48 +64,6 @@ already supports being rebuilt - but the reco-obs callback plumbing
 has to detect the size change and reset cached state (repack
 buffers, OBS texture, etc.). Tier 2 item.
 
-### A8. reco-core only accepts YUV input formats (blocks OBS Browser Source, screen capture, WebRTC)
-
-**Impact**: High for live-streaming setups. Hit 2026-04-18 while
-trying to wire an OBS Browser Source (VDO Ninja WebRTC feed) as an
-input for Tier 1 frame ingestion.
-
-`reco_core::renderer::InputFormat` has exactly two variants:
-`Yuv420p` and `Nv12`. Any OBS source whose native format is a packed
-RGB variety delivers frames in `VIDEO_FORMAT_BGRA` /
-`VIDEO_FORMAT_RGBA` / `VIDEO_FORMAT_BGRX`:
-
-- Browser Source (Chromium renders in BGRA)
-- Screen capture / Window capture
-- Desktop recording with DXGI / PipeWire
-- WebRTC ingest in general
-
-Our Tier 1 gate rejects these with the "unsupported video format"
-warning, so none of them can be stitched today.
-
-**Suggested direction** (reco-core):
-
-Add an `InputFormat::Bgra` variant (and maybe `InputFormat::Rgba` /
-`Bgrx`) to the renderer. Touch points:
-
-- `renderer.rs`: new shader path that samples a single `Rgba8Unorm`
-  texture and skips the YUV→RGB conversion. Bind group shrinks from
-  3 textures down to 1.
-- `StitchPipeline::with_gpu`: accept the new variant.
-- New `upload_left_bgra` / `upload_right_bgra` helpers (or just a
-  `BgraPlane` input struct for `render_to_target`).
-- `LiveSessionConfig::input_format` already threads through, no
-  additional API surface.
-
-Estimated ~2-3 hours of shader + plumbing work.
-
-**Why not convert in reco-obs**: BGRA is a common compositor format
-across use cases (OBS browser, screen capture, WebRTC, whiteboard
-overlays). Having every consumer reimplement the CPU-side BGRA→YUV
-conversion duplicates code and burns CPU that the GPU could absorb
-for free. Keeping conversion in reco-core shader means one
-implementation, zero CPU overhead.
-
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.
@@ -148,6 +106,16 @@ level without a specific interop target.
   `submit_frame(left, right, yaw, pitch) -> Option<&[u8]>` for push-
   based compositor consumers (OBS, V4L2, WebRTC). `reco-obs/src/source.rs`
   migrated to it - net removal of ~30 lines of per-consumer plumbing.
+- **R5. reco-core only accepted YUV inputs (blocked Browser Source / WebRTC)**
+  Resolved 2026-04-18 by Batch J: `InputFormat::Bgra` variant in
+  `reco_core::renderer`, `BgraPlanes` input struct + `render_to_target_bgra`
+  / `LiveStitchSession::submit_frame_bgra`. Shader branches on flags.y==2
+  to sample a single `Rgba8Unorm` texture and skip YUV conversion. Bind
+  group layout unchanged (1x1 dummy textures for u/v in BGRA mode).
+  reco-obs now exposes an "Input format" dropdown (I420 / BGRA); Browser
+  Source, screen capture and WebRTC feeds that deliver BGRA/BGRX/RGBA
+  are accepted, swizzle-to-RGBA happens once per frame into a cached
+  buffer.
 
 ## Notes on plugin status
 

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -6,6 +6,64 @@ resolved items archived at the bottom with the PR that fixed them.
 
 ## Active
 
+### A5. No temporal frame pairing helper in reco-core / reco-io
+
+**Impact**: Medium for any dual-source live consumer (OBS now, V4L2
+later). Hit 2026-04-18 while wiring OBS Tier 1 ingestion.
+
+`obs_source_get_frame` returns the "current" async frame for a given
+source: whatever the upstream producer last handed OBS. With two
+independent cameras feeding two independent OBS sources, the two
+calls return frames whose timestamps may disagree by one or more
+frame intervals (upstream producers run on separate threads with
+their own pacing).
+
+Tier 1 of reco-obs just polls both sides every `video_tick` and
+submits the pair unconditionally - if drift grows, we start stitching
+temporally mismatched frames with no warning.
+
+A proper solution is a reusable ring-buffer pairing helper in reco-io
+(or reco-core) that:
+- Takes `(timestamp, StereoSide, FrameBufferHandle)` submissions from
+  each side,
+- Emits `(left, right)` pairs with the closest timestamps when both
+  sides have recent frames,
+- Drops older unpaired frames,
+- Surfaces a "last pairing delta" so consumers can warn when drift
+  exceeds a threshold.
+
+The same helper would be reused by a future WebRTC ingest or a live
+V4L2 consumer. Living in a consumer crate means every new consumer
+reinvents it.
+
+### A6. No obs_source_get_output_flags binding to filter source picker
+
+**Impact**: Low (UX papercut). The reco-obs source-picker dropdowns
+currently show *every* OBS source - scenes, audio-only inputs,
+transitions, filters. Picking a scene just causes
+`obs_source_get_frame` to return null, which we handle silently,
+but it's a bad UX.
+
+Properly filtering to async-video-capable sources (inputs that set
+`OBS_SOURCE_ASYNC_VIDEO`) requires a new FFI binding for
+`obs_source_get_output_flags`. Noted here so we don't lose track;
+the fix is 5 lines of FFI + a conditional in the enumeration
+callback, but it's OBS-FFI scope only.
+
+### A7. No auto-resize when input frame dimensions don't match
+
+**Impact**: Low (UX papercut). When an upstream source delivers
+frames whose dimensions differ from the plugin's `input_width /
+input_height` properties, we log once and skip all submissions
+until the user edits the properties. A nicer flow would be to
+reinitialize the `LiveStitchSession` on the first received frame
+whose dimensions differ, picking up the new size automatically.
+
+Not actionable at the reco-core level - `LiveStitchSession::new`
+already supports being rebuilt - but the reco-obs callback plumbing
+has to detect the size change and reset cached state (repack
+buffers, OBS texture, etc.). Tier 2 item.
+
 ### A3. No OBS-level wgpu interop
 
 **Impact**: Fundamental to OBS architecture, not a reco-core bug.
@@ -51,8 +109,11 @@ level without a specific interop target.
 
 ## Notes on plugin status
 
-reco-obs is still scaffolding PoC - it renders a green test pattern
-to verify the OBS plugin hook-up works. Real frame ingestion from
-OBS callbacks has not been implemented yet. When that happens, A1
-and A4 will become blockers and likely motivate a Batch H in
-reco-io.
+Tier 1 (2026-04-18): real dual-source frame ingestion landed. The
+plugin now exposes two source pickers in its properties UI (left /
+right), resolves them via `obs_get_source_by_name`, and polls
+`obs_source_get_frame` every `video_tick`. I420 input is routed
+through `StridedYuvPlanes::copy_into` (Batch I) into
+`LiveStitchSession::submit_frame`; other formats (NV12, YUY2,
+UYVY, packed RGB) are logged once and skipped. Tier 2 target is
+NV12 + temporal pairing (blocked on A5).

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -123,6 +123,16 @@ pub enum gs_color_space {
     GS_CS_709_SCRGB = 3,
 }
 
+/// Texture creation flag: auto-generate mipmaps (from `libobs/graphics/graphics.h`).
+#[allow(dead_code)]
+pub const GS_BUILD_MIPMAPS: u32 = 1 << 0;
+/// Texture creation flag: dynamic (CPU-writable via `gs_texture_map` /
+/// `gs_texture_set_image`). Required when uploading frames from the plugin.
+pub const GS_DYNAMIC: u32 = 1 << 1;
+/// Texture creation flag: render target (GPU-writable).
+#[allow(dead_code)]
+pub const GS_RENDER_TARGET: u32 = 1 << 2;
+
 /// OBS graphics color format.
 #[repr(C)]
 #[allow(non_camel_case_types, dead_code)]
@@ -595,6 +605,14 @@ unsafe extern "C" {
     pub fn obs_get_source_by_name(name: *const c_char) -> *mut obs_source_t;
     pub fn obs_source_release(source: *mut obs_source_t);
     pub fn obs_source_get_name(source: *const obs_source_t) -> *const c_char;
+
+    // Source activation (keeps Media Source decoders running even when the
+    // upstream source isn't rendered in the scene directly). We're using
+    // the source's async frames via obs_source_get_frame, but OBS doesn't
+    // track that as "showing", so without inc_showing it may deactivate
+    // the decoder and stall playback.
+    pub fn obs_source_inc_showing(source: *mut obs_source_t);
+    pub fn obs_source_dec_showing(source: *mut obs_source_t);
 
     // Dropdown property (for source pickers)
     pub fn obs_properties_add_list(

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -184,6 +184,20 @@ pub const OBS_SOURCE_ASYNC: u32 = 1 << 2;
 /// Source uses custom draw (no default effect passed to `video_render`).
 #[allow(dead_code)]
 pub const OBS_SOURCE_CUSTOM_DRAW: u32 = 1 << 3;
+/// Source handles interaction callbacks (mouse / key / focus). OBS will
+/// only deliver mouse_click / mouse_move / mouse_wheel events to a source
+/// that declares this flag.
+pub const OBS_SOURCE_INTERACTION: u32 = 1 << 5;
+
+/// OBS mouse button enum (from `libobs/obs-interaction.h`).
+#[repr(i32)]
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum obs_mouse_button_type {
+    MOUSE_LEFT = 0,
+    MOUSE_MIDDLE = 1,
+    MOUSE_RIGHT = 2,
+}
 
 // ---------------------------------------------------------------------------
 // OBS base effect enum

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -517,6 +517,8 @@ unsafe extern "C" {
     // Settings (obs_data_t)
     pub fn obs_data_get_string(data: *mut obs_data_t, name: *const c_char) -> *const c_char;
     pub fn obs_data_get_int(data: *mut obs_data_t, name: *const c_char) -> i64;
+    pub fn obs_data_get_double(data: *mut obs_data_t, name: *const c_char) -> f64;
+    pub fn obs_data_set_default_double(data: *mut obs_data_t, name: *const c_char, val: f64);
     pub fn obs_data_set_default_string(
         data: *mut obs_data_t,
         name: *const c_char,

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -177,6 +177,10 @@ pub enum obs_path_type {
 
 /// Source provides video output (synchronous rendering via `video_render`).
 pub const OBS_SOURCE_VIDEO: u32 = 1;
+/// Source delivers frames asynchronously via `obs_source_output_video`.
+/// When OR'd with `OBS_SOURCE_VIDEO`, forms `OBS_SOURCE_ASYNC_VIDEO` -
+/// the only mode reco-obs can currently consume via `obs_source_get_frame`.
+pub const OBS_SOURCE_ASYNC: u32 = 1 << 2;
 /// Source uses custom draw (no default effect passed to `video_render`).
 #[allow(dead_code)]
 pub const OBS_SOURCE_CUSTOM_DRAW: u32 = 1 << 3;
@@ -607,6 +611,9 @@ unsafe extern "C" {
     pub fn obs_get_source_by_name(name: *const c_char) -> *mut obs_source_t;
     pub fn obs_source_release(source: *mut obs_source_t);
     pub fn obs_source_get_name(source: *const obs_source_t) -> *const c_char;
+    /// Returns the bitmask of OBS_SOURCE_* flags declared by the source.
+    /// Bit 0 = video, bit 1 = audio, bit 2 = async, bit 3 = custom_draw, etc.
+    pub fn obs_source_get_output_flags(source: *const obs_source_t) -> u32;
 
     // Source activation (keeps Media Source decoders running even when the
     // upstream source isn't rendered in the scene directly). We're using

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -566,6 +566,21 @@ unsafe extern "C" {
     );
     pub fn gs_draw_sprite(tex: *mut gs_texture_t, flip: u32, width: u32, height: u32);
 
+    /// High-level draw helper that handles the effect loop internally.
+    ///
+    /// Use this instead of starting a new `gs_effect_loop` inside a source's
+    /// `video_render` callback - OBS already has its outer effect active
+    /// when it calls us, so nesting with `gs_effect_loop` triggers
+    /// "effect is already active" and silently drops the draw.
+    pub fn obs_source_draw(
+        image: *mut gs_texture_t,
+        x: c_int,
+        y: c_int,
+        cx: u32,
+        cy: u32,
+        flip: bool,
+    );
+
     // Effects
     pub fn obs_get_base_effect(effect: obs_base_effect) -> *mut gs_effect_t;
     pub fn gs_effect_get_param_by_name(

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -225,10 +225,81 @@ pub struct audio_output_data {
     _opaque: [u8; 0],
 }
 
-/// Async video frame (opaque placeholder).
+/// Maximum number of planes in an async video frame (from libobs `media-io-defs.h`).
+pub const MAX_AV_PLANES: usize = 8;
+
+/// OBS video pixel format enum (subset - see `libobs/media-io/video-io.h`).
+///
+/// Only the variants reco-obs inspects are represented. Other values are
+/// delivered by OBS but Tier 1 ingestion rejects them with a warning.
+#[repr(i32)]
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum video_format {
+    /// Unset / unknown format.
+    VIDEO_FORMAT_NONE = 0,
+    /// Planar 4:2:0, three planes (Y, U, V). Matches our tight `YuvPlanes`.
+    VIDEO_FORMAT_I420 = 1,
+    /// Planar 4:2:0, two planes (Y, interleaved UV). Tier 2 target.
+    VIDEO_FORMAT_NV12 = 2,
+    /// Packed 4:2:2 - YVYU.
+    VIDEO_FORMAT_YVYU = 3,
+    /// Packed 4:2:2 - YUY2.
+    VIDEO_FORMAT_YUY2 = 4,
+    /// Packed 4:2:2 - UYVY.
+    VIDEO_FORMAT_UYVY = 5,
+    /// Packed RGBA.
+    VIDEO_FORMAT_RGBA = 6,
+    /// Packed BGRA.
+    VIDEO_FORMAT_BGRA = 7,
+    /// Packed BGRX.
+    VIDEO_FORMAT_BGRX = 8,
+    /// 8-bit grayscale.
+    VIDEO_FORMAT_Y800 = 9,
+    /// Planar 4:4:4.
+    VIDEO_FORMAT_I444 = 10,
+}
+
+/// Async video frame delivered to async video sources / consumed via
+/// [`obs_source_get_frame`]. Layout mirrors `struct obs_source_frame`
+/// in `libobs/obs.h` for OBS 30.x.
+///
+/// Fields after `trc` are used internally by libobs; treat them as
+/// opaque and don't rely on their offsets.
 #[repr(C)]
 pub struct obs_source_frame {
-    _opaque: [u8; 0],
+    /// Plane pointers. Only the first few are populated depending on `format`.
+    pub data: [*mut u8; MAX_AV_PLANES],
+    /// Bytes per row per plane (may include padding).
+    pub linesize: [u32; MAX_AV_PLANES],
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Presentation timestamp in nanoseconds.
+    pub timestamp: u64,
+    /// Pixel format.
+    pub format: video_format,
+    /// 4x4 color matrix (column-major) for YUV->RGB conversion.
+    pub color_matrix: [f32; 16],
+    /// Whether the source delivers full-range YUV (vs. limited 16-235).
+    pub full_range: bool,
+    /// HDR max luminance hint.
+    pub max_luminance: u16,
+    /// Min of each color channel (for range shaping).
+    pub color_range_min: [f32; 3],
+    /// Max of each color channel.
+    pub color_range_max: [f32; 3],
+    /// If true, the frame is Y-flipped.
+    pub flip: bool,
+    /// Render flags (bit 0 = is linear alpha).
+    pub flags: u8,
+    /// Transfer characteristic (enum video_trc in libobs).
+    pub trc: u8,
+    /// Internal: refcount (don't touch).
+    pub refs: std::sync::atomic::AtomicI32,
+    /// Internal: "already rendered" flag.
+    pub prev_frame: bool,
 }
 
 /// Async audio data (opaque placeholder).
@@ -243,11 +314,51 @@ pub struct obs_missing_files_t {
     _opaque: [u8; 0],
 }
 
-/// Source enumeration callback type.
+/// Source enumeration callback type (for `enum_active_sources` on a source).
 #[allow(non_camel_case_types)]
 pub type obs_source_enum_proc_t = Option<
     unsafe extern "C" fn(parent: *mut obs_source_t, child: *mut obs_source_t, param: *mut c_void),
 >;
+
+/// Global source enumeration callback (used by `obs_enum_sources`).
+///
+/// Return `true` to continue enumeration, `false` to stop.
+#[allow(non_camel_case_types)]
+pub type obs_enum_sources_cb =
+    Option<unsafe extern "C" fn(param: *mut c_void, source: *mut obs_source_t) -> bool>;
+
+/// UI dropdown kind (from `libobs/obs-properties.h`). We use
+/// `OBS_COMBO_TYPE_LIST` for non-editable source pickers.
+#[repr(i32)]
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum obs_combo_type {
+    /// Invalid / unset.
+    OBS_COMBO_TYPE_INVALID = 0,
+    /// User-editable free-form entry.
+    OBS_COMBO_TYPE_EDITABLE = 1,
+    /// Fixed list (what we want for source pickers).
+    OBS_COMBO_TYPE_LIST = 2,
+    /// Radio-button group.
+    OBS_COMBO_TYPE_RADIO = 3,
+}
+
+/// Dropdown value type (we only use `STRING` for source names).
+#[repr(i32)]
+#[allow(non_camel_case_types, dead_code)]
+#[derive(Debug, Clone, Copy)]
+pub enum obs_combo_format {
+    /// Invalid / unset.
+    OBS_COMBO_FORMAT_INVALID = 0,
+    /// Integer values.
+    OBS_COMBO_FORMAT_INT = 1,
+    /// Float values.
+    OBS_COMBO_FORMAT_FLOAT = 2,
+    /// String values (what we use for source names).
+    OBS_COMBO_FORMAT_STRING = 3,
+    /// Bool values.
+    OBS_COMBO_FORMAT_BOOL = 4,
+}
 
 /// The source info registration struct.
 ///
@@ -463,4 +574,32 @@ unsafe extern "C" {
     ) -> *mut gs_eparam_t;
     pub fn gs_effect_set_texture(param: *mut gs_eparam_t, val: *mut gs_texture_t);
     pub fn gs_effect_loop(effect: *mut gs_effect_t, name: *const c_char) -> bool;
+
+    // Source enumeration + lookup (Tier 1 frame ingestion)
+    pub fn obs_enum_sources(enum_proc: obs_enum_sources_cb, param: *mut c_void);
+    pub fn obs_get_source_by_name(name: *const c_char) -> *mut obs_source_t;
+    pub fn obs_source_release(source: *mut obs_source_t);
+    pub fn obs_source_get_name(source: *const obs_source_t) -> *const c_char;
+
+    // Dropdown property (for source pickers)
+    pub fn obs_properties_add_list(
+        props: *mut obs_properties_t,
+        name: *const c_char,
+        description: *const c_char,
+        list_type: obs_combo_type,
+        format: obs_combo_format,
+    ) -> *mut obs_property_t;
+    pub fn obs_property_list_add_string(
+        p: *mut obs_property_t,
+        name: *const c_char,
+        val: *const c_char,
+    ) -> usize;
+
+    // Pull-based async video frame access.
+    //
+    // Returns the source's current async frame (ref-counted). Must be
+    // paired with obs_source_release_frame to avoid leaking. The frame
+    // contents are valid only between these two calls.
+    pub fn obs_source_get_frame(source: *mut obs_source_t) -> *mut obs_source_frame;
+    pub fn obs_source_release_frame(source: *mut obs_source_t, frame: *mut obs_source_frame);
 }

--- a/crates/reco-obs/src/ffi.rs
+++ b/crates/reco-obs/src/ffi.rs
@@ -611,8 +611,14 @@ unsafe extern "C" {
     // the source's async frames via obs_source_get_frame, but OBS doesn't
     // track that as "showing", so without inc_showing it may deactivate
     // the decoder and stall playback.
+    //
+    // `inc_showing` alone is insufficient for Media Source (ffmpeg_source):
+    // its decode thread also checks active_state, so we pair with
+    // `inc_active` to hold the upstream firmly.
     pub fn obs_source_inc_showing(source: *mut obs_source_t);
     pub fn obs_source_dec_showing(source: *mut obs_source_t);
+    pub fn obs_source_inc_active(source: *mut obs_source_t);
+    pub fn obs_source_dec_active(source: *mut obs_source_t);
 
     // Dropdown property (for source pickers)
     pub fn obs_properties_add_list(

--- a/crates/reco-obs/src/lib.rs
+++ b/crates/reco-obs/src/lib.rs
@@ -69,10 +69,12 @@ pub extern "C" fn obs_module_ver() -> u32 {
 /// Called by OBS during startup. We register our source info struct.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn obs_module_load() -> bool {
-    // Initialize logging (env_logger) if not already set up.
-    // In practice OBS has its own log system, but this helps during
-    // development when testing outside OBS.
-    let _ = env_logger::try_init();
+    // Initialize logging with an Info default so plugin messages
+    // surface in OBS's captured stderr (and via OBS's log files too)
+    // without the user needing to set RUST_LOG manually. If the env
+    // already sets RUST_LOG, env_logger's parser takes over.
+    let _ = env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .try_init();
 
     log::info!("reco-obs: module loading (API version {LIBOBS_API_VER:#010x})");
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -208,13 +208,44 @@ impl RecoSource {
             if ptr.is_null() {
                 log::warn!("reco-obs: upstream source '{new_name}' not found (not yet created?)");
             } else {
+                // Sanity-check the source's output_flags. We can only
+                // consume ASYNC video sources via obs_source_get_frame.
+                // Sync video sources (Browser Source, Screen Capture,
+                // Window Capture, Game Capture) need render-to-texture
+                // (tracked as FRICTION A9) - they'd silently produce no
+                // output if we didn't warn here.
+                let flags = ffi::obs_source_get_output_flags(ptr);
+                let has_video = (flags & ffi::OBS_SOURCE_VIDEO) != 0;
+                let is_async = (flags & ffi::OBS_SOURCE_ASYNC) != 0;
+                if !has_video {
+                    log::warn!(
+                        "reco-obs: source '{new_name}' has no video output (flags={:#06x}); \
+                         it won't produce frames. Pick a video source (Media Source, V4L2 \
+                         Device, NDI).",
+                        flags
+                    );
+                } else if !is_async {
+                    log::warn!(
+                        "reco-obs: source '{new_name}' is a SYNC video source (flags={:#06x}); \
+                         reco-obs Tier 1 only consumes async sources. Browser Source, Screen \
+                         Capture, Window Capture, Game Capture all render this way - tracked \
+                         as FRICTION A9 (needs render-to-texture path). Workarounds: use \
+                         Media Source / V4L2 Device / NDI, or pipe the sync source through \
+                         v4l2loopback first.",
+                        flags
+                    );
+                } else {
+                    log::info!(
+                        "reco-obs: source '{new_name}' is async video (flags={:#06x}) - ok",
+                        flags
+                    );
+                }
                 // Hold both showing + active refs. Media Source's
                 // ffmpeg decode thread pauses on active==0 even when
                 // showing>0, so we need both to keep playback stable
                 // while the upstream isn't visibly rendered in the scene.
                 ffi::obs_source_inc_showing(ptr);
                 ffi::obs_source_inc_active(ptr);
-                log::info!("reco-obs: holding '{new_name}' via inc_showing + inc_active");
             }
             *slot = ptr;
         }
@@ -312,6 +343,24 @@ impl RecoSource {
     /// fire at most once per source instance.
     fn render_and_readback(&mut self) {
         self.diag_tick = self.diag_tick.wrapping_add(1);
+
+        // Lazy re-resolve: on OBS startup, source_create for the Reco
+        // source often fires before scene sources have finished loading,
+        // so our initial apply_settings resolves Media / Media 2 to null.
+        // Retry every 30 ticks (~0.5s at 60fps) until we get non-null
+        // refs. Cheap - obs_get_source_by_name is a hashmap lookup.
+        if self.diag_tick.is_multiple_of(30) {
+            unsafe {
+                if self.left_source.is_null() && !self.left_source_name.is_empty() {
+                    let name = self.left_source_name.clone();
+                    RecoSource::set_source_slot(&mut self.left_source, &name);
+                }
+                if self.right_source.is_null() && !self.right_source_name.is_empty() {
+                    let name = self.right_source_name.clone();
+                    RecoSource::set_source_slot(&mut self.right_source, &name);
+                }
+            }
+        }
         // Every ~60 ticks (~1-2 seconds) flush a diagnostic heartbeat so
         // users can tell "plugin running but no render" from "plugin hung".
         if self.diag_tick.is_multiple_of(60) {
@@ -1014,10 +1063,15 @@ unsafe fn apply_settings(src: &mut RecoSource, settings: *mut ffi::obs_data_t) {
         } else {
             CStr::from_ptr(left_ptr).to_string_lossy().into_owned()
         };
-        if left_name != src.left_source_name {
+        // Always re-resolve when the slot is null and we have a name to
+        // try: the first apply_settings on source creation may have run
+        // before the upstream existed in the scene, caching a null ptr
+        // with a non-empty name. Later updates with the same name would
+        // skip the resolve and leave the slot permanently null.
+        if left_name != src.left_source_name || (src.left_source.is_null() && !left_name.is_empty())
+        {
             RecoSource::set_source_slot(&mut src.left_source, &left_name);
             src.left_source_name = left_name;
-            // New source may deliver a different format; re-enable warning.
             src.warned_unsupported_format = false;
         }
 
@@ -1027,7 +1081,9 @@ unsafe fn apply_settings(src: &mut RecoSource, settings: *mut ffi::obs_data_t) {
         } else {
             CStr::from_ptr(right_ptr).to_string_lossy().into_owned()
         };
-        if right_name != src.right_source_name {
+        if right_name != src.right_source_name
+            || (src.right_source.is_null() && !right_name.is_empty())
+        {
             RecoSource::set_source_slot(&mut src.right_source, &right_name);
             src.right_source_name = right_name;
             src.warned_unsupported_format = false;

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -1033,9 +1033,9 @@ unsafe fn apply_settings(src: &mut RecoSource, settings: *mut ffi::obs_data_t) {
             src.warned_unsupported_format = false;
         }
 
-        // Viewport position.
-        src.yaw_degrees = 0.0; // obs_data_get_double is not bound yet
-        src.pitch_degrees = 0.0;
+        // Viewport position - property-driven yaw/pitch sliders.
+        src.yaw_degrees = ffi::obs_data_get_double(settings, PROP_YAW.as_ptr());
+        src.pitch_degrees = ffi::obs_data_get_double(settings, PROP_PITCH.as_ptr());
     }
 }
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -132,6 +132,15 @@ struct RecoSource {
     /// Camera pitch in degrees (converted to radians for the pipeline).
     pitch_degrees: f64,
 
+    /// Interactive drag state. `true` between mouse-left-down and
+    /// mouse-left-up events. When true, mouse_move deltas translate to
+    /// yaw/pitch adjustments.
+    dragging: bool,
+    /// Last mouse x/y in source-local pixels, used to compute deltas
+    /// between consecutive mouse_move events.
+    last_mouse_x: i32,
+    last_mouse_y: i32,
+
     /// CPU-side RGBA buffer from the last render (owned copy of the most
     /// recent frame from `RgbaReadback`, so `video_render` can read it on
     /// the OBS graphics thread without holding a borrow).
@@ -171,6 +180,9 @@ impl RecoSource {
             input_height: 1080,
             yaw_degrees: 0.0,
             pitch_degrees: 0.0,
+            dragging: false,
+            last_mouse_x: 0,
+            last_mouse_y: 0,
             rgba_buffer: Vec::new(),
             frame_ready: AtomicBool::new(false),
             obs_texture: ptr::null_mut(),
@@ -880,6 +892,103 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
 }
 
 // ---------------------------------------------------------------------------
+// Interactive mouse callbacks (click-drag to pan, wheel to zoom)
+// ---------------------------------------------------------------------------
+
+/// Degrees of yaw/pitch per pixel of mouse drag.
+const DRAG_SENSITIVITY_DEG_PER_PIXEL: f64 = 0.1;
+/// Degrees of FOV change per wheel tick. Small for granular zoom;
+/// users expect wheel to feel smooth, not jumpy.
+const WHEEL_FOV_STEP_DEG: f32 = 0.5;
+
+/// `mouse_click`: start/end a drag for pan.
+///
+/// # Safety
+/// Invoked by OBS on the main UI thread. `data` and `event` are valid
+/// pointers for the lifetime of the call.
+unsafe extern "C" fn source_mouse_click(
+    data: *mut c_void,
+    event: *const ffi::obs_mouse_event,
+    r#type: i32,
+    mouse_up: bool,
+    _click_count: u32,
+) {
+    if data.is_null() || event.is_null() {
+        return;
+    }
+    let src = unsafe { &mut *(data as *mut RecoSource) };
+    let ev = unsafe { &*event };
+    // Only handle left-button for drag-to-pan. Middle/right reserved for
+    // future features (e.g. double-click to reset pose).
+    if r#type != ffi::obs_mouse_button_type::MOUSE_LEFT as i32 {
+        return;
+    }
+    if mouse_up {
+        src.dragging = false;
+    } else {
+        src.dragging = true;
+        src.last_mouse_x = ev.x;
+        src.last_mouse_y = ev.y;
+    }
+}
+
+/// `mouse_move`: while dragging, translate pixel delta to yaw/pitch.
+unsafe extern "C" fn source_mouse_move(
+    data: *mut c_void,
+    event: *const ffi::obs_mouse_event,
+    mouse_leave: bool,
+) {
+    if data.is_null() || event.is_null() {
+        return;
+    }
+    let src = unsafe { &mut *(data as *mut RecoSource) };
+    if mouse_leave {
+        // Treat leaving the source rect as dropping the drag to avoid
+        // a stale drag state if the user releases outside.
+        src.dragging = false;
+        return;
+    }
+    if !src.dragging {
+        return;
+    }
+    let ev = unsafe { &*event };
+    let dx = (ev.x - src.last_mouse_x) as f64;
+    let dy = (ev.y - src.last_mouse_y) as f64;
+    src.last_mouse_x = ev.x;
+    src.last_mouse_y = ev.y;
+
+    // Natural "drag the scene, not the camera" mapping: drag right
+    // shifts the view left (yaw becomes more negative), drag up shifts
+    // the view down (pitch more positive). Clamp pitch to [-89, 89] to
+    // avoid pole flip.
+    src.yaw_degrees -= dx * DRAG_SENSITIVITY_DEG_PER_PIXEL;
+    src.pitch_degrees =
+        (src.pitch_degrees + dy * DRAG_SENSITIVITY_DEG_PER_PIXEL).clamp(-89.0, 89.0);
+}
+
+/// `mouse_wheel`: scroll to zoom (adjust vertical FOV).
+unsafe extern "C" fn source_mouse_wheel(
+    data: *mut c_void,
+    _event: *const ffi::obs_mouse_event,
+    _x_delta: i32,
+    y_delta: i32,
+) {
+    if data.is_null() {
+        return;
+    }
+    let src = unsafe { &mut *(data as *mut RecoSource) };
+    let session = match &mut src.session {
+        Some(s) => s,
+        None => return,
+    };
+    // y_delta is integer "ticks" from OBS (positive = wheel forward, which
+    // conventionally means zoom IN -> narrower FOV -> subtract).
+    let current = session.pipeline().fov();
+    let new_fov = (current - (y_delta as f32) * WHEEL_FOV_STEP_DEG).clamp(10.0, 150.0);
+    session.pipeline_mut().set_fov(new_fov);
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1106,7 +1215,7 @@ pub(crate) fn source_info() -> ffi::obs_source_info {
     ffi::obs_source_info {
         id: SOURCE_ID.as_ptr(),
         r#type: ffi::obs_source_type::OBS_SOURCE_TYPE_INPUT,
-        output_flags: ffi::OBS_SOURCE_VIDEO,
+        output_flags: ffi::OBS_SOURCE_VIDEO | ffi::OBS_SOURCE_INTERACTION,
         get_name: Some(source_get_name),
         create: Some(source_create),
         destroy: Some(source_destroy),
@@ -1126,9 +1235,9 @@ pub(crate) fn source_info() -> ffi::obs_source_info {
         enum_active_sources: None,
         save: None,
         load: None,
-        mouse_click: None,
-        mouse_move: None,
-        mouse_wheel: None,
+        mouse_click: Some(source_mouse_click),
+        mouse_move: Some(source_mouse_move),
+        mouse_wheel: Some(source_mouse_wheel),
         focus: None,
         key_click: None,
         filter_remove: None,

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -86,6 +86,13 @@ struct RecoSource {
     /// One-shot warning flag: emitted once per unsupported video format
     /// so we don't flood the log on every frame.
     warned_unsupported_format: bool,
+    /// Rolling tick counter + per-category "missed frame" counters for
+    /// diagnostic heartbeat logging. Flushed every ~60 ticks so consumers
+    /// can tell "plugin running but never rendered" from silent hang.
+    diag_tick: u64,
+    diag_missed_left: u64,
+    diag_missed_right: u64,
+    diag_submitted: u64,
 
     /// Current calibration loaded from the config file.
     calibration: Option<MatchCalibration>,
@@ -131,6 +138,10 @@ impl RecoSource {
             left_repack: Vec::new(),
             right_repack: Vec::new(),
             warned_unsupported_format: false,
+            diag_tick: 0,
+            diag_missed_left: 0,
+            diag_missed_right: 0,
+            diag_submitted: 0,
             calibration: None,
             config_path: String::new(),
             output_width: 1920,
@@ -147,10 +158,17 @@ impl RecoSource {
 
     /// Replace `slot` with a new OBS source reference (resolved from
     /// `new_name` via `obs_get_source_by_name`). Releases the old ref if
-    /// one was held. Safe to call with an empty name - that just releases.
+    /// one was held, and pairs `inc_showing` with `dec_showing` so the
+    /// upstream source (e.g. a Media Source) keeps its decoder running
+    /// while we're pulling frames from it - without that, OBS can
+    /// deactivate the source when it isn't visibly rendered anywhere,
+    /// which manifests as intermittent freezes in our stitched output.
+    ///
+    /// Safe to call with an empty name - that just releases the old ref.
     unsafe fn set_source_slot(slot: &mut *mut ffi::obs_source_t, new_name: &str) {
         unsafe {
             if !slot.is_null() {
+                ffi::obs_source_dec_showing(*slot);
                 ffi::obs_source_release(*slot);
                 *slot = ptr::null_mut();
             }
@@ -167,6 +185,9 @@ impl RecoSource {
             let ptr = ffi::obs_get_source_by_name(cstr.as_ptr());
             if ptr.is_null() {
                 log::warn!("reco-obs: upstream source '{new_name}' not found (not yet created?)");
+            } else {
+                ffi::obs_source_inc_showing(ptr);
+                log::info!("reco-obs: holding '{new_name}' active via inc_showing");
             }
             *slot = ptr;
         }
@@ -262,6 +283,31 @@ impl RecoSource {
     /// `warned_unsupported_format` flag ensures unsupported-format warnings
     /// fire at most once per source instance.
     fn render_and_readback(&mut self) {
+        self.diag_tick = self.diag_tick.wrapping_add(1);
+        // Every ~60 ticks (~1-2 seconds) flush a diagnostic heartbeat so
+        // users can tell "plugin running but no render" from "plugin hung".
+        if self.diag_tick.is_multiple_of(60) {
+            log::info!(
+                "reco-obs: diag tick={} submitted={} missed_left={} missed_right={} \
+                 session={} left_src={} right_src={}",
+                self.diag_tick,
+                self.diag_submitted,
+                self.diag_missed_left,
+                self.diag_missed_right,
+                if self.session.is_some() { "ok" } else { "none" },
+                if self.left_source.is_null() {
+                    "null"
+                } else {
+                    "ok"
+                },
+                if self.right_source.is_null() {
+                    "null"
+                } else {
+                    "ok"
+                },
+            );
+        }
+
         if self.session.is_none() {
             return;
         }
@@ -273,6 +319,12 @@ impl RecoSource {
         // ref; must pair with release_frame).
         let left_frame = unsafe { ffi::obs_source_get_frame(self.left_source) };
         let right_frame = unsafe { ffi::obs_source_get_frame(self.right_source) };
+        if left_frame.is_null() {
+            self.diag_missed_left += 1;
+        }
+        if right_frame.is_null() {
+            self.diag_missed_right += 1;
+        }
 
         if !left_frame.is_null() && !right_frame.is_null() {
             // SAFETY: both pointers non-null; OBS guarantees the frames
@@ -330,6 +382,13 @@ impl RecoSource {
                     Ok(Some(rgba)) => {
                         self.rgba_buffer.copy_from_slice(rgba);
                         self.frame_ready.store(true, Ordering::Release);
+                        if self.diag_submitted == 0 {
+                            log::info!(
+                                "reco-obs: first stitched frame ready ({} bytes)",
+                                rgba.len()
+                            );
+                        }
+                        self.diag_submitted += 1;
                     }
                     Ok(None) => { /* pipeline warmup */ }
                     Err(e) => {
@@ -362,6 +421,9 @@ impl RecoSource {
     /// Must be called on the OBS graphics thread.
     unsafe fn ensure_obs_texture(&mut self) {
         if self.obs_texture.is_null() && self.output_width > 0 && self.output_height > 0 {
+            // GS_DYNAMIC is required for gs_texture_set_image to work;
+            // without it the texture is static and all updates silently
+            // fail with "Texture is not dynamic" spam in the OBS log.
             self.obs_texture = unsafe {
                 ffi::gs_texture_create(
                     self.output_width,
@@ -369,11 +431,17 @@ impl RecoSource {
                     ffi::gs_color_format::GS_RGBA,
                     1,
                     ptr::null(),
-                    0,
+                    ffi::GS_DYNAMIC,
                 )
             };
             if self.obs_texture.is_null() {
                 log::error!("reco-obs: failed to create OBS texture");
+            } else {
+                log::info!(
+                    "reco-obs: OBS texture created ({}x{}, GS_RGBA, dynamic)",
+                    self.output_width,
+                    self.output_height
+                );
             }
         }
     }
@@ -419,13 +487,16 @@ unsafe extern "C" fn source_destroy(data: *mut c_void) {
     let mut src = unsafe { Box::from_raw(data as *mut RecoSource) };
 
     // Release the upstream source refs we held. Must run before the Box
-    // is dropped - OBS tracks ref lifetime through these calls.
+    // is dropped - OBS tracks ref lifetime through these calls. Pair
+    // dec_showing with the inc_showing set_source_slot issued earlier.
     unsafe {
         if !src.left_source.is_null() {
+            ffi::obs_source_dec_showing(src.left_source);
             ffi::obs_source_release(src.left_source);
             src.left_source = ptr::null_mut();
         }
         if !src.right_source.is_null() {
+            ffi::obs_source_dec_showing(src.right_source);
             ffi::obs_source_release(src.right_source);
             src.right_source = ptr::null_mut();
         }

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -638,15 +638,19 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
         src.frame_ready.store(false, Ordering::Release);
     }
 
-    // Draw the texture using OBS's default effect.
+    // Draw via OBS's helper, which respects the outer effect already
+    // active when video_render is called. Manually running
+    // `gs_effect_loop` here triggers "effect is already active" warnings
+    // and no draw lands on screen.
     unsafe {
-        let effect = ffi::obs_get_base_effect(ffi::obs_base_effect::OBS_EFFECT_DEFAULT);
-        let param = ffi::gs_effect_get_param_by_name(effect, c"image".as_ptr());
-        ffi::gs_effect_set_texture(param, src.obs_texture);
-
-        while ffi::gs_effect_loop(effect, c"Draw".as_ptr()) {
-            ffi::gs_draw_sprite(src.obs_texture, 0, src.output_width, src.output_height);
-        }
+        ffi::obs_source_draw(
+            src.obs_texture,
+            0,
+            0,
+            src.output_width,
+            src.output_height,
+            false,
+        );
     }
 }
 

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use reco_core::calibration::MatchCalibration;
 use reco_core::gpu::GpuContext;
-use reco_core::pipeline::YuvPlanes;
+use reco_core::pipeline::{FramePlaneView, StridedYuvPlanes};
 use reco_core::renderer::InputFormat;
 use reco_core::session::{LiveSessionConfig, LiveStitchSession};
 use reco_core::viewport::ViewportConfig;
@@ -51,6 +51,10 @@ const PROP_INPUT_WIDTH: &CStr = c"input_width";
 const PROP_INPUT_HEIGHT: &CStr = c"input_height";
 const PROP_YAW: &CStr = c"yaw";
 const PROP_PITCH: &CStr = c"pitch";
+/// Name of the OBS source that feeds the left camera.
+const PROP_LEFT_SOURCE: &CStr = c"left_source";
+/// Name of the OBS source that feeds the right camera.
+const PROP_RIGHT_SOURCE: &CStr = c"right_source";
 
 // ---------------------------------------------------------------------------
 // Source state
@@ -64,6 +68,24 @@ struct RecoSource {
     /// High-level push session (bundles pipeline + RGBA readback).
     /// None until calibration is loaded and GPU is initialized.
     session: Option<LiveStitchSession>,
+
+    /// Upstream OBS source that feeds the left camera. Owned reference
+    /// (obs_get_source_by_name increments refcount, we release in destroy
+    /// or when the user picks a different source).
+    left_source: *mut ffi::obs_source_t,
+    /// Upstream OBS source that feeds the right camera. See [`Self::left_source`].
+    right_source: *mut ffi::obs_source_t,
+    /// Source name the user picked for the left camera (used to detect changes).
+    left_source_name: String,
+    /// Source name the user picked for the right camera.
+    right_source_name: String,
+    /// Reusable tight-pack buffers for `StridedYuvPlanes::copy_into`. One
+    /// per side so the render loop never reallocates per frame.
+    left_repack: Vec<u8>,
+    right_repack: Vec<u8>,
+    /// One-shot warning flag: emitted once per unsupported video format
+    /// so we don't flood the log on every frame.
+    warned_unsupported_format: bool,
 
     /// Current calibration loaded from the config file.
     calibration: Option<MatchCalibration>,
@@ -102,6 +124,13 @@ impl RecoSource {
     fn new() -> Self {
         Self {
             session: None,
+            left_source: ptr::null_mut(),
+            right_source: ptr::null_mut(),
+            left_source_name: String::new(),
+            right_source_name: String::new(),
+            left_repack: Vec::new(),
+            right_repack: Vec::new(),
+            warned_unsupported_format: false,
             calibration: None,
             config_path: String::new(),
             output_width: 1920,
@@ -113,6 +142,33 @@ impl RecoSource {
             rgba_buffer: Vec::new(),
             frame_ready: AtomicBool::new(false),
             obs_texture: ptr::null_mut(),
+        }
+    }
+
+    /// Replace `slot` with a new OBS source reference (resolved from
+    /// `new_name` via `obs_get_source_by_name`). Releases the old ref if
+    /// one was held. Safe to call with an empty name - that just releases.
+    unsafe fn set_source_slot(slot: &mut *mut ffi::obs_source_t, new_name: &str) {
+        unsafe {
+            if !slot.is_null() {
+                ffi::obs_source_release(*slot);
+                *slot = ptr::null_mut();
+            }
+            if new_name.is_empty() {
+                return;
+            }
+            let cstr = match std::ffi::CString::new(new_name) {
+                Ok(s) => s,
+                Err(_) => {
+                    log::warn!("reco-obs: source name contains NUL, ignoring");
+                    return;
+                }
+            };
+            let ptr = ffi::obs_get_source_by_name(cstr.as_ptr());
+            if ptr.is_null() {
+                log::warn!("reco-obs: upstream source '{new_name}' not found (not yet created?)");
+            }
+            *slot = ptr;
         }
     }
 
@@ -198,52 +254,97 @@ impl RecoSource {
         }
     }
 
-    /// Perform a render and readback cycle via [`LiveStitchSession`].
+    /// Pull the latest async frame pair from the upstream OBS sources,
+    /// stitch, and stash the RGBA result for `video_render`.
     ///
-    /// Currently renders a blank frame (all-zero YUV) since we don't have
-    /// live camera input wired up yet. When real OBS frame callbacks are
-    /// plumbed, the strided `obs_source_frame` planes should be wrapped
-    /// in [`reco_core::pipeline::StridedYuvPlanes`] and repacked into a
-    /// cached `Vec<u8>` via `copy_into(&mut buf)` before submission.
+    /// Returns silently (no render) when either upstream source is unset,
+    /// has no current frame, or delivers a format other than I420. The
+    /// `warned_unsupported_format` flag ensures unsupported-format warnings
+    /// fire at most once per source instance.
     fn render_and_readback(&mut self) {
-        let session = match &mut self.session {
-            Some(s) => s,
-            None => return,
-        };
+        if self.session.is_none() {
+            return;
+        }
+        if self.left_source.is_null() || self.right_source.is_null() {
+            return;
+        }
 
-        // TODO: Wire up actual camera frame data from OBS source inputs.
-        // For now, render a test pattern (zero YUV = green in BT.601).
-        let y_size = (self.input_width * self.input_height) as usize;
-        let uv_size = y_size / 4;
-        let y_data = vec![0u8; y_size];
-        let u_data = vec![128u8; uv_size];
-        let v_data = vec![128u8; uv_size];
+        // Acquire frames (obs_source_get_frame increments the internal
+        // ref; must pair with release_frame).
+        let left_frame = unsafe { ffi::obs_source_get_frame(self.left_source) };
+        let right_frame = unsafe { ffi::obs_source_get_frame(self.right_source) };
 
-        let left = YuvPlanes {
-            y: &y_data,
-            u: &u_data,
-            v: &v_data,
-        };
-        let right = YuvPlanes {
-            y: &y_data,
-            u: &u_data,
-            v: &v_data,
-        };
+        if !left_frame.is_null() && !right_frame.is_null() {
+            // SAFETY: both pointers non-null; OBS guarantees the frames
+            // are valid between get_frame and release_frame.
+            let l = unsafe { &*left_frame };
+            let r = unsafe { &*right_frame };
 
-        let yaw = (self.yaw_degrees as f32).to_radians();
-        let pitch = (self.pitch_degrees as f32).to_radians();
+            // Tier 1: I420 only. NV12/YUY2/etc. -> warn once, skip.
+            let format_ok = l.format == ffi::video_format::VIDEO_FORMAT_I420
+                && r.format == ffi::video_format::VIDEO_FORMAT_I420;
+            if !format_ok {
+                if !self.warned_unsupported_format {
+                    log::warn!(
+                        "reco-obs: unsupported video format (left={:?}, right={:?}); only I420 \
+                         is accepted in Tier 1. Set the upstream source to deliver I420 or wait \
+                         for NV12 support.",
+                        l.format,
+                        r.format,
+                    );
+                    self.warned_unsupported_format = true;
+                }
+            } else if l.width != self.input_width
+                || l.height != self.input_height
+                || r.width != self.input_width
+                || r.height != self.input_height
+            {
+                if !self.warned_unsupported_format {
+                    log::warn!(
+                        "reco-obs: input-dim mismatch (configured {}x{}, left={}x{}, \
+                         right={}x{}). Update the 'Input width/height' properties to match \
+                         your camera.",
+                        self.input_width,
+                        self.input_height,
+                        l.width,
+                        l.height,
+                        r.width,
+                        r.height,
+                    );
+                    self.warned_unsupported_format = true;
+                }
+            } else {
+                // Wrap OBS planes as StridedYuvPlanes and repack into the
+                // cached tight buffers. `copy_into` takes a single memcpy
+                // fast path when stride == width (common on software
+                // decoders).
+                let left_strided = strided_from_obs(l);
+                let right_strided = strided_from_obs(r);
+                let left_tight = left_strided.copy_into(&mut self.left_repack);
+                let right_tight = right_strided.copy_into(&mut self.right_repack);
 
-        match session.submit_frame(&left, &right, yaw, pitch) {
-            Ok(Some(rgba)) => {
-                self.rgba_buffer.copy_from_slice(rgba);
-                self.frame_ready.store(true, Ordering::Release);
+                let yaw = (self.yaw_degrees as f32).to_radians();
+                let pitch = (self.pitch_degrees as f32).to_radians();
+                let session = self.session.as_mut().expect("checked above");
+                match session.submit_frame(&left_tight, &right_tight, yaw, pitch) {
+                    Ok(Some(rgba)) => {
+                        self.rgba_buffer.copy_from_slice(rgba);
+                        self.frame_ready.store(true, Ordering::Release);
+                    }
+                    Ok(None) => { /* pipeline warmup */ }
+                    Err(e) => {
+                        log::error!("reco-obs: render/readback failed: {e}");
+                    }
+                }
             }
-            Ok(None) => {
-                // Pipeline warmup; next tick will have data.
-            }
-            Err(e) => {
-                log::error!("reco-obs: render/readback failed: {e}");
-            }
+        }
+
+        // Always release frames we acquired.
+        if !left_frame.is_null() {
+            unsafe { ffi::obs_source_release_frame(self.left_source, left_frame) };
+        }
+        if !right_frame.is_null() {
+            unsafe { ffi::obs_source_release_frame(self.right_source, right_frame) };
         }
     }
 
@@ -317,6 +418,19 @@ unsafe extern "C" fn source_destroy(data: *mut c_void) {
 
     let mut src = unsafe { Box::from_raw(data as *mut RecoSource) };
 
+    // Release the upstream source refs we held. Must run before the Box
+    // is dropped - OBS tracks ref lifetime through these calls.
+    unsafe {
+        if !src.left_source.is_null() {
+            ffi::obs_source_release(src.left_source);
+            src.left_source = ptr::null_mut();
+        }
+        if !src.right_source.is_null() {
+            ffi::obs_source_release(src.right_source);
+            src.right_source = ptr::null_mut();
+        }
+    }
+
     // Destroy OBS texture on the graphics thread.
     unsafe {
         ffi::obs_enter_graphics();
@@ -360,6 +474,26 @@ unsafe extern "C" fn source_get_defaults(settings: *mut ffi::obs_data_t) {
 unsafe extern "C" fn source_get_properties(_data: *mut c_void) -> *mut ffi::obs_properties_t {
     unsafe {
         let props = ffi::obs_properties_create();
+
+        // Left / right upstream source pickers. Populated via
+        // obs_enum_sources at property-open time.
+        let left_list = ffi::obs_properties_add_list(
+            props,
+            PROP_LEFT_SOURCE.as_ptr(),
+            c"Left camera source".as_ptr(),
+            ffi::obs_combo_type::OBS_COMBO_TYPE_LIST,
+            ffi::obs_combo_format::OBS_COMBO_FORMAT_STRING,
+        );
+        ffi::obs_enum_sources(Some(source_enum_proc_list), left_list as *mut c_void);
+
+        let right_list = ffi::obs_properties_add_list(
+            props,
+            PROP_RIGHT_SOURCE.as_ptr(),
+            c"Right camera source".as_ptr(),
+            ffi::obs_combo_type::OBS_COMBO_TYPE_LIST,
+            ffi::obs_combo_format::OBS_COMBO_FORMAT_STRING,
+        );
+        ffi::obs_enum_sources(Some(source_enum_proc_list), right_list as *mut c_void);
 
         ffi::obs_properties_add_path(
             props,
@@ -520,6 +654,83 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
 // Helpers
 // ---------------------------------------------------------------------------
 
+/// Wrap an `obs_source_frame` (I420 only) as a [`StridedYuvPlanes`] view.
+///
+/// Assumes the caller has already verified `format == VIDEO_FORMAT_I420`.
+/// OBS delivers I420 with plane[0]=Y (full-res), plane[1]=U, plane[2]=V
+/// (each half-res per dimension).
+fn strided_from_obs<'a>(frame: &'a ffi::obs_source_frame) -> StridedYuvPlanes<'a> {
+    let half_w = frame.width / 2;
+    let half_h = frame.height / 2;
+    // SAFETY: OBS guarantees data[i] points to linesize[i] * plane_height
+    // bytes while the frame is held. We build slices of exactly that length
+    // so FramePlaneView can traverse safely via stride indexing.
+    let y_slice = unsafe {
+        std::slice::from_raw_parts(
+            frame.data[0] as *const u8,
+            (frame.linesize[0] as usize) * (frame.height as usize),
+        )
+    };
+    let u_slice = unsafe {
+        std::slice::from_raw_parts(
+            frame.data[1] as *const u8,
+            (frame.linesize[1] as usize) * (half_h as usize),
+        )
+    };
+    let v_slice = unsafe {
+        std::slice::from_raw_parts(
+            frame.data[2] as *const u8,
+            (frame.linesize[2] as usize) * (half_h as usize),
+        )
+    };
+    StridedYuvPlanes {
+        y: FramePlaneView {
+            data: y_slice,
+            stride: frame.linesize[0],
+            width: frame.width,
+            height: frame.height,
+        },
+        u: FramePlaneView {
+            data: u_slice,
+            stride: frame.linesize[1],
+            width: half_w,
+            height: half_h,
+        },
+        v: FramePlaneView {
+            data: v_slice,
+            stride: frame.linesize[2],
+            width: half_w,
+            height: half_h,
+        },
+    }
+}
+
+/// OBS enumeration callback: appends every source name to the dropdown
+/// list passed as `param`. Always returns `true` to continue iterating.
+///
+/// Filtering out sources that can't deliver async video (scenes,
+/// transitions, audio-only inputs) requires additional bindings
+/// (`obs_source_get_output_flags`). For Tier 1 we accept everything;
+/// picking a bad source just means `obs_source_get_frame` returns null
+/// and we skip.
+unsafe extern "C" fn source_enum_proc_list(
+    param: *mut c_void,
+    source: *mut ffi::obs_source_t,
+) -> bool {
+    if param.is_null() || source.is_null() {
+        return true;
+    }
+    let prop = param as *mut ffi::obs_property_t;
+    let name_ptr = unsafe { ffi::obs_source_get_name(source) };
+    if !name_ptr.is_null() {
+        unsafe {
+            // Use the same cstring as both label and value.
+            ffi::obs_property_list_add_string(prop, name_ptr, name_ptr);
+        }
+    }
+    true
+}
+
 /// Read settings from an `obs_data_t` into the source struct.
 ///
 /// # Safety
@@ -550,6 +761,32 @@ unsafe fn apply_settings(src: &mut RecoSource, settings: *mut ffi::obs_data_t) {
         let ih = ffi::obs_data_get_int(settings, PROP_INPUT_HEIGHT.as_ptr());
         if ih > 0 {
             src.input_height = ih as u32;
+        }
+
+        // Upstream source picks. Empty string clears the slot.
+        let left_ptr = ffi::obs_data_get_string(settings, PROP_LEFT_SOURCE.as_ptr());
+        let left_name = if left_ptr.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(left_ptr).to_string_lossy().into_owned()
+        };
+        if left_name != src.left_source_name {
+            RecoSource::set_source_slot(&mut src.left_source, &left_name);
+            src.left_source_name = left_name;
+            // New source may deliver a different format; re-enable warning.
+            src.warned_unsupported_format = false;
+        }
+
+        let right_ptr = ffi::obs_data_get_string(settings, PROP_RIGHT_SOURCE.as_ptr());
+        let right_name = if right_ptr.is_null() {
+            String::new()
+        } else {
+            CStr::from_ptr(right_ptr).to_string_lossy().into_owned()
+        };
+        if right_name != src.right_source_name {
+            RecoSource::set_source_slot(&mut src.right_source, &right_name);
+            src.right_source_name = right_name;
+            src.warned_unsupported_format = false;
         }
 
         // Viewport position.

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -26,7 +26,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use reco_core::calibration::MatchCalibration;
 use reco_core::gpu::GpuContext;
-use reco_core::pipeline::{FramePlaneView, StridedYuvPlanes};
+use reco_core::pipeline::{BgraPlanes, FramePlaneView, StridedYuvPlanes};
 use reco_core::renderer::InputFormat;
 use reco_core::session::{LiveSessionConfig, LiveStitchSession};
 use reco_core::viewport::ViewportConfig;
@@ -55,6 +55,12 @@ const PROP_PITCH: &CStr = c"pitch";
 const PROP_LEFT_SOURCE: &CStr = c"left_source";
 /// Name of the OBS source that feeds the right camera.
 const PROP_RIGHT_SOURCE: &CStr = c"right_source";
+/// Upstream pixel format (string: "i420" | "bgra"). Must match what the
+/// picked OBS sources actually deliver - OBS can't negotiate, so this is
+/// a manual hint.
+const PROP_INPUT_FORMAT: &CStr = c"input_format";
+const INPUT_FORMAT_I420: &CStr = c"i420";
+const INPUT_FORMAT_BGRA: &CStr = c"bgra";
 
 // ---------------------------------------------------------------------------
 // Source state
@@ -83,6 +89,10 @@ struct RecoSource {
     /// per side so the render loop never reallocates per frame.
     left_repack: Vec<u8>,
     right_repack: Vec<u8>,
+    /// Which reco-core input format the session was built with. Determines
+    /// which submit path (YUV vs BGRA) we dispatch to and which OBS video
+    /// formats we accept as valid input.
+    input_format: InputFormat,
     /// One-shot warning flag: emitted once per unsupported video format
     /// so we don't flood the log on every frame.
     warned_unsupported_format: bool,
@@ -145,6 +155,7 @@ impl RecoSource {
             right_source_name: String::new(),
             left_repack: Vec::new(),
             right_repack: Vec::new(),
+            input_format: InputFormat::Yuv420p,
             warned_unsupported_format: false,
             diag_tick: 0,
             diag_missed_left: 0,
@@ -244,16 +255,17 @@ impl RecoSource {
                 input_width: self.input_width,
                 input_height: self.input_height,
                 output_format: reco_core::wgpu::TextureFormat::Rgba8Unorm,
-                input_format: InputFormat::Yuv420p,
+                input_format: self.input_format,
             },
         ) {
             Ok(session) => {
                 log::info!(
-                    "reco-obs: session initialized ({}x{} output, {}x{} input)",
+                    "reco-obs: session initialized ({}x{} output, {}x{} input, format={:?})",
                     self.output_width,
                     self.output_height,
                     self.input_width,
                     self.input_height,
+                    self.input_format,
                 );
                 self.session = Some(session);
                 let buf_size = (self.output_width * self.output_height * 4) as usize;
@@ -350,18 +362,38 @@ impl RecoSource {
             let l = unsafe { &*left_frame };
             let r = unsafe { &*right_frame };
 
-            // Tier 1: I420 only. NV12/YUY2/etc. -> warn once, skip.
-            let format_ok = l.format == ffi::video_format::VIDEO_FORMAT_I420
-                && r.format == ffi::video_format::VIDEO_FORMAT_I420;
+            // Must match what the session was built with. Mismatch =>
+            // warn once and skip. Camera inputs (V4L2, Media Source) are
+            // I420; browser / screen capture / WebRTC are BGRA.
+            let format_ok = match self.input_format {
+                InputFormat::Yuv420p => {
+                    l.format == ffi::video_format::VIDEO_FORMAT_I420
+                        && r.format == ffi::video_format::VIDEO_FORMAT_I420
+                }
+                InputFormat::Bgra => {
+                    matches!(
+                        l.format,
+                        ffi::video_format::VIDEO_FORMAT_BGRA
+                            | ffi::video_format::VIDEO_FORMAT_BGRX
+                            | ffi::video_format::VIDEO_FORMAT_RGBA
+                    ) && matches!(
+                        r.format,
+                        ffi::video_format::VIDEO_FORMAT_BGRA
+                            | ffi::video_format::VIDEO_FORMAT_BGRX
+                            | ffi::video_format::VIDEO_FORMAT_RGBA
+                    )
+                }
+                InputFormat::Nv12 => false,
+            };
             if !format_ok {
                 if !self.warned_unsupported_format {
                     log::warn!(
-                        "reco-obs: unsupported video format (left={:?}, right={:?}); Tier 1 \
-                         accepts only I420 (VIDEO_FORMAT_I420). NV12 is tracked as Tier 2. \
-                         Browser Source / screen capture / WebRTC deliver BGRA and need \
-                         reco-core InputFormat::Bgra support (see reco-obs FRICTION A8). For \
-                         now, use an OBS Media Source pointed at an I420-encoded video file, \
-                         or a V4L2 camera configured for I420 output.",
+                        "reco-obs: upstream format doesn't match session ({:?}, configured \
+                         for {:?}; got left={:?}, right={:?}). Change the plugin's 'Input \
+                         format' property to match the source type: I420 for V4L2 / Media \
+                         Source, BGRA for Browser Source / screen capture / WebRTC.",
+                        self.input_format,
+                        self.input_format,
                         l.format,
                         r.format,
                     );
@@ -387,19 +419,38 @@ impl RecoSource {
                     self.warned_unsupported_format = true;
                 }
             } else {
-                // Wrap OBS planes as StridedYuvPlanes and repack into the
-                // cached tight buffers. `copy_into` takes a single memcpy
-                // fast path when stride == width (common on software
-                // decoders).
-                let left_strided = strided_from_obs(l);
-                let right_strided = strided_from_obs(r);
-                let left_tight = left_strided.copy_into(&mut self.left_repack);
-                let right_tight = right_strided.copy_into(&mut self.right_repack);
-
                 let yaw = (self.yaw_degrees as f32).to_radians();
                 let pitch = (self.pitch_degrees as f32).to_radians();
-                let session = self.session.as_mut().expect("checked above");
-                match session.submit_frame(&left_tight, &right_tight, yaw, pitch) {
+                let result = match self.input_format {
+                    InputFormat::Yuv420p => {
+                        // Wrap OBS planes as StridedYuvPlanes and repack
+                        // into the cached tight buffers. `copy_into` takes
+                        // a single memcpy fast path when stride == width.
+                        let left_strided = strided_from_obs(l);
+                        let right_strided = strided_from_obs(r);
+                        let left_tight = left_strided.copy_into(&mut self.left_repack);
+                        let right_tight = right_strided.copy_into(&mut self.right_repack);
+                        let session = self.session.as_mut().expect("checked above");
+                        session.submit_frame(&left_tight, &right_tight, yaw, pitch)
+                    }
+                    InputFormat::Bgra => {
+                        // BGRA sources: swizzle bytes into cached RGBA
+                        // buffers once per frame. Shader expects RGB in
+                        // .rgb of a single sample. RGBA sources pass
+                        // through without swizzle (we go through the same
+                        // path because the caller would typically hand us
+                        // the right order already).
+                        let left_bgra = build_bgra_planes(l, &mut self.left_repack);
+                        let right_bgra = build_bgra_planes(r, &mut self.right_repack);
+                        let session = self.session.as_mut().expect("checked above");
+                        session.submit_frame_bgra(&left_bgra, &right_bgra, yaw, pitch)
+                    }
+                    InputFormat::Nv12 => {
+                        // Not yet supported in reco-obs; guarded above.
+                        Ok(None)
+                    }
+                };
+                match result {
                     Ok(Some(rgba)) => {
                         self.rgba_buffer.copy_from_slice(rgba);
                         self.frame_ready.store(true, Ordering::Release);
@@ -561,6 +612,11 @@ unsafe extern "C" fn source_get_defaults(settings: *mut ffi::obs_data_t) {
         ffi::obs_data_set_default_int(settings, PROP_INPUT_WIDTH.as_ptr(), 1920);
         ffi::obs_data_set_default_int(settings, PROP_INPUT_HEIGHT.as_ptr(), 1080);
         ffi::obs_data_set_default_string(settings, PROP_CONFIG_PATH.as_ptr(), c"".as_ptr());
+        ffi::obs_data_set_default_string(
+            settings,
+            PROP_INPUT_FORMAT.as_ptr(),
+            INPUT_FORMAT_I420.as_ptr(),
+        );
     }
 }
 
@@ -588,6 +644,27 @@ unsafe extern "C" fn source_get_properties(_data: *mut c_void) -> *mut ffi::obs_
             ffi::obs_combo_format::OBS_COMBO_FORMAT_STRING,
         );
         ffi::obs_enum_sources(Some(source_enum_proc_list), right_list as *mut c_void);
+
+        // Input format picker. Must match the native format OBS's picked
+        // sources deliver - OBS can't negotiate, and guessing wrong
+        // means no output.
+        let format_list = ffi::obs_properties_add_list(
+            props,
+            PROP_INPUT_FORMAT.as_ptr(),
+            c"Input format".as_ptr(),
+            ffi::obs_combo_type::OBS_COMBO_TYPE_LIST,
+            ffi::obs_combo_format::OBS_COMBO_FORMAT_STRING,
+        );
+        ffi::obs_property_list_add_string(
+            format_list,
+            c"I420 (Media Source, V4L2)".as_ptr(),
+            INPUT_FORMAT_I420.as_ptr(),
+        );
+        ffi::obs_property_list_add_string(
+            format_list,
+            c"BGRA (Browser Source, Screen Capture)".as_ptr(),
+            INPUT_FORMAT_BGRA.as_ptr(),
+        );
 
         ffi::obs_properties_add_path(
             props,
@@ -675,8 +752,11 @@ unsafe extern "C" fn source_update(data: *mut c_void, settings: *mut ffi::obs_da
     let dims_changed = (src.output_width, src.output_height) != old_output
         || (src.input_width, src.input_height) != old_input;
     let config_changed = src.config_path != old_config_path;
+    // apply_settings sets src.session to None when the input format
+    // changes, so we can use that as our "needs rebuild" signal.
+    let format_changed = src.session.is_none() && src.calibration.is_some();
 
-    if dims_changed || config_changed {
+    if dims_changed || config_changed || format_changed {
         // Destroy old OBS texture since dimensions may have changed.
         unsafe {
             ffi::obs_enter_graphics();
@@ -753,6 +833,44 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Build a [`BgraPlanes`] view over the source frame's RGBA data,
+/// swizzling from BGRA into the cached buffer when needed.
+///
+/// OBS packed RGB formats (BGRA, BGRX, RGBA) all store 4 bytes per
+/// pixel with `linesize[0]` bytes per row (may include padding). We
+/// strip the stride padding into the cached buffer and reorder to
+/// RGBA so the shader can sample `.rgb` directly.
+fn build_bgra_planes<'a>(frame: &ffi::obs_source_frame, buffer: &'a mut Vec<u8>) -> BgraPlanes<'a> {
+    let w = frame.width as usize;
+    let h = frame.height as usize;
+    let stride = frame.linesize[0] as usize;
+    let tight_size = w * h * 4;
+    buffer.resize(tight_size, 0);
+    // SAFETY: frame.data[0] is valid for linesize[0] * height bytes
+    // between get_frame/release_frame, guaranteed by OBS.
+    let src = unsafe { std::slice::from_raw_parts(frame.data[0] as *const u8, stride * h) };
+    let bgra_mode = matches!(
+        frame.format,
+        ffi::video_format::VIDEO_FORMAT_BGRA | ffi::video_format::VIDEO_FORMAT_BGRX
+    );
+    for row in 0..h {
+        let src_row = &src[row * stride..row * stride + w * 4];
+        let dst_row = &mut buffer[row * w * 4..(row + 1) * w * 4];
+        if bgra_mode {
+            for (s, d) in src_row.chunks_exact(4).zip(dst_row.chunks_exact_mut(4)) {
+                d[0] = s[2];
+                d[1] = s[1];
+                d[2] = s[0];
+                d[3] = s[3];
+            }
+        } else {
+            // VIDEO_FORMAT_RGBA: already in the order the shader wants.
+            dst_row.copy_from_slice(src_row);
+        }
+    }
+    BgraPlanes::from_rgba(buffer)
+}
 
 /// Wrap an `obs_source_frame` (I420 only) as a [`StridedYuvPlanes`] view.
 ///
@@ -861,6 +979,32 @@ unsafe fn apply_settings(src: &mut RecoSource, settings: *mut ffi::obs_data_t) {
         let ih = ffi::obs_data_get_int(settings, PROP_INPUT_HEIGHT.as_ptr());
         if ih > 0 {
             src.input_height = ih as u32;
+        }
+
+        // Input format choice. Parse string -> InputFormat. Unknown
+        // strings fall back to I420 with a one-shot warning.
+        let format_ptr = ffi::obs_data_get_string(settings, PROP_INPUT_FORMAT.as_ptr());
+        let new_format = if format_ptr.is_null() {
+            InputFormat::Yuv420p
+        } else {
+            match CStr::from_ptr(format_ptr).to_str() {
+                Ok("bgra") => InputFormat::Bgra,
+                Ok("i420") | Ok("") => InputFormat::Yuv420p,
+                Ok(other) => {
+                    log::warn!("reco-obs: unknown input_format '{other}', defaulting to I420");
+                    InputFormat::Yuv420p
+                }
+                Err(_) => InputFormat::Yuv420p,
+            }
+        };
+        if new_format != src.input_format {
+            src.input_format = new_format;
+            // Existing session was built with the old format; drop it so
+            // source_update rebuilds. This happens after apply_settings
+            // returns (the dim / config / format-change gate reruns
+            // try_init_pipeline).
+            src.session = None;
+            src.warned_unsupported_format = false;
         }
 
         // Upstream source picks. Empty string clears the slot.

--- a/crates/reco-obs/src/source.rs
+++ b/crates/reco-obs/src/source.rs
@@ -93,6 +93,14 @@ struct RecoSource {
     diag_missed_left: u64,
     diag_missed_right: u64,
     diag_submitted: u64,
+    /// Count of video_render invocations since source creation. Logged
+    /// alongside the regular diag heartbeat so we can distinguish
+    /// "stitching runs but OBS never asks us to draw" from
+    /// "render runs but the texture isn't repainting".
+    diag_render_calls: u64,
+    /// Count of texture uploads (gs_texture_set_image calls) - should
+    /// track diag_submitted when the display path is healthy.
+    diag_uploads: u64,
 
     /// Current calibration loaded from the config file.
     calibration: Option<MatchCalibration>,
@@ -142,6 +150,8 @@ impl RecoSource {
             diag_missed_left: 0,
             diag_missed_right: 0,
             diag_submitted: 0,
+            diag_render_calls: 0,
+            diag_uploads: 0,
             calibration: None,
             config_path: String::new(),
             output_width: 1920,
@@ -168,6 +178,7 @@ impl RecoSource {
     unsafe fn set_source_slot(slot: &mut *mut ffi::obs_source_t, new_name: &str) {
         unsafe {
             if !slot.is_null() {
+                ffi::obs_source_dec_active(*slot);
                 ffi::obs_source_dec_showing(*slot);
                 ffi::obs_source_release(*slot);
                 *slot = ptr::null_mut();
@@ -186,8 +197,13 @@ impl RecoSource {
             if ptr.is_null() {
                 log::warn!("reco-obs: upstream source '{new_name}' not found (not yet created?)");
             } else {
+                // Hold both showing + active refs. Media Source's
+                // ffmpeg decode thread pauses on active==0 even when
+                // showing>0, so we need both to keep playback stable
+                // while the upstream isn't visibly rendered in the scene.
                 ffi::obs_source_inc_showing(ptr);
-                log::info!("reco-obs: holding '{new_name}' active via inc_showing");
+                ffi::obs_source_inc_active(ptr);
+                log::info!("reco-obs: holding '{new_name}' via inc_showing + inc_active");
             }
             *slot = ptr;
         }
@@ -288,10 +304,12 @@ impl RecoSource {
         // users can tell "plugin running but no render" from "plugin hung".
         if self.diag_tick.is_multiple_of(60) {
             log::info!(
-                "reco-obs: diag tick={} submitted={} missed_left={} missed_right={} \
-                 session={} left_src={} right_src={}",
+                "reco-obs: diag tick={} submitted={} uploads={} renders={} \
+                 missed_left={} missed_right={} session={} left_src={} right_src={}",
                 self.diag_tick,
                 self.diag_submitted,
+                self.diag_uploads,
+                self.diag_render_calls,
                 self.diag_missed_left,
                 self.diag_missed_right,
                 if self.session.is_some() { "ok" } else { "none" },
@@ -338,9 +356,12 @@ impl RecoSource {
             if !format_ok {
                 if !self.warned_unsupported_format {
                     log::warn!(
-                        "reco-obs: unsupported video format (left={:?}, right={:?}); only I420 \
-                         is accepted in Tier 1. Set the upstream source to deliver I420 or wait \
-                         for NV12 support.",
+                        "reco-obs: unsupported video format (left={:?}, right={:?}); Tier 1 \
+                         accepts only I420 (VIDEO_FORMAT_I420). NV12 is tracked as Tier 2. \
+                         Browser Source / screen capture / WebRTC deliver BGRA and need \
+                         reco-core InputFormat::Bgra support (see reco-obs FRICTION A8). For \
+                         now, use an OBS Media Source pointed at an I420-encoded video file, \
+                         or a V4L2 camera configured for I420 output.",
                         l.format,
                         r.format,
                     );
@@ -491,11 +512,13 @@ unsafe extern "C" fn source_destroy(data: *mut c_void) {
     // dec_showing with the inc_showing set_source_slot issued earlier.
     unsafe {
         if !src.left_source.is_null() {
+            ffi::obs_source_dec_active(src.left_source);
             ffi::obs_source_dec_showing(src.left_source);
             ffi::obs_source_release(src.left_source);
             src.left_source = ptr::null_mut();
         }
         if !src.right_source.is_null() {
+            ffi::obs_source_dec_active(src.right_source);
             ffi::obs_source_dec_showing(src.right_source);
             ffi::obs_source_release(src.right_source);
             src.right_source = ptr::null_mut();
@@ -683,6 +706,7 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
         return;
     }
     let src = unsafe { &mut *(data as *mut RecoSource) };
+    src.diag_render_calls = src.diag_render_calls.wrapping_add(1);
 
     if src.session.is_none() {
         return;
@@ -707,6 +731,7 @@ unsafe extern "C" fn source_video_render(data: *mut c_void, _effect: *mut ffi::g
             );
         }
         src.frame_ready.store(false, Ordering::Release);
+        src.diag_uploads = src.diag_uploads.wrapping_add(1);
     }
 
     // Draw via OBS's helper, which respects the outer effect already


### PR DESCRIPTION
Replaces reco-obs's green test-pattern scaffolding with actual frame pulling from two upstream OBS sources. Exercises Batch I's \`StridedYuvPlanes\` + \`LiveStitchSession\` end-to-end on real video data.

## How it works

1. Plugin properties expose two dropdowns (**Left camera source**, **Right camera source**) populated at property-open time via \`obs_enum_sources\`.
2. On \`source_update\` we resolve the picked names via \`obs_get_source_by_name\`, release old refs first, store new ones.
3. Every \`video_tick\` we call \`obs_source_get_frame\` on both sides, wrap I420 planes as \`StridedYuvPlanes\` (Batch I), \`copy_into\` the cached per-side repack buffers, and hand the tight pair to \`LiveStitchSession::submit_frame\`. Frames are always released before the tick returns.
4. Format mismatches (NV12/YUY2/UYVY/etc) log once per source instance and skip; same for dim mismatches. No per-frame log spam.
5. \`source_destroy\` releases both upstream refs before the Box drop.

## FFI additions

Pinned against libobs-dev 30.0.2 headers on the host system:
- \`obs_source_frame\` struct (now real, was opaque placeholder)
- \`video_format\` enum (I420/NV12/YUY2/UYVY/RGBA/BGRA/BGRX/Y800/I444)
- \`obs_combo_type\` / \`obs_combo_format\` enums
- \`obs_enum_sources\`, \`obs_get_source_by_name\`, \`obs_source_release\`, \`obs_source_get_name\`
- \`obs_properties_add_list\`, \`obs_property_list_add_string\`
- \`obs_source_get_frame\`, \`obs_source_release_frame\`

## FRICTION documented (per policy, not worked around)

Three new active items added to \`reco-obs/FRICTION.md\`:

- **A5**: no temporal frame-pairing helper in reco-core/reco-io. \`obs_source_get_frame\` returns \"latest per side\" with no timestamp handshake - drift between two cameras can produce temporally mismatched stitches. Wants a reusable \`RingBufferPair\` helper that a future WebRTC / V4L2 consumer could share.
- **A6**: no \`obs_source_get_output_flags\` binding, so the dropdown shows all source types. Picking a scene just returns null from \`get_frame\` (we handle silently) but UX papercut. 5-line FFI fix when we get to it.
- **A7**: no auto-resize on first-frame dim mismatch; user edits properties manually. Plugin-level, not a reco-core gap.

## Test plan

- [x] \`cargo fmt --all --check\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo clippy --all-targets --features profiling -- -D warnings\`
- [x] \`RUSTDOCFLAGS=-D warnings cargo doc --no-deps -p reco-obs\`
- [x] \`cargo build --release -p reco-obs\` produces \`libreco_obs.so\` (9.4 MB)
- [ ] **Manual** (you): install \`target/release/libreco_obs.so\` as the OBS plugin, restart OBS, add two camera sources in a scene, add a \"Reco Panorama Stitcher\" source, pick the two cameras in its properties, load a calibration JSON, verify a stitched panorama renders.

## What's intentionally out of scope

- **NV12 input** (most common on hardware-decoded V4L2 sources). Tier 2 - will need either an \`Nv12StridedPlanes\` in reco-core or an inline NV12→I420 converter.
- **Timestamp-based pairing** (A5).
- **Zero-copy GPU interop** (A3, architectural - OBS runs on OpenGL/D3D11, reco-core on wgpu).