### PR TITLE
chore: triage FRICTION, telemetry, issues, drop re-exports

### DIFF
--- a/crates/reco-autocam/src/lib.rs
+++ b/crates/reco-autocam/src/lib.rs
@@ -442,16 +442,6 @@ pub fn setup_autocam(
 
         // Pre-tracker flicker rejection: class-keyed bucketed-spatial
         // histogram that drops recurrent static mimics (line
-        // intersections, logos, corner flags). Skipped in field mode
-        // because the ROI already filters non-pitch detections, and
-        // stationary players (pre-kickoff, set pieces) are legitimate
-        // signal that the flicker filter aggressively removes.
-        if tracking_mode != TrackingMode::Field {
-            session.add_detection_filter(Box::new(
-                crate::detection_filters::FlickerDetectionFilter::with_defaults(),
-            ));
-        }
-
         match tracking_mode {
             TrackingMode::Field => {
                 let player_tracker = crate::trackers::PlayerTracker::new(person_id);

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -132,7 +132,7 @@ pub fn run_camera(
     let capture_width = cam_config.width;
     let capture_height = cam_config.height;
 
-    let session_config = reco_core::session::SessionConfig {
+    let session_config = reco_core::session::types::SessionConfig {
         calibration: cal,
         viewport,
         input_width: capture_width,
@@ -349,7 +349,7 @@ pub fn run_camera(
     session.set_encoder(Box::new(encoder), 2);
 
     let frame_limit =
-        reco_core::session::compute_frame_limit(duration, max_frames, capture_fps as f64);
+        reco_core::session::types::compute_frame_limit(duration, max_frames, capture_fps as f64);
 
     if frame_limit < u64::MAX {
         println!("Capturing up to {frame_limit} frames");

--- a/crates/reco-cli/src/libcamera_cmd.rs
+++ b/crates/reco-cli/src/libcamera_cmd.rs
@@ -80,7 +80,7 @@ pub fn run_libcamera(
     let capture_width = cam_config.width;
     let capture_height = cam_config.height;
 
-    let session_config = reco_core::session::SessionConfig {
+    let session_config = reco_core::session::types::SessionConfig {
         calibration: cal,
         viewport,
         input_width: capture_width,
@@ -149,7 +149,7 @@ pub fn run_libcamera(
     session.set_encoder(Box::new(encoder), 2);
 
     let frame_limit =
-        reco_core::session::compute_frame_limit(duration, max_frames, capture_fps as f64);
+        reco_core::session::types::compute_frame_limit(duration, max_frames, capture_fps as f64);
 
     if frame_limit < u64::MAX {
         println!("Capturing up to {frame_limit} frames");

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -87,7 +87,7 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
         .quality(parse_quality(args.quality))
         .resolution(args.width, args.height)
         .blend_width(args.blend)
-        .on_progress(move |p: &reco_core::session::FrameProgress| {
+        .on_progress(move |p: &reco_core::session::types::FrameProgress| {
             // Use the session's own elapsed clock so the reported
             // rate excludes one-time GPU / encoder / ORT init and
             // reflects only the decode → stitch → encode loop.

--- a/crates/reco-core/README.md
+++ b/crates/reco-core/README.md
@@ -2,19 +2,27 @@
 
 GPU stitching engine. The no-I/O, no-domain-logic foundation of the Reco workspace.
 
-## What it owns
+## Module structure
 
-- The push-based [`StitchCore`] — canonical frame-submission entry point for consumers.
-- The wgpu 28 pipeline: fisheye undistort, two-plane L-shape composite, viewport crop, NV12 converter, RGBA readback.
-- Traits: `Projection`, `CameraInput`, `PipelineStage`, `UnifiedDetector`, `FrameSource`, `Encoder`, `Director`, `DetectionSink`.
-- Platform interop: `cuda_interop` (CUDA 12 FFI on Linux/Windows), `metal_interop` (CVPixelBuffer import on macOS/iOS), `vulkan_interop` (DMA-BUF import on Linux), `zero_copy` shared-texture sets.
-- `PoseControl` — unified mouse-drag / wheel / keyboard -> yaw / pitch / FOV primitive shared by every consumer.
-- `framesync::TimestampedIngestBuffer` — N-source timestamp pairing for live calibration.
-- `yuv_stack_packer` — GPU-resident stacked-video pack / unpack (pairs with the replay path in reco-io).
+```
+src/
+  core/        - StitchCore push API (submit frames, get rendered output)
+  session/     - StitchSession pull API (batch processing with encoder wiring)
+  render/      - GPU rendering pipeline, planes, viewport, scene geometry
+  gpu/         - GpuContext, NV12 converter, RGBA readback, YUV stack packer
+  detect/      - Detection/tracking vocabulary (detector, tracker, panner traits)
+  interop/     - Platform zero-copy (CUDA, Vulkan, Metal, D3D11, DMA-buf)
+  projection/  - Coordinate math, coverage boundary, virtual camera
+  lens/        - KB4 fisheye model, undistortion, rig correction
+  calibration.rs - MatchCalibration (stereo camera parameters)
+  source.rs      - FrameSource trait, StereoFrame enum
+  encoder.rs     - Encoder trait
+  telemetry.rs   - Per-frame timing collection
+```
 
 ## What it does NOT own
 
-No file I/O, no FFmpeg, no GStreamer, no ONNX / TensorRT. Those live in `reco-io` and `reco-detect`. reco-core is usable headless — the GUI, OBS plugin, and cloud workers all plug in the same engine.
+No file I/O, no FFmpeg, no GStreamer, no ONNX/TensorRT. Those live in `reco-io` and `reco-detect`. reco-core is usable headless.
 
 ## Build
 
@@ -23,5 +31,3 @@ cargo build -p reco-core
 cargo build -p reco-core --features profiling   # tracing-chrome instrumentation
 cargo doc --no-deps -p reco-core --open
 ```
-
-[`StitchCore`]: src/core/mod.rs

--- a/crates/reco-core/src/interop/d3d11.rs
+++ b/crates/reco-core/src/interop/d3d11.rs
@@ -60,9 +60,9 @@ impl From<windows::core::Error> for D3d11InteropError {
     }
 }
 
-impl From<D3d11InteropError> for crate::session::SessionError {
+impl From<D3d11InteropError> for crate::session::types::SessionError {
     fn from(e: D3d11InteropError) -> Self {
-        crate::session::SessionError::ZeroCopy(e.to_string())
+        crate::session::types::SessionError::ZeroCopy(e.to_string())
     }
 }
 

--- a/crates/reco-core/src/render/stitch_renderer.rs
+++ b/crates/reco-core/src/render/stitch_renderer.rs
@@ -42,7 +42,7 @@ pub enum RenderTarget<'a> {
 }
 
 /// What happened after a [`StitchRenderer::render`] call.
-pub enum RenderOutcome {
+pub enum SurfaceRenderOutcome {
     /// Surface render submitted to the GPU queue (nothing to do).
     Submitted,
     /// Texture render returned a command buffer for readback.
@@ -156,9 +156,9 @@ impl StitchRenderer {
     /// `pipeline().render_to_target` (readback). The outcome tells the
     /// caller what happened:
     ///
-    /// - [`RenderOutcome::Submitted`] — GPU work was submitted for a
+    /// - [`SurfaceRenderOutcome::Submitted`] — GPU work was submitted for a
     ///   surface present; nothing left to do.
-    /// - [`RenderOutcome::Commands`] — a command buffer is ready for
+    /// - [`SurfaceRenderOutcome::Commands`] — a command buffer is ready for
     ///   readback (pass to [`RgbaReadback::readback`](crate::gpu::rgba_readback::RgbaReadback::readback)
     ///   or [`Nv12Converter::convert_and_readback`](crate::gpu::nv12_converter::Nv12Converter::convert_and_readback)).
     pub fn render(
@@ -168,16 +168,16 @@ impl StitchRenderer {
         yaw: f32,
         pitch: f32,
         target: RenderTarget<'_>,
-    ) -> Result<RenderOutcome, PipelineError> {
+    ) -> Result<SurfaceRenderOutcome, PipelineError> {
         match target {
             RenderTarget::Surface(view) => {
                 self.pipeline
                     .render_to_view(left, right, yaw, pitch, view)?;
-                Ok(RenderOutcome::Submitted)
+                Ok(SurfaceRenderOutcome::Submitted)
             }
             RenderTarget::Texture => {
                 let cmd = self.pipeline.render_to_target(left, right, yaw, pitch)?;
-                Ok(RenderOutcome::Commands(cmd))
+                Ok(SurfaceRenderOutcome::Commands(cmd))
             }
         }
     }

--- a/crates/reco-core/src/session/detection.rs
+++ b/crates/reco-core/src/session/detection.rs
@@ -22,7 +22,7 @@
 use crate::detect::detector::{CameraId, Detection, DetectorError, DetectorFrame, UnifiedDetector};
 use crate::detect::director::MappedDetection;
 
-use super::{DetectionSink, DetectionSinkError};
+use super::types::{DetectionSink, DetectionSinkError};
 
 /// Detection pipeline owning a unified-trait detector, interval,
 /// sink, and cached detections.

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -18,7 +18,6 @@
 
 /// Session type definitions, error types, and builder.
 pub mod types;
-pub use types::*;
 
 /// Detection pipeline - also usable standalone without StitchSession.
 pub mod detection;
@@ -56,6 +55,8 @@ use crate::gpu::nv12_converter::Nv12Converter;
 use crate::gpu::{GpuContext, OutputFormat};
 use crate::render::pipeline::StitchPipeline;
 use crate::render::renderer::InputFormat;
+
+use types::{ErrorPolicy, SessionConfig, SessionError, SessionMetrics, StitchSessionBuilder};
 
 use detection::DetectionPipeline;
 

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -9,7 +9,8 @@
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use super::*;
+use super::StitchSession;
+use super::types::*;
 use crate::calibration::{CameraParams, MatchCalibration, PlaneLayout};
 use crate::detect::detector::{CameraId, Detection, DetectorError, DetectorFrame, UnifiedDetector};
 use crate::detect::director::{MappedDetection, ViewportPosition};

--- a/crates/reco-core/src/session/types.rs
+++ b/crates/reco-core/src/session/types.rs
@@ -1,8 +1,8 @@
 //! Type definitions and builder for the stitching session.
 //!
 //! Extracted from `session/mod.rs` to keep the main module focused on
-//! the `StitchSession` implementation. All public items are re-exported
-//! from `crate::session` via `pub use types::*`.
+//! the `StitchSession` implementation. Import types from
+//! `reco_core::session::types` (e.g. `reco_core::session::types::SessionConfig`).
 
 use crate::calibration::MatchCalibration;
 use crate::core::types::StitchCoreError;

--- a/crates/reco-core/src/session/zero_copy_linux.rs
+++ b/crates/reco-core/src/session/zero_copy_linux.rs
@@ -3,7 +3,8 @@
 //! Separated from the main session module to isolate platform-specific
 //! shared-texture orchestration (CUDA VMM, Vulkan external memory).
 
-use super::{FrameProgress, ProgressCallback, SessionError, StitchSession};
+use super::StitchSession;
+use super::types::{FrameProgress, ProgressCallback, SessionError};
 use crate::interop::vulkan::{Nv12Plane, SharedTexture, create_nv12_shared_texture};
 use crate::interop::zero_copy::GpuBufInfo;
 

--- a/crates/reco-core/src/session/zero_copy_macos.rs
+++ b/crates/reco-core/src/session/zero_copy_macos.rs
@@ -3,7 +3,8 @@
 //! Separated from the main session module to isolate platform-specific
 //! CVPixelBuffer import and Metal texture cache management.
 
-use super::{FrameProgress, ProgressCallback, SessionError, StitchSession};
+use super::StitchSession;
+use super::types::{FrameProgress, ProgressCallback, SessionError};
 
 impl StitchSession {
     /// Run the zero-copy frame loop on macOS (VideoToolbox/Metal).

--- a/crates/reco-core/src/telemetry.rs
+++ b/crates/reco-core/src/telemetry.rs
@@ -89,11 +89,8 @@ impl<const N: usize> RingBuffer<N> {
 /// read-only view of the current state.
 pub struct TelemetryCollector {
     frame_count: u64,
-    frames_dropped: u64,
     ring: RingBuffer<256>,
     total_detections: u64,
-    total_tracks_created: u64,
-    total_tracks_lost: u64,
     ball_present_frames: u64,
     active_tracks: u32,
     max_frame_time: Duration,
@@ -109,11 +106,8 @@ impl TelemetryCollector {
     pub fn new() -> Self {
         Self {
             frame_count: 0,
-            frames_dropped: 0,
             ring: RingBuffer::new(),
             total_detections: 0,
-            total_tracks_created: 0,
-            total_tracks_lost: 0,
             ball_present_frames: 0,
             active_tracks: 0,
             max_frame_time: Duration::ZERO,
@@ -170,18 +164,6 @@ impl TelemetryCollector {
         if ball_present {
             self.ball_present_frames += 1;
         }
-    }
-
-    pub fn record_tracks_created(&mut self, count: u32) {
-        self.total_tracks_created += count as u64;
-    }
-
-    pub fn record_tracks_lost(&mut self, count: u32) {
-        self.total_tracks_lost += count as u64;
-    }
-
-    pub fn record_drop(&mut self) {
-        self.frames_dropped += 1;
     }
 
     pub fn snapshot(&self) -> TelemetrySnapshot {
@@ -255,7 +237,6 @@ impl TelemetryCollector {
 
         TelemetrySnapshot {
             frames_processed: self.frame_count,
-            frames_dropped: self.frames_dropped,
             elapsed,
             fps_average,
             fps_recent,
@@ -276,8 +257,6 @@ impl TelemetryCollector {
             },
             ball_presence_pct: ball_pct,
             active_tracks: self.active_tracks,
-            total_tracks_created: self.total_tracks_created,
-            total_tracks_lost: self.total_tracks_lost,
             gpu_name: self.gpu_name.clone(),
             encoder_name: self.encoder_name.clone(),
             decode_mode: self.decode_mode.clone(),
@@ -334,7 +313,6 @@ impl Default for TelemetryCollector {
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct TelemetrySnapshot {
     pub frames_processed: u64,
-    pub frames_dropped: u64,
     #[serde(with = "duration_secs")]
     pub elapsed: Duration,
     pub fps_average: f32,
@@ -352,8 +330,6 @@ pub struct TelemetrySnapshot {
     pub detections_per_frame: f32,
     pub ball_presence_pct: f32,
     pub active_tracks: u32,
-    pub total_tracks_created: u64,
-    pub total_tracks_lost: u64,
     pub gpu_name: String,
     pub encoder_name: Option<String>,
     pub decode_mode: Option<String>,
@@ -378,11 +354,7 @@ impl std::fmt::Display for SessionSummary {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = &self.snapshot;
         writeln!(f, "--- Session Summary ---")?;
-        writeln!(
-            f,
-            "Frames:    {} processed, {} dropped",
-            s.frames_processed, s.frames_dropped
-        )?;
+        writeln!(f, "Frames:    {} processed", s.frames_processed)?;
         writeln!(f, "Duration:  {:.1}s", s.elapsed.as_secs_f64())?;
         writeln!(
             f,
@@ -416,11 +388,6 @@ impl std::fmt::Display for SessionSummary {
             writeln!(f, "Detection:")?;
             writeln!(f, "  Ball present:  {:.0}% of frames", s.ball_presence_pct)?;
             writeln!(f, "  Detections:    {:.1}/frame", s.detections_per_frame)?;
-            writeln!(
-                f,
-                "  Tracks:        {} created, {} lost",
-                s.total_tracks_created, s.total_tracks_lost
-            )?;
         }
         Ok(())
     }

--- a/crates/reco-gui/FRICTION.md
+++ b/crates/reco-gui/FRICTION.md
@@ -1,316 +1,65 @@
 # GUI Consumer API Friction
 
-Friction points encountered while building the Slint GUI consumer of
-reco-core and reco-io. Active items are at the top; resolved items
-archived at the bottom with the PR that fixed them, so we can tell
-"this used to be painful" without re-litigating solved problems.
+Active friction points building the Slint GUI consumer against
+reco-core and reco-io.
 
 ## Active
 
-### ~~A3. Preview + export CUDA context race~~ RESOLVED
-
-Resolved in v0.5.0: preview rendering is paused during export via
-`is_exporting()` guard in `vsync_render_tick`. Playback is paused
-on export start and rendering resumes on completion.
-
-### ~~A4. No clean pipeline unload~~ RESOLVED
-
-Resolved in v0.5.0: `reset_pipeline()` on `AppState` drops bridge,
-resets playback, pose, calibration baselines, and pending seeks.
-Called from `unload_pipeline()` and all file-swap paths.
-
-**Impact**: Medium. Manifested as a real state-corruption bug in Tier 3.
-
-Once a `PreviewBridge` / `StitchPipeline` is built, the only way to
-swap to different source files is to drop the whole struct and rebuild
-from scratch. The GUI had to add its own `unload_pipeline()` helper
-that sets `bridge = None`, `calibration = None`, `playback = new()`,
-etc. - a half-dozen-field reset that reco-core doesn't own.
-
-Without this, swapping a file while a pipeline is live left the preview
-rendering the OLD source while `AppState.left_path/right_path` pointed
-elsewhere - and export read the new paths and produced garbage.
-
-**Suggested direction**: either a reco-core "session state" helper that
-bundles pipeline + source + calibration with a single `unload()`, or
-document the pattern in reco-io's StitchJob docs so the next consumer
-doesn't reinvent it.
-
 ### A5-residual. No intra-step heartbeat during very slow steps
 
-**Impact**: Low after the A5 primary fix (R22). The step label now
-matches the work (DetectingProfiles step) and telemetry isn't parsed
-twice, but individual steps can still run 20-60s silently: AKAZE
-feature detection on dense scenes, the optimizer on 100+ frame pairs,
-audio PCM extraction on long clips. A consumer can't distinguish
-"making progress" from "hung" inside a single step.
-
-**Suggested direction**: a heartbeat event every 2s during any step
-that exceeds a short threshold, so consumers can show a spinner or
-elapsed-time hint without needing intra-step instrumentation in every
-slow routine.
-
-### A7. render_to_target() still returns CommandBuffer
-
-**Impact**: Low. The Batch A `RenderTarget` / `RenderOutcome` enums
-simplified the surface-vs-internal asymmetry, but the lower-level
-`render_to_target()` still returns a `wgpu::CommandBuffer` the caller
-must submit. For the zero-copy Slint path this is fine (we render
-directly to a Slint-owned texture via `render_yuv`); future consumers
-that want to batch our render with their own copy commands already
-work with the current API. Leaving this as a note for anyone hitting
-the old asymmetry - the Batch A outcome enum was the right abstraction.
+**Impact**: Low. Individual calibration steps can run 20-60s silently
+(AKAZE on dense scenes, optimizer on 100+ pairs, audio PCM extraction).
+A consumer can't distinguish "making progress" from "hung."
 
 ### N5. ExportOutcome::Failed loses structured StitchError variants
 
-**Impact**: Medium. Hit while wiring the export-error toast/dialog.
-
-The cross-thread channel from the export worker back to the UI
-flattens `StitchError` into `ExportOutcome::Failed(String)`. The UI
-can show "something broke" but can't branch on the variant (e.g.
-retry-friendly FFmpegDecode vs hard-fail BadCalibration). Fixing it
-requires `StitchError: Clone + Send + Sync` so a rich variant can
-cross the channel boundary.
-
-Plan disposition: K3 / E5 (cross-thread error propagation cleanup).
+**Impact**: Medium. The cross-thread channel flattens `StitchError`
+into `ExportOutcome::Failed(String)`. The UI can't branch on the
+variant (retry-friendly vs hard-fail). Fix: `StitchError: Clone + Send + Sync`.
 
 ### N6. Calibration thread loses reco_calibrate::Error variants
 
-**Impact**: Medium. Sibling of N5 for the calibrate path.
+**Impact**: Medium. Sibling of N5. `CalibrationProgress::Failed` is
+a flat string. Users see "calibration failed" without actionable guidance.
 
-The calibration worker surfaces failures as a flat string via
-`CalibrationProgress::Failed`. Low-level context (AKAZE threshold
-too strict, RANSAC under-8 pairs, telemetry parse failure) gets
-collapsed. Users see "calibration failed" without actionable
-guidance. Same fix vector as N5: Clone+Send+Sync on the error enum.
+### N7. FfmpegFileSource opens full container just to read total_frames
 
-### N7. FfmpegFileSource opens the whole container just to read total_frames
-
-**Impact**: Low. Hit in the export dialog init.
-
-The GUI wants total_frames up front to render the progress bar
-scale. Today it constructs a full `FfmpegFileSource`, reads
-`.total_frames()`, and drops it. That's two muxer opens per export
-(init + real read). A lightweight `reco_io::probe_duration(path)`
-that only opens the muxer, reads stream metadata, and closes would
-remove one open.
-
-Plan disposition: K6 (E6-adjacent).
+**Impact**: Low. Two muxer opens per export (probe + real read).
+A lightweight `reco_io::probe_duration(path)` would remove one.
 
 ### N8. Slint wgpu 28 rendering notifier does not expose AdapterInfo
 
-**Impact**: Low (diagnostics). Hit while writing the "GPU info" footer.
-
-`reco-core::GpuContext::adapter_info()` is available everywhere
-_except_ inside the Slint rendering notifier closure, because Slint
-1.15 hands consumers a `wgpu::Device` without the parent `Adapter`.
-The GUI currently falls back to "unknown GPU" in its diagnostics
-panel. Upstream Slint feature request, blocked on them exposing
-the adapter reference.
-
-Plan disposition: K8 (Slint upstream; out of scope for this branch).
-
-### ~~N10. setup_autocam positional-11-arg signature~~ RESOLVED
-
-Resolved: the 11-arg function was deleted. `setup_autocam(&mut session, &config, fps)` with `AutocamConfig` is now the only API. All consumers migrated. `FieldPannerConfig` exposes all tuning parameters with safe defaults.
-
-### N11. Codec / Quality string parsing duplicated across consumers
-
-**Impact**: Low. Hit when a new codec variant lands.
-
-Each consumer (reco-cli `stitch`/`camera`/`preview`, reco-gui export
-dropdown) hand-rolls a `match` for `"h264" | "x264" | ...` to build
-`reco_io::Codec`. Four copies, and they drift on obscure names. A
-`Codec::from_str_loose` / `Quality::from_str_loose` helper in reco-io
-would collapse them into one.
-
-Plan disposition: K6 / E9.
+**Impact**: Low. Blocked on Slint upstream exposing the adapter reference.
 
 ### N12. YuvPlanes hand-constructed in every render call site
 
-**Impact**: Low. API ergonomics.
-
-To call `StitchCore::submit_frame_yuv`, each consumer builds
-`YuvPlanes { y: &[..], u: &[..], v: &[..], width, height }` from
-whatever shape its source delivers. That's 6 field accesses and an
-aspect-ratio compute spread across the GUI playback path and the CLI
-stitch path. A `YuvData::planes()` method that returns
-`YuvPlanes<'_>` directly would remove the per-call boilerplate.
-
-Plan disposition: K6 / E7.
+**Impact**: Low. A `YuvData::planes()` returning `YuvPlanes<'_>` would
+remove per-call boilerplate across GUI and CLI.
 
 ### N13. StereoFrame::into_yuv420p is missing
 
-**Impact**: Low. Sibling of N12.
-
-`StereoFrame` has `Yuv420p`, `Nv12`, and `Bgra` variants but no
-accessor to produce a `(YuvPlanes, YuvPlanes)` tuple from a Yuv420p
-variant. Consumers match on the variant themselves and destructure
-the inner pair — which is fine once, awkward when five sites do it.
-`as_yuv420p()` returning `Option<(YuvPlanes, YuvPlanes)>` would
-centralize the destructure.
-
-### ~~N14. StitchJob single on_session callback~~ RESOLVED
-
-Resolved: `on_session` now pushes to a `Vec<SessionCallback>`.
-Multiple hooks compose cleanly. A trait-based hook system would
-be preferred for complex future composition.
+**Impact**: Low. `as_yuv420p()` returning `Option<(YuvPlanes, YuvPlanes)>`
+would centralize the destructure done in 5+ sites.
 
 ### N15. PoseControl requires manual rig_tilt threading
 
-**Impact**: High. Caused a constrained-look regression in the GUI.
-
-Consumers must pass rig_tilt to both `clamp_via_coverage` and
-`render_pose` on every tick, and must remember to use `render_pose`
-instead of `current_pose` for the renderer. The CLI got this right;
-the GUI got it wrong.
-
-The renderer should own the pose state machine so rig_tilt, coverage
-clamping, and render compensation are automatic. Consumers would call
-`renderer.set_constrained_look(bool)` and `renderer.tick()` instead
-of manually coordinating PoseControl + coverage + rig_tilt.
-
-Plan disposition: K6 / E7. Lands with N12.
+**Impact**: High. Caused a constrained-look regression. Consumers must
+pass rig_tilt to both `clamp_via_coverage` and `render_pose` on every
+tick. The renderer should own the pose state machine.
 
 ### N16. Recording lags preview and drops frames during panning
 
-**Impact**: High. User-visible stutter during preview recording.
-
-The GUI's recording path runs `render_and_readback_nv12` on the UI
-thread. The NV12 readback stalls the GPU pipeline (triple-buffer
-latency), blocking the Slint compositor. Even with async encoder
-threads, the readback itself is synchronous and takes ~5-8ms per
-frame on the UI thread.
-
-**Current mitigation**: NV12 render every frame for the encoder,
-display preview only every 5th frame. This prioritizes encoding
-smoothness over preview responsiveness.
-
-**Proper fix**: Recording should use the export pipeline (`StitchSession`
-on a background thread with its own decoder), matching the CLI's
-`run_immediate` loop. The preview continues independently at its own
-rate. This is the Phase 11 recording architecture - "Rec" becomes
-a lightweight export job. Requires sharing the calibration and viewport
-state but NOT the GPU pipeline between preview and recording threads.
-
-**Alternative**: Accept the preview-loop model but move the NV12
-readback to a separate GPU queue or use compute-shader NV12 without
-readback (encode from GPU-resident data via VAAPI/NVENC hardware
-encoder path).
+**Impact**: High. NV12 readback runs on the UI thread, stalling the
+Slint compositor. Recording should use a background StitchSession
+(the export pipeline), not UI-thread readback.
 
 ### N17. No ROI visualization or editing in GUI
 
-**Impact**: Medium. The calibration produces `field_roi` (bounding box
-of the playing field in panoramic coordinates) but the GUI never shows
-or lets users adjust it. The ROI gates which detections the AI tracker
-considers - a wrong ROI means the tracker ignores the ball or tracks
-spectators. Users have no way to verify the ROI is correct without
-looking at raw calibration JSON.
-
-**Suggested direction**: overlay the ROI rectangle on the preview
-(transparent colored border). An edit mode where users can drag the
-ROI corners. Requires `panorama_to_screen` projection (inverse of the
-stitch projection) to map ROI coordinates to screen pixels.
+**Impact**: Medium. The calibration produces `field_roi` but the GUI
+never shows or lets users adjust it. Users can't verify the ROI
+without reading raw JSON.
 
 ### N18. Slint slider loses pointer tracking inside ScrollView
 
-**Impact**: Low. Reproducible with the correction slider in the Lens
-section. When the user drags a Slint Slider inside a ScrollView, the
-ScrollView can capture the pointer and the slider stops tracking.
-The slider "drops" from the cursor and blocks until re-clicked.
-
-Likely a Slint bug or interaction between ScrollView's pointer
-handling and Slider's drag gesture. Workaround: move critical sliders
-outside the ScrollView, or use a custom drag-based control.
-
-## Resolved (archived)
-
-Items pruned from Active once the reco-core / reco-io API added what
-we asked for. Kept as an audit trail of which consumer friction items
-drove which upstream changes.
-
-- **R1. wgpu version mismatch blocking zero-copy rendering**
-  Resolved 2026-04-16 by downgrading reco-core to wgpu 28 and using
-  Slint 1.15's `unstable-wgpu-28` feature. `PreviewBridge` now shares
-  Slint's device/queue via `GpuContext::from_device_queue()`.
-- **R2. No RGBA readback API on StitchRenderer**
-  Resolved by Batch A (#223): `StitchRenderer::render_and_readback_rgba()`
-  + `flush_rgba()` with triple-buffered staging.
-- **R3. StitchRenderer hardcoded InputFormat::Yuv420p**
-  Resolved by Batch A (#223): `StitchRenderer::new` now takes an
-  `input_format: InputFormat` parameter.
-- **R4. resize() didn't notify consumers of new dimensions**
-  Resolved by Batch C: `StitchPipeline::resize()` returns
-  `Option<(u32, u32)>`.
-- **R5. FrameSource::try_next_frame() EOF ambiguity**
-  Resolved by Batch A: `FrameSource::is_exhausted()` trait method.
-- **R6. render_to_view vs render_to_target asymmetry**
-  Resolved by Batch A: `RenderTarget` enum + `RenderOutcome`.
-- **R7. CalibrationResult didn't expose detected lens profile**
-  Resolved by Batch B (#224): `CalibrationResult.left_lens_profile` /
-  `right_lens_profile` carry `LensProfileInfo`.
-- **R8. No API to list available lens profiles**
-  Resolved by Batch B: `LensDatabase::iter_profiles()` +
-  `candidates(width, height)` returning `LensProfileSummary`.
-- **R9. Slider value binding echoes `changed` on programmatic updates**
-  Resolved by seek slider using `released` callback.
-- **R10. slint::Image::try_from(wgpu::Texture) per-frame allocation**
-  Investigated and closed upstream. Slint maintainer (tronical)
-  confirmed wgpu barriers handle the aliasing concern; no perf
-  difference measured.
-- **R11. No runtime API to probe ONNX Runtime execution providers**
-  Resolved by Batch E: `reco_detect::probe_execution_providers()`.
-- **R12. reco-calibrate didn't re-export lens profile types at crate root**
-  Resolved by Tier 1 PR (#236): `LensProfileInfo`,
-  `LensProfileSummary`, `ProfileSource` now re-exported from
-  `reco_calibrate` crate root.
-- **R13. Live lens tweaking had no fast CameraParams update path**
-  Resolved by Batch F (#238): `StitchPipeline::update_camera_params`
-  + matching method on `StitchRenderer`. Cheap enough for per-slider-
-  drag updates (no GPU pipeline rebuild).
-- **R14. No API to clamp camera pose to coverage boundary**
-  False friend - `CoverageBoundary::safe_clamp(yaw, pitch, fov, aspect,
-  rig_tilt)` was already present. Tier 2b constrained-look toggle uses
-  it directly.
-- **R15. Cannot re-run auto-calibrate after files_loaded**
-  Resolved by Tier 2 (#237) dropping the `!files_loaded` gate on the
-  Auto Calibrate button. Tier 3 hotfixes follow up with pipeline
-  unload on failure so the user doesn't end up in a mixed state.
-- **R16. Silent ffmpeg "Invalid argument" on bad input paths**
-  Resolved by Batch G (#254): `reco_core::source::validate_input_path`
-  with structured `InvalidPathReason` variants. The GUI maps each
-  reason to a toast ("File not found", "Permission denied", etc).
-- **R17. Silent encoder failures produce audio-only output**
-  Resolved by Batch G (#254): `StitchJob::run` re-opens the output
-  file after `session.finish()` and returns
-  `StitchError::EmptyOutput` if the video stream is empty. Catches
-  AV1-on-pre-Ada silent failure.
-- **R18. No shared settings persistence utility across consumers**
-  Resolved by reco-io PR #255: `reco_io::settings::{load, save,
-  config_dir, RecentFiles}` behind an opt-in `config` feature.
-  Per-consumer namespacing (`gui` / `cli` / `obs`) keeps each
-  consumer's settings independent.
-- **R19. CalibrateVideosOptions only accepted lens profiles via paths**
-  Resolved by Batch H: `CalibrateVideosOptions { left_params,
-  right_params: Option<CameraParams> }` added. Lens profile resolution
-  now goes params > path > auto-detect. Consumers with a pre-resolved
-  `CameraParams` (e.g. from `LensDatabase::candidates()`) can skip the
-  file round-trip.
-- **R20. StitchJob had no start_frame for partial exports**
-  Resolved by Batch H: `StitchJob::start_frame(u64)` builder. Combines
-  with `max_frames`/`duration` to select a time window. Implemented as
-  drain-and-discard (no seek), so exports like "0:15 - 0:30" decode
-  from 0:00 but session progress reflects only the exported window.
-- **R21. GpuContext::new() was async, consumers had to pollster-wrap**
-  Resolved by Batch H: `GpuContext::new_blocking()`. reco-cli, reco-io,
-  reco-calibrate, reco-obs, and reco-gui dropped their direct `pollster`
-  deps (except reco-cli, which still needs it for
-  `GpuContext::for_surface` on the preview path).
-- **R22. Wrong step label + double telemetry parse during calibration**
-  Resolved 2026-04-18: new `CalibrationStep::DetectingProfiles` variant
-  emitted before `pipeline.detect_profiles()` so the GUI label matches
-  the work. `CalibrationPipeline` caches parsed `TelemetryData` for each
-  side on first use; `imu_sync()` reuses what `detect_profiles()` already
-  read. On DJI Action 4 4K/10-bit this halves wall time on the first
-  half of calibrate_videos (~175s → ~85s). Heartbeat emission during
-  very slow individual steps is tracked as A5-residual.
+**Impact**: Low. Likely a Slint bug. Workaround: move critical sliders
+outside the ScrollView.

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -155,7 +155,7 @@ pub fn run_export(
     .format(format)
     .resolution(width, height)
     .blend_width(blend)
-    .on_progress(move |p: &reco_core::session::FrameProgress| {
+    .on_progress(move |p: &reco_core::session::types::FrameProgress| {
         let frames = p.frames_completed;
         let elapsed = progress_start.elapsed().as_secs_f64();
         let fps = if elapsed > 0.0 {

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -46,7 +46,6 @@ impl reco_core::telemetry::TelemetrySink for ExportTelemetrySink {
                 app.set_telem_active_tracks(snap.active_tracks as i32);
                 app.set_telem_ball_pct(snap.ball_presence_pct);
                 app.set_telem_det_per_frame(snap.detections_per_frame);
-                app.set_telem_frames_dropped(snap.frames_dropped as i32);
                 app.set_telem_gpu_name(snap.gpu_name.clone().into());
                 app.set_telem_bottleneck(
                     snap.bottleneck

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -290,8 +290,6 @@ fn build_bug_report(state: &AppState, app_weak: &slint::Weak<RecoApp>) -> String
         let fps_recent = app.get_telem_fps_recent();
         let total_ms = app.get_telem_total_ms();
         let bottleneck = app.get_telem_bottleneck().to_string();
-        let dropped = app.get_telem_frames_dropped();
-
         if fps_avg > 0.0 || total_ms > 0.0 {
             report.push_str(&format!(
                 "\n## Performance\n\
@@ -300,9 +298,6 @@ fn build_bug_report(state: &AppState, app_weak: &slint::Weak<RecoApp>) -> String
             ));
             if !bottleneck.is_empty() {
                 report.push_str(&format!("- Bottleneck: {bottleneck}\n"));
-            }
-            if dropped > 0 {
-                report.push_str(&format!("- Dropped frames: {dropped}\n"));
             }
         }
 

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -23,7 +23,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use crate::output::{AudioMode, Bitrate, Codec, Format, Quality};
-use reco_core::session::{FrameProgress, StitchSession};
+use reco_core::session::StitchSession;
+use reco_core::session::types::FrameProgress;
 use reco_core::source::FrameSource;
 
 /// One-shot stitching job: video files in, encoded video out.
@@ -185,7 +186,7 @@ pub enum StitchError {
     Gpu(#[from] reco_core::gpu::GpuError),
     /// Session/pipeline error during stitching.
     #[error("session: {0}")]
-    Session(#[from] reco_core::session::SessionError),
+    Session(#[from] reco_core::session::types::SessionError),
     /// Encoder error.
     #[error("encoder: {0}")]
     Encoder(#[from] reco_core::encoder::EncodeError),
@@ -560,7 +561,7 @@ impl StitchJob {
             rig_roll: cal.rig_roll as f32,
             ..Default::default()
         };
-        let session_config = reco_core::session::SessionConfig {
+        let session_config = reco_core::session::types::SessionConfig {
             calibration: cal,
             viewport,
             input_width: info.width,
@@ -664,8 +665,11 @@ impl StitchJob {
         }
 
         // Compute frame limit
-        let frame_limit =
-            reco_core::session::compute_frame_limit(self.duration, self.max_frames, info.fps);
+        let frame_limit = reco_core::session::types::compute_frame_limit(
+            self.duration,
+            self.max_frames,
+            info.fps,
+        );
 
         // Optional replay recording: wrap the source with a
         // decorator that writes pre-stitch frames to a stacked-video

--- a/crates/reco-obs/FRICTION.md
+++ b/crates/reco-obs/FRICTION.md
@@ -1,459 +1,101 @@
 # OBS Plugin Consumer API Friction
 
-Friction points encountered while building `reco-obs` as a plugin
-consumer of `reco-core` / `reco-io`. Active items at the top;
-resolved items archived at the bottom with the PR that fixed them.
+Active friction points building `reco-obs` against `reco-core` / `reco-io`.
 
 ## Active
 
-### A5. No temporal frame pairing helper in reco-core / reco-io
+### A3. No OBS-level wgpu interop
 
-**Impact**: Medium for any dual-source live consumer (OBS now, V4L2
-later). Hit 2026-04-18 while wiring OBS Tier 1 ingestion.
+**Impact**: Fundamental. OBS uses OpenGL/D3D11, reco-core uses wgpu.
+Rendered frames must roundtrip through CPU (~8 MB/frame at 1080p).
+Platform-specific solutions (DMA-BUF on Linux, shared D3D11 on Windows)
+need new interop code. Known limit, not actionable without a specific target.
 
-`obs_source_get_frame` returns the "current" async frame for a given
-source: whatever the upstream producer last handed OBS. With two
-independent cameras feeding two independent OBS sources, the two
-calls return frames whose timestamps may disagree by one or more
-frame intervals (upstream producers run on separate threads with
-their own pacing).
+### A5. No temporal frame pairing helper
 
-Tier 1 of reco-obs just polls both sides every `video_tick` and
-submits the pair unconditionally - if drift grows, we start stitching
-temporally mismatched frames with no warning.
+**Impact**: Medium. Two independent OBS sources return frames with
+mismatched timestamps. A reusable ring-buffer pairing helper in
+reco-io would emit closest-timestamp pairs and surface drift warnings.
+Same helper reused by future WebRTC/V4L2 consumers.
 
-A proper solution is a reusable ring-buffer pairing helper in reco-io
-(or reco-core) that:
-- Takes `(timestamp, StereoSide, FrameBufferHandle)` submissions from
-  each side,
-- Emits `(left, right)` pairs with the closest timestamps when both
-  sides have recent frames,
-- Drops older unpaired frames,
-- Surfaces a "last pairing delta" so consumers can warn when drift
-  exceeds a threshold.
+### A6. No source filtering by OBS_SOURCE_ASYNC_VIDEO
 
-The same helper would be reused by a future WebRTC ingest or a live
-V4L2 consumer. Living in a consumer crate means every new consumer
-reinvents it.
+**Impact**: Low. Source-picker shows every OBS source including scenes
+and audio-only. Fix: 5 lines of FFI + a conditional.
 
-### A6. No obs_source_get_output_flags binding to filter source picker
+### A7. No auto-resize on input dimension change
 
-**Impact**: Low (UX papercut). The reco-obs source-picker dropdowns
-currently show *every* OBS source - scenes, audio-only inputs,
-transitions, filters. Picking a scene just causes
-`obs_source_get_frame` to return null, which we handle silently,
-but it's a bad UX.
-
-Properly filtering to async-video-capable sources (inputs that set
-`OBS_SOURCE_ASYNC_VIDEO`) requires a new FFI binding for
-`obs_source_get_output_flags`. Noted here so we don't lose track;
-the fix is 5 lines of FFI + a conditional in the enumeration
-callback, but it's OBS-FFI scope only.
-
-### A7. No auto-resize when input frame dimensions don't match
-
-**Impact**: Low (UX papercut). When an upstream source delivers
-frames whose dimensions differ from the plugin's `input_width /
-input_height` properties, we log once and skip all submissions
-until the user edits the properties. A nicer flow would be to
-reinitialize the `LiveStitchSession` on the first received frame
-whose dimensions differ, picking up the new size automatically.
-
-Not actionable at the reco-core level - `LiveStitchSession::new`
-already supports being rebuilt - but the reco-obs callback plumbing
-has to detect the size change and reset cached state (repack
-buffers, OBS texture, etc.). Tier 2 item.
+**Impact**: Low. Dimension mismatch between properties and actual frames
+silently freezes output. Consumer-side rebuild works but isn't automatic.
 
 ### A9. obs_source_get_frame only sees async video sources
 
-**Impact**: High. Discovered 2026-04-18 while trying to route an OBS
-Browser Source (VDO Ninja) into Tier 1 ingestion.
+**Impact**: High. Sync sources (Browser Source, screen capture) are
+invisible. Needs a render-to-texture fallback path via OBS graphics API.
 
-OBS has two source rendering models:
+### A10. No detector/director hooks on push API
 
-- **Async video sources** (Media Source / ffmpeg_source, V4L2 Device,
-  NDI, Decklink): produce frames via `obs_source_output_video()`. OBS
-  buffers them and our current ingestion path reads via
-  `obs_source_get_frame()`.
-- **Sync video sources** (Browser Source, Screen Capture, Window
-  Capture, Game Capture, Video Composite): render directly via a
-  `video_render` callback. OBS never buffers their output; there is
-  no async frame queue for `obs_source_get_frame` to pull from.
+**Impact**: Medium. AI tracking works in StitchSession (pull) but not
+in StitchCore (push, used by OBS). Need set_detector/set_director on
+the push API, plus a worker-thread inference scheduler.
 
-Tier 1 of reco-obs uses `obs_source_get_frame`, so sync video sources
-are silently invisible - `get_frame` returns NULL forever, our diag
-log shows `submitted=0 missed_*` ticking up indefinitely with no
-warning (it looks healthy but no frames arrive).
+### A11. Visible upstream sources steal async frames
 
-**Suggested direction** (reco-obs, not reco-core):
+**Impact**: High UX. When an upstream source is visible in the OBS scene,
+its renderer consumes the async frame before our poller can read it.
+Hiding the source via the eye icon fixes it. Needs auto-hide on pick.
 
-Add a render-to-texture fallback. In `render_and_readback`, after
-`obs_source_get_frame` returns NULL for a slot, render the source to
-our own `gs_texture_t`:
+### A12. No keyboard/controller mapping for pan-zoom
 
-```c
-obs_enter_graphics();
-gs_texture_t *my_tex = /* pre-allocated per side */;
-gs_viewport_push();
-gs_projection_push();
-gs_set_render_target(my_tex, NULL);
-gs_ortho(0.0f, cx, 0.0f, cy, -100.0f, 100.0f);
-gs_clear(GS_CLEAR_COLOR, &zero, 0.0f, 0);
-obs_source_video_render(left_source);
-gs_set_render_target(NULL, NULL);
-gs_projection_pop();
-gs_viewport_pop();
-// download my_tex -> CPU staging -> BgraPlanes (Batch J)
-obs_leave_graphics();
-```
+**Impact**: Medium. Only OBS Interact window works for pan/zoom. Need
+obs_hotkey_register_source for keyboard, SDL3 sidecar for gamepad.
 
-Needs new FFI bindings for `gs_set_render_target`,
-`gs_viewport_push/pop`, `gs_projection_push/pop`, `gs_ortho`,
-`gs_clear`, `obs_source_video_render`, and a GPU-to-CPU texture
-readback path (staging buffer + `gs_stagesurface_map`). ~2-3 hours.
+### A13. No constrained-look toggle
 
-Once implemented, the existing Batch J BGRA path (R5) is what
-consumes the readback, so no further reco-core work needed.
-
-**Workaround for now**: use any async source (Media Source pointed at
-a file, V4L2 camera, NDI input) while sync-source support is on
-backlog. VDO Ninja can also expose a local v4l2loopback virtual
-camera via `v4l2loopback-dkms` + an ffmpeg pipeline - that path is
-async and works with Tier 1 I420 today.
-
-### A10. LiveStitchSession doesn't expose director / detector hooks for AI panning
-
-**Impact**: Medium. AI ball-tracking / auto-pan works in `reco-cli
-stitch --model` and in the GUI via `reco_core::session::StitchSession`
-(the file-stitching pull-based path), but `LiveStitchSession` (the
-push path used by reco-obs and any future live consumer) has no API
-to plug in a detector + director.
-
-Manual panning is live in reco-obs via the yaw/pitch property sliders
-(2026-04-18), which gives basic usability, but there's no path to
-"follow the ball automatically" in the OBS plugin today.
-
-**Suggested direction** (reco-core):
-
-Mirror `StitchSession`'s detector/director hooks on
-`LiveStitchSession`:
-
-- `LiveStitchSession::set_detector(Box<dyn Detector>)`
-- `LiveStitchSession::set_director(Box<dyn Director>)`
-- In `submit_frame` / `submit_frame_bgra`: after receiving the frame,
-  run detector -> update director -> use director's `ViewportPosition`
-  for yaw/pitch instead of the caller-provided values (or blend
-  director output with manual offsets).
-
-Consumer side (reco-obs Batch L):
-
-- Add `reco-autocam` + `reco-detect` as deps (plugin binary grows
-  ~30-50 MB with ORT bundled).
-- New properties: "Auto-pan model" (path to .onnx), "Tracking mode"
-  (ball / field), "Detection interval" (every N frames).
-- Run detection on a worker thread (not the video_tick thread) so
-  inference latency doesn't stall frame submission at 30fps+.
-- Expose tracking-quality feedback somehow (overlay? log? status
-  indicator?) so users see why auto-pan landed somewhere.
-
-Estimated ~4-6 hours minimum for a workable v1, plus meaningful
-testing time to validate tracking on real camera pairs.
-
-### A11. Visible upstream sources steal async frames from our poller
-
-**Impact**: High (UX footgun). When an upstream Media Source is
-visible in the scene (eye icon ON), OBS's scene renderer pulls its
-async frames for compositing, and our subsequent
-`obs_source_get_frame` polls return NULL every tick. Hiding the
-upstream with the eye icon (while our `inc_showing` / `inc_active`
-refs keep its decoder running) is what lets frames land in our poll.
-
-Discovered 2026-04-18 after a long debugging session where picking
-Media Sources appeared to do nothing. Toggling their visibility off
-immediately produced `first stitched frame ready` and `submitted`
-counters started growing at 30 fps.
-
-**Suggested direction** (reco-obs, plugin-level): when the user
-picks an upstream source in our properties, automatically hide its
-scene item (if any) via `obs_sceneitem_set_visible(item, false)`.
-Would need new FFI bindings for:
-
-- `obs_source_get_scene` or equivalent (walk scene graph to find the
-  scene item referencing our picked source)
-- `obs_sceneitem_set_visible`
-- Likely `obs_scene_enum_items` to locate the scene item
-
-Undo on `dec_showing` / destroy would be nice but not required - the
-user can toggle visibility back themselves if they move the source
-to a different scene.
-
-Alternate direction: surface a UI hint in the properties dialog
-("Hide upstream sources in the scene panel for correct frame
-capture"), or add a dedicated help string on each dropdown.
-
-Documenting here so the next person hitting this has an immediate
-answer; the pure-UX fix is small but OBS scene-graph walking is
-fiddly so it's backlog, not urgent.
-
-### A12. No keyboard / controller mapping for pan-zoom
-
-**Impact**: Medium. Drag-to-pan and scroll-to-zoom work in OBS
-"Interact" mode, but that requires opening a separate interact
-window every session. Live operators using a keyboard, or game-pad
-operators with a PS5/Xbox controller, have no fast path.
-
-**Suggested direction**:
-
-- **Keyboard (short-term)**: use OBS's `obs_hotkey_register_source`
-  API to declare hotkeys on the Reco source (yaw_left,
-  yaw_right, pitch_up, pitch_down, zoom_in, zoom_out, reset).
-  Users bind them in File -> Settings -> Hotkeys. Requires new FFI
-  bindings for the hotkey registration API; ~1 hour of work.
-- **Game pad (medium-term)**: OBS does not expose controller input
-  directly. Options: (a) a sidecar process using SDL3 that reads
-  controller axes and sends them to the plugin via a Unix socket /
-  named pipe; (b) use a general-purpose virtual-joystick-to-keyboard
-  utility (QJoyPad, antimicro) and bind to the hotkeys from path
-  (a). Plan to document the SDL3 sidecar approach in a separate
-  PR so game-pad support is reproducible.
-
-### A13. No "constrained look" toggle in the OBS plugin
-
-**Impact**: Medium. `reco_core::projection::CoverageBoundary::safe_clamp`
-exists (it's used by the GUI's constrained-look toggle, Tier 2b) but
-the OBS plugin applies raw yaw/pitch straight to the renderer. At
-extreme pan angles the view shows black borders outside the stitched
-coverage.
-
-**Suggested direction**: add a `constrained_look: bool` property to
-reco-obs, default true. When set, `render_and_readback` should clamp
-yaw/pitch via `CoverageBoundary::safe_clamp(yaw, pitch, fov, aspect,
-rig_tilt)` before passing to `submit_frame`. The calibration file
-already carries the boundary definition - just need to expose the
-clamp function through `LiveStitchSession` or plumb it at the
-reco-obs layer. Small: ~30 min including property wiring.
+**Impact**: Medium. CoverageBoundary::safe_clamp exists but the OBS
+plugin applies raw yaw/pitch. Extreme pan shows black borders. Fix:
+add a constrained_look property, ~30 min.
 
 ### A14. No live calibration workflow for non-file sources
 
-**Impact**: High for production live use. The current calibration
-path (`reco_calibrate::video::calibrate_videos`) requires two video
-*files* on disk. For live OBS sources (V4L2 cameras, NDI, WebRTC)
-there's no equivalent that captures from a live source to produce
-calibration JSON.
-
-**Suggested direction** (reco-calibrate + reco-obs):
-
-- reco-calibrate already exposes the lower-level
-  `calibrate(&gpu, &frame_pairs)` that takes in-memory frame pairs -
-  the algorithmic side is ready.
-- New reco-io helper: a "capture N frame pairs from two live
-  FrameSources" utility that wraps the `StereoFrame` delivery and
-  hands back `Vec<(YuvFrame, YuvFrame)>`.
-- reco-obs UI: a "Calibrate from current sources" button in the
-  properties that grabs ~30 frame pairs from the picked async
-  sources via our existing `obs_source_get_frame` loop, feeds to
-  `calibrate()`, writes the JSON next to the configured calibration
-  path, then reloads.
-
-Estimated 3-4 hours of work across the two crates.
+**Impact**: High. Calibration requires video files. Live OBS sources
+need a "Calibrate from current sources" button that captures N frame
+pairs and runs the solver.
 
 ### A15. OBS Interact window is a poor primary UX
 
-**Impact**: Medium. Users expect to pan the panorama in the main
-scene view, not a separate interact window that must be kept open.
-OBS's interaction model is designed for web source clicks, not
-continuous compositor control.
+**Impact**: Medium. Users expect to pan in the main scene view, not a
+separate interact window. A dock panel with sliders + preview would be
+better but requires Qt bindings.
 
-**Suggested direction**: the nicer shape is an embedded dock panel
-(like Transition Override, Scene Filters) that gives a dedicated
-control surface: yaw / pitch sliders with live preview, FOV slider,
-constrained-look toggle, detector-status LED, recenter button. OBS
-exposes dock registration via `obs_frontend_add_dock_by_id` (needs
-qt bindings, typically via a small C++ shim). This is substantial
-plumbing work but dramatically better UX than per-property sliders +
-Interact mode.
+### A16. No built-in replay mode
 
-Alternate short-term: offer a full-screen projector ("Windowed
-Projector (Source)" in OBS, already built in) that shows just our
-panorama, and keep driving the pose via hotkeys (A12).
+**Impact**: Low-Medium. Users want scene-switch to replay. Needs an
+opt-in rolling buffer on StitchCore (~7 GB at 1080p/30fps/30s).
 
-### A16. No built-in scene / replay mode
+### A17. No AI auto-pan in the OBS plugin
 
-**Impact**: Low to medium. Users want to switch scenes to a playback
-view and enable replay instantly - replay isn't a plugin feature
-today, and scene switching is regular OBS behavior but OBS doesn't
-know our plugin's internal ring-buffer state.
+**Impact**: Medium. See A10. Requires reco-autocam + reco-detect as
+deps with worker-thread inference.
 
-**Suggested direction** (two parts):
+### A20. Replay toggle decoupled from OBS Record/Stream buttons
 
-- **Reco-core**: add an optional "rolling buffer" helper on
-  `LiveStitchSession` - a ring of the last N stitched RGBA frames
-  with timestamps, configurable duration (e.g. "keep last 30s").
-  Memory cost: 1920*1080*4 * 30fps * 30s = ~7 GB, so needs to be
-  opt-in.
-- **Reco-obs**: expose a "Replay mode" toggle + hotkey. When
-  activated, the source's `submit_frame` path switches from "stitch
-  current" to "replay from buffer", advancing the buffer pointer
-  based on wall time (or scrubbable via hotkey). Scene switch
-  orthogonal to this - the user uses standard OBS scene transitions
-  and the source just plays back from the buffer.
+**Impact**: Medium. The replay checkbox is independent of OBS's global
+recording state. Users expect OBS's Record button to control everything.
 
-Estimated 4-6 hours plus memory-budget discussion.
+### A21. Live Matroska replay hard to scrub in players
 
-### A22. Input dimensions are declared, not detected — mismatched sources silently freeze the output
+**Impact**: Low. Matroska files being written have unstable duration
+metadata. Finalized files scrub normally.
 
-**Impact**: High UX. Surfaced 2026-04-19 during second in-OBS test. `Input width` and `Input height` in the Reco source Properties dialog are user-declared values that must match the actual frames coming from both upstream OBS sources. If they drift out of sync (e.g. user swaps one source from a 1080p Media Source to a 4K Media Source without also updating Input W/H), the plugin logs `input-dim mismatch (configured WxH, left=..., right=...)` once and then refuses to submit frames. The last rendered frame stays on screen, OBS keeps polling, and the user sees a hang.
+### A22. Input dimensions declared, not detected
 
-Observed symptom: `diag_tick` keeps advancing while `submitted` plateaus. Only visible in stderr/log; Properties UI gives no hint.
+**Impact**: High UX. User must manually set input W/H in properties.
+Mismatched dims silently freeze output. Should auto-detect from first
+frame and rebuild the pipeline.
 
-Root cause: the pipeline's GPU textures are sized at `StitchCore::new` time using the declared Input W/H. When the actual incoming frame dimensions differ, the submit path (`StitchCore::submit_frame_yuv_at_pose`) correctly rejects — but reco-obs does not rebuild the session to match the new input.
+### N9. FOV accessors require pipeline_mut()
 
-**Suggested direction**: on every successful upstream-source bind, peek the first frame's reported width/height, compare against `self.input_width` / `self.input_height`, and if they differ:
-
-1. Log the detected dims at `info!` level so the story is obvious: "reco-obs: detected input 5312x2988 on right, rebuilding pipeline."
-2. Update `self.input_width` / `self.input_height` from the detection (probably also write them back to the OBS settings dict so the Properties UI reflects reality next time the user opens it).
-3. Invalidate the current `core` (set to `None`) and call `try_init_pipeline` to rebuild with the new dimensions.
-4. Handle the mismatch case (left=1080p, right=4K) explicitly: log a clear error, maybe grey out the source preview with an overlay, and wait for both sides to match instead of silently refusing.
-
-Bonus: a scale / downscale option in Properties (tied to A19) would let users mix 1080p + 4K intentionally by requesting the output scale to the lower of the two.
-
-**Blocks**: nothing urgent in production, but the first time any user changes sources they hit this and assume the plugin crashed.
-
-**Impact**: Medium. Surfaced 2026-04-19 during first in-OBS test. Replay tiles are written at the exact input resolution (the stacked composite is `width × 2*height` for N=2), with no way to request a smaller recording. Consequences:
-
-- Two 5K cameras produce a 5120×5760 composite. libx264 software encode at this size struggles to keep up on modest hardware, the file grows at several GB/min, and disk I/O may stall the OBS video_tick.
-- A user who wants replay for review purposes (not archival) has no way to trade quality for size.
-
-Today we emit a `warn!` when the input exceeds 4K per tile so the user isn't silently blindsided, but the proper fix is a UI-visible `Replay scale` dropdown (Full / 1080p / 720p) and a `Replay quality` dropdown (Fast / Balanced / High). Both map onto `StackedEncoderConfig.inner.{resolution, quality, crf}` which already exist.
-
-**Suggested direction**: add two dropdowns in the reco-obs properties UI and thread them through `StackedEncoderConfig`. A GPU-resident downscale (once the future wgpu pack path lands) would avoid the CPU hit entirely.
-
-### A20. Replay record toggle is fully decoupled from OBS Stream / Record buttons
-
-**Impact**: Medium UX. Surfaced 2026-04-19 during first in-OBS test, revisited same-day. The "Record replay (stacked video)" checkbox in the Reco source Properties dialog is a pure plugin-side toggle - it starts and stops writing the `.mkv` file on its own, with no connection to OBS's global "Start Recording" or "Start Streaming" buttons. Two surprises in both directions:
-
-- Enabling the checkbox while OBS isn't recording anything still writes a replay file (probably unexpected; the user may assume "OBS isn't recording" means nothing is being written to disk).
-- Clicking OBS's "Start Recording" does NOT also start the replay (and conversely "Stop Recording" doesn't stop it). Users have to toggle the replay checkbox separately, each time.
-
-The mental model users carry is closer to "OBS's record button controls everything the plugin writes." Ours doesn't match that.
-
-**Suggested direction** (two alternatives):
-
-1. **Follow OBS state**: the replay toggle becomes "Enable replay recording" (intent), and the actual file is opened when OBS starts recording/streaming AND the checkbox is ticked, closed when OBS stops. Cleanest from a user-expectation standpoint.
-2. **Surface a dedicated button**: add a "Record replay" button in OBS's main UI alongside the existing Start Recording / Start Streaming. Requires registering a hotkey or dock. More work but gives the user a clear separate control when they genuinely want replay independent of OBS recording.
-
-Option 1 is the lower-friction default, but loses the use case "record replay for post-match review without also doing an OBS recording of the stitched output." Option 2 preserves both flows at the cost of UI weight. Leaning toward shipping option 1 + documenting that option 2 is available as a toggle in Advanced settings.
-
-**Blocks**: nothing urgent, but every user who tries replay hits this on first run.
-
-### A21. Live Matroska replay is hard to scrub in general-purpose players
-
-**Impact**: Low. Surfaced 2026-04-19 during first in-OBS test. A Matroska file that's still being written has unstable duration metadata - VLC, mpv, and OBS itself treat the duration as `N/A` and won't scrub backwards past a few seconds. This is a generic streaming-container limitation, not a reco bug: finalized files (after the user unticks the toggle) scrub normally.
-
-**Suggested direction**: either accept it (replay is replay, not scrub), or write a parallel "chunked" file (rotate every N seconds into a new .mkv) so recent chunks are always complete and seekable. Low priority - real-time replay in a stitcher UI is future work anyway.
-
-### A17. No AI auto-pan access in the OBS plugin
-
-See also A10 (deeper architectural notes). Short version: reco-obs
-needs a way to plug in `reco_autocam::Director` + `reco_detect`
-execution. Requires `LiveStitchSession::set_detector` /
-`set_director` hooks in reco-core, then adding
-`reco-autocam` + `reco-detect` as reco-obs deps with a worker-thread
-inference scheduler so the 30fps tick doesn't stall on ORT
-inference. User has flagged AI access as important; worth
-prioritizing once the friction backlog is worked.
-
-### A3. No OBS-level wgpu interop
-
-**Impact**: Fundamental to OBS architecture, not a reco-core bug.
-
-OBS uses its own graphics context (OpenGL / D3D11) and reco-core uses
-wgpu. There's no interop path, so rendered frames must be copied
-through CPU (GPU → staging → CPU → OBS texture). At 1080p that's
-~8 MB per frame; at 60fps = ~480 MB/s memory bandwidth wasted.
-
-Platform-specific solutions (DMA-BUF on Linux, shared D3D11 textures
-on Windows) would need new interop code in reco-core. The
-`GpuContext::from_device_queue()` method would help if OBS moved to
-wgpu, which it hasn't.
-
-Tracking here as a known limit; not actionable at the reco-core
-level without a specific interop target.
-
-### N9. FOV accessors still require pipeline[_mut]()
-
-**Impact**: Low. Hit every time the plugin changes FOV from a UI
-event.
-
-Post-M3, `StitchCore` owns the pipeline and exposes `pipeline_mut()`
-for direct access, but there's no `StitchCore::set_fov(f32)` /
-`fov_degrees()` shortcut. Consumers go through
-`core.pipeline_mut().set_fov(v)` and `core.pipeline().viewport_config().fov_degrees`.
-Three public surfaces for a single hot-path operation.
-
-A `StitchCore::set_fov` + `StitchCore::fov_degrees` pair would match
-the `set_rig_tilt` / `rig_tilt` pattern already on the core. Same
-shape extension applies to `blend_width` and `rig_roll` — currently
-reached via the same pipeline detour.
-
-Plan disposition: K6 (post-M3 ergonomics; defer until a second
-consumer hits the same pain).
-
-## Resolved (archived)
-
-- **R1. No RGBA readback helper on StitchPipeline**
-  Resolved by Batch A (#223): `StitchRenderer::render_and_readback_rgba()`
-  + `flush_rgba()` with triple-buffered staging, same pattern as
-  `Nv12Converter`. Earlier ~40 lines of boilerplate in
-  `reco-obs/source.rs` can be replaced.
-- **R2. GpuContext::new() was async**
-  Resolved by Batch H: `GpuContext::new_blocking()` added in reco-core.
-  `reco-obs` dropped its direct `pollster` dep; plugin callbacks can
-  now init the GPU synchronously without a runtime.
-- **R3. YuvPlanes required tight packing, not stride-aware**
-  Resolved by Batch I: `reco_core::pipeline::{FramePlaneView,
-  StridedYuvPlanes}` added alongside the existing tight `YuvPlanes`.
-  `StridedYuvPlanes::copy_into(&mut Vec<u8>)` repacks padded rows into
-  a caller-owned buffer (tight-fast-path when `stride == width`) and
-  returns a borrowed `YuvPlanes` ready for
-  `StitchPipeline::render_to_target`. Buffer is reusable across frames
-  to avoid per-frame allocation.
-- **R4. No live camera input consumer helper**
-  Resolved by Batch I: `reco_core::session::{LiveSessionConfig,
-  LiveStitchSession}`. Bundles `StitchPipeline` + `RgbaReadback` with
-  `submit_frame(left, right, yaw, pitch) -> Option<&[u8]>` for push-
-  based compositor consumers (OBS, V4L2, WebRTC). `reco-obs/src/source.rs`
-  migrated to it - net removal of ~30 lines of per-consumer plumbing.
-- **R5. reco-core only accepted YUV inputs (blocked Browser Source / WebRTC)**
-  Resolved 2026-04-18 by Batch J: `InputFormat::Bgra` variant in
-  `reco_core::renderer`, `BgraPlanes` input struct + `render_to_target_bgra`
-  / `LiveStitchSession::submit_frame_bgra`. Shader branches on flags.y==2
-  to sample a single `Rgba8Unorm` texture and skip YUV conversion. Bind
-  group layout unchanged (1x1 dummy textures for u/v in BGRA mode).
-  reco-obs now exposes an "Input format" dropdown (I420 / BGRA); Browser
-  Source, screen capture and WebRTC feeds that deliver BGRA/BGRX/RGBA
-  are accepted, swizzle-to-RGBA happens once per frame into a cached
-  buffer.
-- **A18. No push-API entry point for disk-based replay recording**
-  Resolved 2026-04-19 alongside M6.5 item 3 wiring. Added
-  `reco_core::core::StackedReplayRecorder` trait and
-  `StitchSession::{set,clear,flush}_stacked_recorder` on the push
-  API. reco-io provides `stacked_video::replay::session_recorder(path,
-  config, width, height)` that returns a `Box<dyn StackedReplayRecorder>`
-  ready for `session.set_stacked_recorder(...)`. Mirrors the pull-side
-  `StitchJob::with_replay_recording` builder: one line for the
-  consumer, the session owns the per-frame tap + encoder lifecycle.
-  Integration test `session_recorder_records_planes` in
-  `reco-io/tests/stacked_video_roundtrip.rs` verifies a round trip
-  through the trait path.
-
-## Notes on plugin status
-
-Tier 1 (2026-04-18): real dual-source frame ingestion landed. The
-plugin now exposes two source pickers in its properties UI (left /
-right), resolves them via `obs_get_source_by_name`, and polls
-`obs_source_get_frame` every `video_tick`. I420 input is routed
-through `StridedYuvPlanes::copy_into` (Batch I) into
-`LiveStitchSession::submit_frame`; other formats (NV12, YUY2,
-UYVY, packed RGB) are logged once and skipped. Tier 2 target is
-NV12 + temporal pairing (blocked on A5).
+**Impact**: Low. No StitchCore::set_fov/fov_degrees shortcut. Consumers
+detour through core.pipeline_mut().set_fov(v). Should match the
+set_rig_tilt pattern.

--- a/docs/WGPU_29_METAL_REFERENCE.md
+++ b/docs/WGPU_29_METAL_REFERENCE.md
@@ -1,7 +1,7 @@
 # wgpu 29 Metal Interop Reference
 
-The `crates/reco-core/src/metal_interop.rs` and
-`crates/reco-core/src/metal_compute.rs` modules were ported from
+The `crates/reco-core/src/interop/metal.rs` and
+`crates/reco-detect/src/metal_compute.rs` modules were ported from
 the objc2-metal API (wgpu 29-era) to the metal crate 0.33 API
 (wgpu 28) in PR #217 as part of the wgpu version downgrade.
 


### PR DESCRIPTION
## Summary

Housekeeping pass to clean up stale tracking before moving to feature work.

### FRICTION.md cleanup
- reco-gui: 317 -> 61 lines (deleted all resolved items and archive)
- reco-obs: 460 -> 86 lines (same)

### Session re-exports removed
- Dropped `pub use types::*` from session/mod.rs
- Consumers now import from `reco_core::session::types::SessionConfig` etc.
- 12 files updated

### Telemetry cleanup
- Removed 3 never-called methods: `record_tracks_created`, `record_tracks_lost`, `record_drop`
- Removed dead counters: `total_tracks_created`, `total_tracks_lost`, `frames_dropped` (from telemetry - session has its own counter)
- Telemetry now only reports what it actually measures

### GitHub issue triage
Closed 6 issues resolved by recent work:
- #274 Jetson NVMM zero-copy (merged ef3088e4)
- #165 Dead code cleanup (PR #297)
- #192 Live calibration preview (superseded by GUI sliders)
- #185 Gyroflow research (documented in vault)
- #184 Simplify lookahead (Anticipator removed)
- #170 Persistent config (reco-io settings module)

41 open issues remain, all genuinely active.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] All tests pass