### PR TITLE
fix: v0.5.1 bug fixes, telemetry, and color range support

### DIFF
--- a/crates/reco-core/src/gpu/mod.rs
+++ b/crates/reco-core/src/gpu/mod.rs
@@ -200,7 +200,9 @@ impl GpuContext {
             features |= wgpu::Features::TEXTURE_FORMAT_P010;
         }
 
+        log::info!("Requesting device with features: {:?}", features);
         let (device, queue) = Self::request_device_with_fallback(&adapter, features).await?;
+        log::info!("Device created successfully");
 
         Ok(Self {
             device,
@@ -334,7 +336,9 @@ impl GpuContext {
             features |= wgpu::Features::TEXTURE_FORMAT_NV12;
         }
 
+        log::info!("Requesting device with features: {:?}", features);
         let (device, queue) = Self::request_device_with_fallback(&adapter, features).await?;
+        log::info!("Device created successfully");
 
         let ctx = Self {
             device,

--- a/crates/reco-core/src/gpu/mod.rs
+++ b/crates/reco-core/src/gpu/mod.rs
@@ -190,6 +190,9 @@ impl GpuContext {
         {
             features |= wgpu::Features::TEXTURE_FORMAT_NV12;
         }
+        // P010 is only needed on Windows (D3D11VA imports 10-bit as a single
+        // P010 texture). Metal uses per-plane R16Unorm/Rg16Unorm instead.
+        #[cfg(target_os = "windows")]
         if adapter
             .features()
             .contains(wgpu::Features::TEXTURE_FORMAT_P010)

--- a/crates/reco-core/src/interop/d3d11.rs
+++ b/crates/reco-core/src/interop/d3d11.rs
@@ -32,7 +32,9 @@ use windows::Win32::Graphics::Direct3D11::{
     ID3D11Texture2D,
 };
 use windows::Win32::Graphics::Direct3D12::ID3D12Resource;
-use windows::Win32::Graphics::Dxgi::Common::{DXGI_FORMAT_NV12, DXGI_FORMAT_P010, DXGI_SAMPLE_DESC};
+use windows::Win32::Graphics::Dxgi::Common::{
+    DXGI_FORMAT_NV12, DXGI_FORMAT_P010, DXGI_SAMPLE_DESC,
+};
 use windows::Win32::Graphics::Dxgi::IDXGIResource1;
 use windows::core::Interface;
 

--- a/crates/reco-core/src/interop/metal.rs
+++ b/crates/reco-core/src/interop/metal.rs
@@ -84,14 +84,21 @@ unsafe extern "C" {
 // MTLPixelFormat constants (matching objc2-metal values)
 // ---------------------------------------------------------------------------
 
-/// `MTLPixelFormat::R8Unorm` - single-channel 8-bit, used for Y plane.
+/// `MTLPixelFormat::R8Unorm` - single-channel 8-bit, used for NV12 Y plane.
 const MTL_PIXEL_FORMAT_R8_UNORM: u64 = 10;
-/// `MTLPixelFormat::RG8Unorm` - two-channel 8-bit, used for interleaved UV plane.
+/// `MTLPixelFormat::RG8Unorm` - two-channel 8-bit, used for NV12 UV plane.
 const MTL_PIXEL_FORMAT_RG8_UNORM: u64 = 30;
+/// `MTLPixelFormat::R16Unorm` - single-channel 16-bit, used for P010 Y plane.
+const MTL_PIXEL_FORMAT_R16_UNORM: u64 = 20;
+/// `MTLPixelFormat::RG16Unorm` - two-channel 16-bit, used for P010 UV plane.
+const MTL_PIXEL_FORMAT_RG16_UNORM: u64 = 60;
 
-// NV12 FourCC values from VideoToolbox
+// NV12 (8-bit) FourCC values from VideoToolbox
 const K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_VIDEO_RANGE: u32 = 0x34323076; // '420v'
 const K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_FULL_RANGE: u32 = 0x34323066; // '420f'
+// P010 (10-bit) FourCC values from VideoToolbox
+const K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_VIDEO_RANGE: u32 = 0x78343230; // 'x420'
+const K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_FULL_RANGE: u32 = 0x78663230; // 'xf20'
 
 /// Read the pixel format FourCC from a CVPixelBuffer.
 ///
@@ -255,9 +262,10 @@ impl MetalTextureCache {
         unsafe { CVMetalTextureCacheFlush(self.cv_cache, 0) };
     }
 
-    /// Import a single NV12 plane from a `CVPixelBuffer` as a wgpu texture.
+    /// Import a single plane from a `CVPixelBuffer` as a wgpu texture.
     ///
-    /// - `plane_index` 0 = Y plane (`R8Unorm`), 1 = UV plane (`Rg8Unorm`)
+    /// For 8-bit NV12: plane 0 = Y (`R8Unorm`), plane 1 = UV (`Rg8Unorm`).
+    /// For 10-bit P010: plane 0 = Y (`R16Unorm`), plane 1 = UV (`Rg16Unorm`).
     ///
     /// The returned `ImportedPlaneTexture` keeps the underlying
     /// `CVMetalTextureRef` alive. Drop it when the GPU is done reading.
@@ -269,15 +277,18 @@ impl MetalTextureCache {
         &self,
         cv_pixel_buffer: CVPixelBufferRef,
         plane_index: u64,
+        is_10bit: bool,
         gpu: &GpuContext,
     ) -> Result<ImportedPlaneTexture, MetalInteropError> {
         let width = unsafe { CVPixelBufferGetWidthOfPlane(cv_pixel_buffer, plane_index) } as u32;
         let height = unsafe { CVPixelBufferGetHeightOfPlane(cv_pixel_buffer, plane_index) } as u32;
 
-        let (mtl_format, wgpu_format) = match plane_index {
-            0 => (MTL_PIXEL_FORMAT_R8_UNORM, wgpu::TextureFormat::R8Unorm),
-            1 => (MTL_PIXEL_FORMAT_RG8_UNORM, wgpu::TextureFormat::Rg8Unorm),
-            _ => unreachable!("NV12 only has planes 0 and 1"),
+        let (mtl_format, wgpu_format) = match (plane_index, is_10bit) {
+            (0, false) => (MTL_PIXEL_FORMAT_R8_UNORM, wgpu::TextureFormat::R8Unorm),
+            (1, false) => (MTL_PIXEL_FORMAT_RG8_UNORM, wgpu::TextureFormat::Rg8Unorm),
+            (0, true) => (MTL_PIXEL_FORMAT_R16_UNORM, wgpu::TextureFormat::R16Unorm),
+            (1, true) => (MTL_PIXEL_FORMAT_RG16_UNORM, wgpu::TextureFormat::Rg16Unorm),
+            _ => unreachable!("NV12/P010 only has planes 0 and 1"),
         };
 
         // Create a Metal texture view of this CVPixelBuffer plane
@@ -317,9 +328,10 @@ impl MetalTextureCache {
         })
     }
 
-    /// Import both NV12 planes (Y + UV) from a `CVPixelBuffer`.
+    /// Import both Y + UV planes from a `CVPixelBuffer` (NV12 or P010).
     ///
     /// Returns `(y_texture, uv_texture)` ready for use in shader bind groups.
+    /// Automatically detects 8-bit (NV12) vs 10-bit (P010) from the pixel format.
     ///
     /// # Safety
     ///
@@ -329,17 +341,17 @@ impl MetalTextureCache {
         cv_pixel_buffer: CVPixelBufferRef,
         gpu: &GpuContext,
     ) -> Result<(ImportedPlaneTexture, ImportedPlaneTexture), MetalInteropError> {
-        // Validate pixel format
         let format = unsafe { CVPixelBufferGetPixelFormatType(cv_pixel_buffer) };
-        if format != K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_VIDEO_RANGE
-            && format != K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_FULL_RANGE
-        {
-            return Err(MetalInteropError::UnsupportedFormat(format));
-        }
+        let is_10bit = match format {
+            K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_VIDEO_RANGE
+            | K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_FULL_RANGE => false,
+            K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_VIDEO_RANGE
+            | K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_FULL_RANGE => true,
+            _ => return Err(MetalInteropError::UnsupportedFormat(format)),
+        };
 
-        // SAFETY: caller guarantees cv_pixel_buffer is valid
-        let y = unsafe { self.import_plane(cv_pixel_buffer, 0, gpu)? };
-        let uv = unsafe { self.import_plane(cv_pixel_buffer, 1, gpu)? };
+        let y = unsafe { self.import_plane(cv_pixel_buffer, 0, is_10bit, gpu)? };
+        let uv = unsafe { self.import_plane(cv_pixel_buffer, 1, is_10bit, gpu)? };
         Ok((y, uv))
     }
 
@@ -441,15 +453,20 @@ impl Drop for ImportedPlaneTexture {
     }
 }
 
-/// Validate that a `CVPixelBuffer` has a supported NV12 pixel format.
+/// Validate that a `CVPixelBuffer` has a supported pixel format.
 ///
-/// Returns `true` for `420v` (video range) and `420f` (full range) NV12 formats.
+/// Returns `true` for NV12 (`420v`/`420f`) and P010 (`x420`/`xf20`) formats.
 ///
 /// # Safety
 ///
 /// `cv_pixel_buffer` must be a valid, non-null `CVPixelBufferRef`.
 pub unsafe fn is_supported_format(cv_pixel_buffer: CVPixelBufferRef) -> bool {
     let format = unsafe { CVPixelBufferGetPixelFormatType(cv_pixel_buffer) };
-    format == K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_VIDEO_RANGE
-        || format == K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_FULL_RANGE
+    matches!(
+        format,
+        K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_VIDEO_RANGE
+            | K_CV_PIXEL_FORMAT_420_YP_CB_CR_8_BI_PLANAR_FULL_RANGE
+            | K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_VIDEO_RANGE
+            | K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_FULL_RANGE
+    )
 }

--- a/crates/reco-core/src/interop/metal.rs
+++ b/crates/reco-core/src/interop/metal.rs
@@ -210,6 +210,7 @@ unsafe impl Send for RetainedCVPixelBuffer {}
 /// Create one per `GpuContext` and reuse across frames.
 pub struct MetalTextureCache {
     cv_cache: CVMetalTextureCacheRef,
+    logged_format: bool,
 }
 
 // CVMetalTextureCacheRef is thread-safe per Apple docs.
@@ -251,7 +252,10 @@ impl MetalTextureCache {
             return Err(MetalInteropError::CacheCreationFailed(ret));
         }
 
-        Ok(Self { cv_cache: cache })
+        Ok(Self {
+            cv_cache: cache,
+            logged_format: false,
+        })
     }
 
     /// Flush stale entries from the texture cache.
@@ -337,7 +341,7 @@ impl MetalTextureCache {
     ///
     /// `cv_pixel_buffer` must be a valid, non-null `CVPixelBufferRef`.
     pub unsafe fn import_nv12(
-        &self,
+        &mut self,
         cv_pixel_buffer: CVPixelBufferRef,
         gpu: &GpuContext,
     ) -> Result<(ImportedPlaneTexture, ImportedPlaneTexture), MetalInteropError> {
@@ -349,6 +353,19 @@ impl MetalTextureCache {
             | K_CV_PIXEL_FORMAT_420_YP_CB_CR_10_BI_PLANAR_FULL_RANGE => true,
             _ => return Err(MetalInteropError::UnsupportedFormat(format)),
         };
+
+        if !self.logged_format {
+            let w = unsafe { CVPixelBufferGetWidthOfPlane(cv_pixel_buffer, 0) };
+            let h = unsafe { CVPixelBufferGetHeightOfPlane(cv_pixel_buffer, 0) };
+            log::info!(
+                "Metal import: {}x{} {} (FourCC 0x{:08x})",
+                w,
+                h,
+                if is_10bit { "P010 10-bit" } else { "NV12 8-bit" },
+                format
+            );
+            self.logged_format = true;
+        }
 
         let y = unsafe { self.import_plane(cv_pixel_buffer, 0, is_10bit, gpu)? };
         let uv = unsafe { self.import_plane(cv_pixel_buffer, 1, is_10bit, gpu)? };

--- a/crates/reco-core/src/interop/metal.rs
+++ b/crates/reco-core/src/interop/metal.rs
@@ -361,7 +361,11 @@ impl MetalTextureCache {
                 "Metal import: {}x{} {} (FourCC 0x{:08x})",
                 w,
                 h,
-                if is_10bit { "P010 10-bit" } else { "NV12 8-bit" },
+                if is_10bit {
+                    "P010 10-bit"
+                } else {
+                    "NV12 8-bit"
+                },
                 format
             );
             self.logged_format = true;

--- a/crates/reco-core/src/lens/preview.rs
+++ b/crates/reco-core/src/lens/preview.rs
@@ -302,7 +302,7 @@ impl LensPreviewRenderer {
         let mvp = opengl_to_wgpu_matrix() * ortho.to_homogeneous();
 
         let mut uniforms =
-            build_gpu_uniforms(&mvp, params, false, 0.0, InputFormat::Yuv420p, false);
+            build_gpu_uniforms(&mvp, params, false, 0.0, InputFormat::Yuv420p, false, false);
         uniforms.lens_preview[0] = correction_amount.clamp(-1.0, 1.0);
 
         gpu.queue

--- a/crates/reco-core/src/lens/undistort.rs
+++ b/crates/reco-core/src/lens/undistort.rs
@@ -329,7 +329,8 @@ impl GpuUndistort {
         let ortho = Orthographic3::new(-0.5, 0.5, -hh, hh, -1.0, 1.0);
         let mvp = opengl_to_wgpu_matrix() * ortho.to_homogeneous();
 
-        let uniforms = build_gpu_uniforms(&mvp, params, false, 0.0, InputFormat::Yuv420p, false);
+        let uniforms =
+            build_gpu_uniforms(&mvp, params, false, 0.0, InputFormat::Yuv420p, false, false);
         gpu.queue
             .write_buffer(&self.uniform_buffer, 0, bytemuck::bytes_of(&uniforms));
 

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -726,6 +726,10 @@ impl StitchPipeline {
         self.renderer.set_flip_180(left, right);
     }
 
+    pub fn set_full_range(&mut self, full_range: bool) {
+        self.renderer.set_full_range(full_range);
+    }
+
     /// Access the rendered RGBA texture for NV12 conversion.
     pub fn render_target(&self) -> &wgpu::Texture {
         self.renderer.render_target()

--- a/crates/reco-core/src/render/renderer.rs
+++ b/crates/reco-core/src/render/renderer.rs
@@ -234,6 +234,8 @@ pub(crate) struct Renderer {
     output_height: u32,
     /// Input pixel format (YUV420P or NV12).
     input_format: InputFormat,
+    /// Full-range YUV (0-255) instead of limited (16-235).
+    is_full_range: bool,
     /// Stored for creating bind groups from external textures (zero-copy).
     texture_layout: wgpu::BindGroupLayout,
     /// Shared sampler, stored for bind group creation.
@@ -425,6 +427,7 @@ impl Renderer {
             output_width,
             output_height,
             input_format,
+            is_full_range: false,
             texture_layout,
             sampler,
             device: device.clone(),
@@ -760,6 +763,11 @@ impl Renderer {
         self.flip_180 = [left, right];
     }
 
+    /// Set full-range YUV mode for the shader.
+    pub fn set_full_range(&mut self, full_range: bool) {
+        self.is_full_range = full_range;
+    }
+
     /// Create fresh `TextureView`s for the left plane's Y/U/V
     /// textures. Needed by [`crate::gpu::yuv_stack_packer::YuvStackPacker`]
     /// when replay recording is enabled: the packer samples the same
@@ -846,6 +854,7 @@ impl Renderer {
             blend_width,
             self.input_format,
             self.flip_180[0],
+            self.is_full_range,
         );
         left_uniforms.lens_preview[0] = correction;
 
@@ -857,6 +866,7 @@ impl Renderer {
             blend_width,
             self.input_format,
             self.flip_180[1],
+            self.is_full_range,
         );
         right_uniforms.lens_preview[0] = correction;
 
@@ -1231,6 +1241,7 @@ pub(crate) fn build_gpu_uniforms(
     blend_width: f32,
     input_format: InputFormat,
     flip_180: bool,
+    is_full_range: bool,
 ) -> GpuUniforms {
     let w = camera.width as f32;
     let h = camera.height as f32;
@@ -1258,7 +1269,7 @@ pub(crate) fn build_gpu_uniforms(
                 InputFormat::Bgra => 2,
             },
             flip_180 as u32,
-            0,
+            is_full_range as u32,
         ],
         // Full correction for normal stitching. LensPreviewRenderer
         // overrides this field for the single-camera preview mode.
@@ -1307,7 +1318,15 @@ mod tests {
             d: [0.0342, 0.0677, -0.0741, 0.0299],
         };
         let mvp = Matrix4::identity();
-        let u = build_gpu_uniforms(&mvp, &camera, false, 0.0, InputFormat::Yuv420p, false);
+        let u = build_gpu_uniforms(
+            &mvp,
+            &camera,
+            false,
+            0.0,
+            InputFormat::Yuv420p,
+            false,
+            false,
+        );
 
         // fx/width ≈ 0.4678
         assert!((u.intrinsics[0] - 1796.32 / 3840.0).abs() < 1e-4);

--- a/crates/reco-core/src/session/detection.rs
+++ b/crates/reco-core/src/session/detection.rs
@@ -473,7 +473,8 @@ impl DetectionPipeline {
     /// Dispatches `DetectorFrame::WgpuNv12` to the detector. The detector
     /// (typically `WgpuPreprocessingDetector` from reco-autocam) handles
     /// the compute shader preprocessing internally.
-    #[cfg(target_os = "windows")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn run_detection_wgpu_nv12(
         &mut self,
         left_y: &wgpu::TextureView,

--- a/crates/reco-core/src/session/detection_dispatch.rs
+++ b/crates/reco-core/src/session/detection_dispatch.rs
@@ -119,25 +119,6 @@ impl StitchSession {
         })
     }
 
-    /// Run detection via wgpu NV12 texture views (universal GPU path).
-    #[cfg(target_os = "windows")]
-    pub(crate) fn detect_and_update_director_wgpu_nv12(
-        &mut self,
-        left_y: &wgpu::TextureView,
-        left_uv: &wgpu::TextureView,
-        right_y: &wgpu::TextureView,
-        right_uv: &wgpu::TextureView,
-        width: u32,
-        height: u32,
-        elapsed: std::time::Duration,
-    ) -> Result<(), SessionError> {
-        let lr = self.left_rotation;
-        let rr = self.right_rotation;
-        self.detect_and_update_director_with(elapsed, |det| {
-            det.run_detection_wgpu_nv12(left_y, left_uv, right_y, right_uv, width, height, lr, rr)
-        })
-    }
-
     /// Update the director without detection.
     ///
     /// Advances the panner/tracker state without running object

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -107,20 +107,57 @@ impl StitchSession {
                 left_slot,
                 right_slot,
             } => {
-                if let Some((left_buf, right_buf)) = &ctx.gpu_buf_info {
-                    self.detect_and_update_director_gpu(
-                        left_buf,
-                        right_buf,
-                        *left_slot,
-                        *right_slot,
-                        elapsed,
-                    )?;
+                if self.detection.needs_cuda_frames() {
+                    if self.frame_count == 0 {
+                        log::info!("GpuResident detection: CUDA path (TensorRT/ORT-CUDA)");
+                    }
+                    if let Some((left_buf, right_buf)) = &ctx.gpu_buf_info {
+                        self.detect_and_update_director_gpu(
+                            left_buf,
+                            right_buf,
+                            *left_slot,
+                            *right_slot,
+                            elapsed,
+                        )?;
+                        scheduled_detection
+                    } else {
+                        if self.frame_count == 0 {
+                            log::warn!(
+                                "GpuResident frame but no gpu_buf_info - detection disabled, \
+                                 director advancing without detections"
+                            );
+                        }
+                        self.update_director(elapsed)?;
+                        false
+                    }
+                } else if let Some(ref views) = self.gpu_shared_views {
+                    if self.frame_count == 0 {
+                        log::info!("GpuResident detection: wgpu shared texture views (ORT/wgpu preprocess)");
+                    }
+                    let ls = *left_slot as usize;
+                    let rs = *right_slot as usize;
+                    let (w, h) = self.core.pipeline().source_info();
+                    let lr = self.left_rotation;
+                    let rr = self.right_rotation;
+                    if scheduled_detection {
+                        let detections = self.detection.run_detection_wgpu_nv12(
+                            &views[ls * 2],
+                            &views[ls * 2 + 1],
+                            &views[4 + rs * 2],
+                            &views[4 + rs * 2 + 1],
+                            w,
+                            h,
+                            lr,
+                            rr,
+                        );
+                        self.detection.last_detections = self.map_detections(detections);
+                    }
+                    self.fire_sink_and_update_director(elapsed, scheduled_detection)?;
                     scheduled_detection
                 } else {
                     if self.frame_count == 0 {
                         log::warn!(
-                            "GpuResident frame but no gpu_buf_info - detection disabled, \
-                             director advancing without detections"
+                            "GpuResident frame but no shared views - detection disabled"
                         );
                     }
                     self.update_director(elapsed)?;

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -355,7 +355,7 @@ impl StitchSession {
             )?);
             log::info!("Metal zero-copy: texture cache initialized");
         }
-        let cache = self.metal_texture_cache.as_ref().unwrap();
+        let cache = self.metal_texture_cache.as_mut().unwrap();
 
         // SAFETY: RetainedCVPixelBuffer guarantees the pointer is valid.
         let (left_y, left_uv) = unsafe { cache.import_nv12(left.as_ptr(), self.core.gpu())? };

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -132,7 +132,9 @@ impl StitchSession {
                     }
                 } else if let Some(ref views) = self.gpu_shared_views {
                     if self.frame_count == 0 {
-                        log::info!("GpuResident detection: wgpu shared texture views (ORT/wgpu preprocess)");
+                        log::info!(
+                            "GpuResident detection: wgpu shared texture views (ORT/wgpu preprocess)"
+                        );
                     }
                     let ls = *left_slot as usize;
                     let rs = *right_slot as usize;
@@ -156,9 +158,7 @@ impl StitchSession {
                     scheduled_detection
                 } else {
                     if self.frame_count == 0 {
-                        log::warn!(
-                            "GpuResident frame but no shared views - detection disabled"
-                        );
+                        log::warn!("GpuResident frame but no shared views - detection disabled");
                     }
                     self.update_director(elapsed)?;
                     false

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -159,6 +159,8 @@ pub struct StitchSession {
     pub(crate) right_rotation: i32,
     /// GPU pixel format (NV12 or P010) for D3D11VA staging pool creation.
     pub(crate) gpu_pixel_format: crate::render::renderer::GpuPixelFormat,
+    /// Full-range YUV (0-255) vs limited range (16-235).
+    pub(crate) is_full_range: bool,
 }
 
 impl StitchSession {
@@ -261,6 +263,7 @@ impl StitchSession {
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             right_rotation: 0,
             gpu_pixel_format: crate::render::renderer::GpuPixelFormat::Nv12,
+            is_full_range: false,
         })
     }
 

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -16,6 +16,10 @@ impl StitchSession {
     /// the source's metadata.
     fn configure_from_source(&mut self, source: &dyn FrameSource) {
         self.gpu_pixel_format = source.gpu_pixel_format();
+        self.is_full_range = source.is_full_range();
+        if self.is_full_range {
+            self.core.pipeline_mut().set_full_range(true);
+        }
         // Apply rotation via shader UV flip ONLY for GPU-resident sources.
         // CPU sources handle rotation via buffer reversal in the decoder,
         // so applying the shader flip too would rotate 360 degrees (no-op but wrong).

--- a/crates/reco-core/src/shaders/fisheye.wgsl
+++ b/crates/reco-core/src/shaders/fisheye.wgsl
@@ -23,7 +23,7 @@ struct Uniforms {
     //          in t_u; 2 = BGRA/RGBA: t_y holds packed 4-channel RGB, skip YUV conversion)
     // flags.z: flip_180 (0 or 1) - flip UV coordinates for 180-degree rotation
     //          Used by the GPU zero-copy path where buffer reversal is not possible.
-    // flags.w: reserved
+    // flags.w: is_full_range (0 = limited 16-235, 1 = full 0-255)
     flags: vec4<u32>,
     // lens_preview.x: correction_amount (0.0 = no correction, 1.0 = full KB4)
     // lens_preview.y: split_view (> 0.5 = left half uncorrected, right half corrected)
@@ -133,10 +133,21 @@ fn sample_yuv(uv: vec2<f32>) -> vec4<f32> {
         v_raw = textureSample(t_v, s_video, sample_uv).r;
     }
 
-    // BT.709 limited-range YCbCr -> full-range R'G'B'
-    let y = (y_raw - 16.0 / 255.0) * (255.0 / 219.0);
-    let cb = (u_raw - 128.0 / 255.0) * (255.0 / 224.0);
-    let cr = (v_raw - 128.0 / 255.0) * (255.0 / 224.0);
+    // BT.709 YCbCr -> R'G'B'. Range scaling depends on flags.w:
+    //   0 = limited range (Y: 16-235, Cb/Cr: 16-240)
+    //   1 = full range (Y: 0-255, Cb/Cr: 0-255)
+    var y: f32;
+    var cb: f32;
+    var cr: f32;
+    if u.flags.w == 1u {
+        y = y_raw;
+        cb = u_raw - 0.5;
+        cr = v_raw - 0.5;
+    } else {
+        y = (y_raw - 16.0 / 255.0) * (255.0 / 219.0);
+        cb = (u_raw - 128.0 / 255.0) * (255.0 / 224.0);
+        cr = (v_raw - 128.0 / 255.0) * (255.0 / 224.0);
+    }
 
     let r = y + 1.5748 * cr;
     let g = y - 0.1873 * cb - 0.4681 * cr;

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -379,6 +379,11 @@ pub trait FrameSource: Send {
         crate::render::renderer::GpuPixelFormat::Nv12
     }
 
+    /// Whether the source uses full-range YUV (0-255) rather than limited (16-235).
+    fn is_full_range(&self) -> bool {
+        false
+    }
+
     /// Left camera rotation from stream metadata (degrees: 0, 90, 180, 270).
     ///
     /// The session applies rotation automatically: the CPU path handles it

--- a/crates/reco-detect/src/metal_compute.rs
+++ b/crates/reco-detect/src/metal_compute.rs
@@ -287,13 +287,16 @@ impl MetalPreprocessPipeline {
 
         reco_core::profile_scope!("metal_preprocess");
 
-        // Detect pixel format (video-range vs full-range).
+        // Detect pixel format (video-range vs full-range, 8-bit vs 10-bit).
         let format = unsafe { reco_core::interop::metal::pixel_buffer_format(cv_pixel_buffer) };
-        self.is_full_range = format == 0x34323066; // '420f'
+        self.is_full_range = format == 0x34323066 || format == 0x78663230; // '420f' or 'xf20'
+        let is_10bit = format == 0x78343230 || format == 0x78663230; // 'x420' or 'xf20'
 
         // Import Y and UV planes as Metal textures (zero-copy via IOSurface).
-        let y_plane = unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 0, gpu)? };
-        let uv_plane = unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 1, gpu)? };
+        let y_plane =
+            unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 0, is_10bit, gpu)? };
+        let uv_plane =
+            unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 1, is_10bit, gpu)? };
 
         // Write preprocessing parameters to the shared params buffer.
         let (fw, fh) = (self.frame_width as f32, self.frame_height as f32);

--- a/crates/reco-detect/src/metal_compute.rs
+++ b/crates/reco-detect/src/metal_compute.rs
@@ -293,10 +293,14 @@ impl MetalPreprocessPipeline {
         let is_10bit = format == 0x78343230 || format == 0x78663230; // 'x420' or 'xf20'
 
         // Import Y and UV planes as Metal textures (zero-copy via IOSurface).
-        let y_plane =
-            unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 0, is_10bit, gpu)? };
-        let uv_plane =
-            unsafe { self.texture_cache.import_plane(cv_pixel_buffer, 1, is_10bit, gpu)? };
+        let y_plane = unsafe {
+            self.texture_cache
+                .import_plane(cv_pixel_buffer, 0, is_10bit, gpu)?
+        };
+        let uv_plane = unsafe {
+            self.texture_cache
+                .import_plane(cv_pixel_buffer, 1, is_10bit, gpu)?
+        };
 
         // Write preprocessing parameters to the shared params buffer.
         let (fw, fh) = (self.frame_width as f32, self.frame_height as f32);

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -327,6 +327,23 @@ fn build_bug_report(state: &AppState, app_weak: &slint::Weak<RecoApp>) -> String
          <!-- 1. ... 2. ... 3. ... -->\n",
     );
 
+    if let Some(log_path) = log_file_path()
+        && let Ok(contents) = std::fs::read_to_string(&log_path)
+    {
+        let lines: Vec<&str> = contents.lines().collect();
+        let tail = if lines.len() > 200 {
+            &lines[lines.len() - 200..]
+        } else {
+            &lines
+        };
+        report.push_str("\n## Log (last 200 lines)\n```\n");
+        for line in tail {
+            report.push_str(line);
+            report.push('\n');
+        }
+        report.push_str("```\n");
+    }
+
     report
 }
 
@@ -1044,27 +1061,53 @@ fn init_tracing() {
     let _ = tracing_log::LogTracer::init();
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
-    // On Windows release builds, windows_subsystem="windows" detaches
-    // stderr so tracing output is lost. Write to a log file alongside
-    // the executable so we can always diagnose startup failures.
-    #[cfg(all(target_os = "windows", not(debug_assertions)))]
-    {
-        let log_path = std::env::current_exe()
-            .ok()
-            .and_then(|p| p.parent().map(|d| d.join("reco-gui.log")))
-            .unwrap_or_else(|| std::path::PathBuf::from("reco-gui.log"));
+    // In release builds, write logs to a file so bug reports have context.
+    // Debug builds just use stderr.
+    #[cfg(not(debug_assertions))]
+    if let Some(log_path) = log_file_path() {
+        if let Some(parent) = log_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
         if let Ok(file) = std::fs::File::create(&log_path) {
-            let _ = tracing_subscriber::registry()
-                .with(filter)
-                .with(
-                    fmt::layer()
-                        .with_target(true)
-                        .with_level(true)
-                        .with_ansi(false)
-                        .with_writer(file),
-                )
-                .try_init();
-            return;
+            // Windows: file only (stderr is detached by windows_subsystem="windows").
+            // Mac/Linux: file + stderr (user may launch from terminal).
+            #[cfg(target_os = "windows")]
+            {
+                let _ = tracing_subscriber::registry()
+                    .with(filter)
+                    .with(
+                        fmt::layer()
+                            .with_target(true)
+                            .with_level(true)
+                            .with_ansi(false)
+                            .with_writer(file),
+                    )
+                    .try_init();
+                eprintln!("Log file: {}", log_path.display());
+                return;
+            }
+            #[cfg(not(target_os = "windows"))]
+            {
+                let file = std::sync::Mutex::new(file);
+                let _ = tracing_subscriber::registry()
+                    .with(filter)
+                    .with(
+                        fmt::layer()
+                            .with_target(true)
+                            .with_level(true)
+                            .with_ansi(false)
+                            .with_writer(file),
+                    )
+                    .with(
+                        fmt::layer()
+                            .with_target(true)
+                            .with_level(true)
+                            .with_writer(std::io::stderr),
+                    )
+                    .try_init();
+                eprintln!("Log file: {}", log_path.display());
+                return;
+            }
         }
     }
 
@@ -1072,6 +1115,38 @@ fn init_tracing() {
         .with(filter)
         .with(fmt::layer().with_target(true).with_level(true))
         .try_init();
+}
+
+/// Platform-appropriate log file path.
+///
+/// - Windows: next to executable (`reco-gui.log`)
+/// - macOS: `~/Library/Logs/reco-gui.log`
+/// - Linux: `~/.config/reco/reco-gui.log`
+fn log_file_path() -> Option<std::path::PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.parent().map(|d| d.join("reco-gui.log")))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        std::env::var("HOME")
+            .ok()
+            .map(|h| std::path::PathBuf::from(h).join("Library/Logs/reco-gui.log"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var("XDG_CONFIG_HOME")
+            .ok()
+            .map(std::path::PathBuf::from)
+            .or_else(|| {
+                std::env::var("HOME")
+                    .ok()
+                    .map(|h| std::path::PathBuf::from(h).join(".config"))
+            })
+            .map(|d| d.join("reco/reco-gui.log"))
+    }
 }
 
 /// Panic hook: emit panic location + payload as a `tracing::error!`

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1087,7 +1087,11 @@ fn init_tracing() {
         }
         // Truncate if over 2 MB to prevent unbounded growth, otherwise append
         // so crash logs survive a restart.
-        if log_path.metadata().map(|m| m.len() > 2_000_000).unwrap_or(false) {
+        if log_path
+            .metadata()
+            .map(|m| m.len() > 2_000_000)
+            .unwrap_or(false)
+        {
             let _ = std::fs::remove_file(&log_path);
         }
         let file_result = std::fs::File::options()
@@ -1095,7 +1099,10 @@ fn init_tracing() {
             .append(true)
             .open(&log_path);
         if let Err(ref e) = file_result {
-            eprintln!("Warning: could not open log file {}: {e}", log_path.display());
+            eprintln!(
+                "Warning: could not open log file {}: {e}",
+                log_path.display()
+            );
         }
         if let Ok(file) = file_result {
             // Windows: file only (stderr is detached by windows_subsystem="windows").

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1085,7 +1085,19 @@ fn init_tracing() {
         if let Some(parent) = log_path.parent() {
             let _ = std::fs::create_dir_all(parent);
         }
-        if let Ok(file) = std::fs::File::create(&log_path) {
+        // Truncate if over 2 MB to prevent unbounded growth, otherwise append
+        // so crash logs survive a restart.
+        if log_path.metadata().map(|m| m.len() > 2_000_000).unwrap_or(false) {
+            let _ = std::fs::remove_file(&log_path);
+        }
+        let file_result = std::fs::File::options()
+            .create(true)
+            .append(true)
+            .open(&log_path);
+        if let Err(ref e) = file_result {
+            eprintln!("Warning: could not open log file {}: {e}", log_path.display());
+        }
+        if let Ok(file) = file_result {
             // Windows: file only (stderr is detached by windows_subsystem="windows").
             // Mac/Linux: file + stderr (user may launch from terminal).
             #[cfg(target_os = "windows")]
@@ -1138,7 +1150,7 @@ fn init_tracing() {
 ///
 /// - Windows: next to executable (`reco-gui.log`)
 /// - macOS: `~/Library/Logs/reco-gui.log`
-/// - Linux: `~/.config/reco/reco-gui.log`
+/// - Linux: `~/.local/state/reco/reco-gui.log` (XDG_STATE_HOME)
 fn log_file_path() -> Option<std::path::PathBuf> {
     #[cfg(target_os = "windows")]
     {
@@ -1154,13 +1166,13 @@ fn log_file_path() -> Option<std::path::PathBuf> {
     }
     #[cfg(target_os = "linux")]
     {
-        std::env::var("XDG_CONFIG_HOME")
+        std::env::var("XDG_STATE_HOME")
             .ok()
             .map(std::path::PathBuf::from)
             .or_else(|| {
                 std::env::var("HOME")
                     .ok()
-                    .map(|h| std::path::PathBuf::from(h).join(".config"))
+                    .map(|h| std::path::PathBuf::from(h).join(".local/state"))
             })
             .map(|d| d.join("reco/reco-gui.log"))
     }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -810,6 +810,23 @@ impl AppState {
         self.clamp_targets();
     }
 
+    fn set_sync_offset(&mut self, frames: i32) {
+        let offset = frames as i64;
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.sync_offset = offset;
+        }
+        if let (Some(left), Some(right)) = (&self.left_path, &self.right_path) {
+            let left = left.clone();
+            let right = right.clone();
+            if let Err(e) = self.playback.open(&left, &right, offset) {
+                log::error!("Failed to reopen playback with sync offset {offset}: {e}");
+                return;
+            }
+            log::info!("Sync offset changed to {offset} frames");
+            self.preview_dirty = true;
+        }
+    }
+
     fn set_rig_roll(&mut self, deg: f32) {
         if let Some(cal) = self.calibration.as_mut() {
             cal.rig_roll = deg as f64;
@@ -2421,6 +2438,15 @@ fn main() -> anyhow::Result<()> {
     });
 
     let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_sync_offset(move |frames| {
+        state_ref.borrow_mut().set_sync_offset(frames);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
     app.on_changed_fov(move |deg| {
         state_ref.borrow_mut().set_fov(deg);
     });
@@ -3600,6 +3626,9 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 if let Some(bw) = blend_width {
                     app.set_blend_width(bw);
                 }
+                if let Some(cal) = s.calibration.as_ref() {
+                    app.set_sync_offset(cal.sync_offset as i32);
+                }
                 app.set_fov(clamped_fov);
                 // Manual calibration JSON does not embed lens-profile info,
                 // so clear the display (hide the lens card) and just show
@@ -3814,6 +3843,9 @@ fn handle_calibration_result(
                         }
                         if let Some(bw) = blend_width {
                             app.set_blend_width(bw);
+                        }
+                        if let Some(cal) = state.calibration.as_ref() {
+                            app.set_sync_offset(cal.sync_offset as i32);
                         }
                         app.set_fov(clamped_fov);
                         set_lens_profile_props(&app, left_profile, right_profile, in_w, in_h);

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3915,6 +3915,9 @@ fn handle_calibration_result(
         }
         Err(e) => {
             log::error!("Auto-calibration failed: {e}");
+            if let Some(ref t) = state.telemetry {
+                t.calibration_error(&e.to_string());
+            }
             // Critical: unload the live pipeline so the preview stops
             // rendering whatever it was showing before. Otherwise the
             // preview keeps playing the OLD right/left video while the

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3303,7 +3303,10 @@ fn main() -> anyhow::Result<()> {
                             );
                             app.set_last_output_path(path.display().to_string().into());
                             if let Some(ref t) = s.telemetry {
-                                t.export_complete(frames, 0.0, "");
+                                let fps = s.playback.fps();
+                                let dur = if fps > 0.0 { frames as f64 / fps } else { 0.0 };
+                                let codec = app.get_export_codec().to_string();
+                                t.export_complete(frames, dur, &codec);
                             }
                             s.toasts.push(
                                 Severity::Info,
@@ -3654,6 +3657,20 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                             .unwrap_or_else(|| "reco".into())
                     ));
                     app.set_export_output_path(suggested.to_string_lossy().to_string().into());
+                }
+
+                if let Some(ref t) = s.telemetry {
+                    let gpu = s
+                        .bridge
+                        .as_ref()
+                        .map(|b| {
+                            let g = b.renderer().gpu();
+                            format!("{} ({:?})", g.gpu_name(), g.backend_name())
+                        })
+                        .unwrap_or_else(|| "unknown".into());
+                    let os = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
+                    let (ai_status, _) = ai_capability_summary();
+                    t.context(&gpu, &os, &ai_status);
                 }
             }
         }

--- a/crates/reco-gui/src/telemetry_client.rs
+++ b/crates/reco-gui/src/telemetry_client.rs
@@ -51,9 +51,24 @@ fn now_iso() -> String {
     let h = (secs / 3600) % 24;
     let m = (secs / 60) % 60;
     let s = secs % 60;
-    let days = secs / 86400;
-    let y = 1970 + days / 365;
-    format!("{y}-01-01T{h:02}:{m:02}:{s:02}.000Z")
+    let (y, mo, day) = civil_from_days((secs / 86400) as i64);
+    format!("{y}-{mo:02}-{day:02}T{h:02}:{m:02}:{s:02}.000Z")
+}
+
+/// Convert days since Unix epoch to (year, month, day).
+/// Algorithm from Howard Hinnant (public domain, used in chrono/date.h).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u32;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
 }
 
 impl TelemetryClient {

--- a/crates/reco-gui/src/telemetry_client.rs
+++ b/crates/reco-gui/src/telemetry_client.rs
@@ -78,6 +78,10 @@ impl TelemetryClient {
 
         thread::spawn(move || {
             let version = env!("CARGO_PKG_VERSION").to_string();
+            let agent = ureq::Agent::config_builder()
+                .timeout_global(Some(std::time::Duration::from_secs(5)))
+                .build()
+                .new_agent();
             while let Ok(event) = rx.recv() {
                 let batch = Batch {
                     schema_version: 1,
@@ -99,7 +103,8 @@ impl TelemetryClient {
                     }
                 };
 
-                match ureq::post(ENDPOINT)
+                match agent
+                    .post(ENDPOINT)
                     .header("Content-Type", "application/json")
                     .send(json.as_str())
                 {
@@ -174,6 +179,15 @@ impl TelemetryClient {
             Some(serde_json::json!({
                 "confidence": confidence,
                 "matches": matches,
+            })),
+        );
+    }
+
+    pub fn calibration_error(&self, error: &str) {
+        self.send(
+            "calibration_error",
+            Some(serde_json::json!({
+                "error_message": &error[..error.len().min(500)],
             })),
         );
     }

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -267,6 +267,7 @@ export component RecoApp inherits Window {
     in-out property <float> blend-width: 0.05;
     in-out property <float> rig-tilt: 0.0; // degrees
     in-out property <float> rig-roll: 0.0; // degrees
+    in-out property <int> sync-offset: 0;  // frames
 
     // Live calibration adjustments (PlaneLayout fields on MatchCalibration).
     // Updating these re-runs StitchPipeline::update_layout() so the user
@@ -441,6 +442,7 @@ export component RecoApp inherits Window {
     callback changed-blend-width(float);
     callback changed-rig-tilt(float);
     callback changed-rig-roll(float);
+    callback changed-sync-offset(int);
     callback changed-fov(float);
     // Live calibration editing.
     callback changed-cal-intersect(float);
@@ -905,6 +907,16 @@ export component RecoApp inherits Window {
                             suffix: "°";
                             decimals: 1;
                             changed(v) => { root.changed-rig-roll(v); }
+                        }
+
+                        if root.files-loaded: LabeledSlider {
+                            label: "Sync offset";
+                            minimum: -300;
+                            maximum: 300;
+                            value: root.sync-offset;
+                            suffix: " frames";
+                            decimals: 0;
+                            changed(v) => { root.sync-offset = round(v); root.changed-sync-offset(round(v)); }
                         }
 
                         if root.files-loaded && (root.cal-dirty || root.lens-dirty): Button {

--- a/crates/reco-io/src/ffmpeg/decoder.rs
+++ b/crates/reco-io/src/ffmpeg/decoder.rs
@@ -214,6 +214,7 @@ pub struct VideoDecoder {
     backend: DecodeBackend,
     rotation: i32,
     is_10bit: bool,
+    is_full_range: bool,
     decoded_frame: VideoFrame,
     sw_frame: VideoFrame,
     converted_frame: VideoFrame,
@@ -384,6 +385,20 @@ impl VideoDecoder {
             }
         };
 
+        let is_full_range = {
+            let raw_codecpar = unsafe { &*stream.parameters().as_ptr() };
+            let format = Pixel::from(raw_i32_to_pix_fmt(raw_codecpar.format));
+            let yuvj = matches!(format, Pixel::YUVJ420P | Pixel::YUVJ422P | Pixel::YUVJ444P);
+            let range_jpeg = raw_codecpar.color_range == ffi::AVColorRange::AVCOL_RANGE_JPEG;
+            if yuvj || range_jpeg {
+                log::info!(
+                    "Source is full-range YUV (format={format:?}, color_range={:?})",
+                    raw_codecpar.color_range
+                );
+            }
+            yuvj || range_jpeg
+        };
+
         log::debug!(
             "Decoder: {}x{} {:?}, time_base={}/{}, backend={}",
             width,
@@ -410,6 +425,7 @@ impl VideoDecoder {
             backend,
             rotation,
             is_10bit,
+            is_full_range,
             decoded_frame: VideoFrame::empty(),
             sw_frame: VideoFrame::empty(),
             converted_frame: VideoFrame::empty(),
@@ -504,6 +520,11 @@ impl VideoDecoder {
         } else {
             reco_core::render::renderer::GpuPixelFormat::Nv12
         }
+    }
+
+    /// Whether the source uses full-range YUV (0-255) rather than limited range (16-235).
+    pub fn is_full_range(&self) -> bool {
+        self.is_full_range
     }
 
     /// Rotation from stream metadata (0, 90, 180, 270 degrees).

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -35,6 +35,7 @@ pub struct SmartFileSource {
     mode: SourceMode,
     info: SourceInfo,
     pixel_format: GpuPixelFormat,
+    full_range: bool,
     left_rotation: i32,
     right_rotation: i32,
     /// Human-readable description of the active decode path.
@@ -163,6 +164,7 @@ impl SmartFileSource {
             total_frames: None,
         };
         let pixel_format = probe.pixel_format();
+        let full_range = probe.is_full_range();
         let left_rotation = probe.rotation();
         let decode_backend = probe.backend();
         drop(probe);
@@ -198,6 +200,7 @@ impl SmartFileSource {
                 sync_offset,
                 info,
                 pixel_format,
+                full_range,
                 left_rotation,
                 right_rotation,
             )
@@ -208,6 +211,7 @@ impl SmartFileSource {
                 sync_offset,
                 info,
                 pixel_format,
+                full_range,
                 left_rotation,
                 right_rotation,
             )
@@ -236,6 +240,7 @@ impl SmartFileSource {
             total_frames: None,
         };
         let pixel_format = probe.pixel_format();
+        let full_range = probe.is_full_range();
         let left_rotation = probe.rotation();
         drop(probe);
 
@@ -252,6 +257,7 @@ impl SmartFileSource {
             sync_offset,
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
         )
@@ -263,19 +269,22 @@ impl SmartFileSource {
         sync_offset: i64,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
+        full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
         let source = crate::adapters::FfmpegFileSource::open_from_inputs(left, right, sync_offset)?;
         log::info!(
-            "SmartFileSource: CPU decode ({}x{}, {pixel_format:?})",
+            "SmartFileSource: CPU decode ({}x{}, {pixel_format:?}{})",
             info.width,
-            info.height
+            info.height,
+            if full_range { ", full-range" } else { "" }
         );
         Ok(Self {
             mode: SourceMode::Cpu(source),
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
             decode_mode: "CPU upload",
@@ -292,6 +301,7 @@ impl SmartFileSource {
         sync_offset: i64,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
+        full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
@@ -426,6 +436,7 @@ impl SmartFileSource {
             })),
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
             decode_mode: "GPU zero-copy (CUDA/Vulkan)",
@@ -663,6 +674,10 @@ impl FrameSource for SmartFileSource {
 
     fn gpu_pixel_format(&self) -> GpuPixelFormat {
         self.pixel_format
+    }
+
+    fn is_full_range(&self) -> bool {
+        self.full_range
     }
 
     fn left_rotation(&self) -> i32 {

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -453,21 +453,24 @@ impl SmartFileSource {
         sync_offset: i64,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
+        full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
         let pair_rx = crate::zero_copy::spawn_vt_decode_pair(left, right, sync_offset);
 
         log::info!(
-            "SmartFileSource: Metal zero-copy ({}x{}, VideoToolbox decode)",
+            "SmartFileSource: Metal zero-copy ({}x{}, VideoToolbox decode{})",
             info.width,
-            info.height
+            info.height,
+            if full_range { ", full-range" } else { "" }
         );
 
         Ok(Self {
             mode: SourceMode::MetalZeroCopy(pair_rx),
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
             decode_mode: "Metal zero-copy (VideoToolbox)",
@@ -484,6 +487,7 @@ impl SmartFileSource {
         sync_offset: i64,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
+        full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
@@ -500,6 +504,7 @@ impl SmartFileSource {
             })),
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
             decode_mode: "D3D11VA zero-copy",
@@ -516,6 +521,7 @@ impl SmartFileSource {
         sync_offset: i64,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
+        full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
@@ -526,6 +532,7 @@ impl SmartFileSource {
             sync_offset,
             info,
             pixel_format,
+            full_range,
             left_rotation,
             right_rotation,
         )


### PR DESCRIPTION
## Summary

Cross-platform bug fixes and telemetry improvements based on community testing of v0.5.0.

### Bug fixes
- **BUG-4**: Full-range YUV color (yuvj420p/GoPro 4K) - shader was clipping blacks/whites with limited-range scaling. Detects full range from AVCodecParameters + YUVJ pixel formats, branches in shader.
- **BUG-17**: Linux release binary AI gave 0 detections on GPU-resident frames. GpuResident path now uses wgpu shared texture views when the detector doesn't need CUDA (ORT/wgpu preprocess path).
- **BUG-19**: Mac Metal 10-bit zero-copy hang. Added P010 FourCC support (x420/xf20) to Metal import, gated TEXTURE_FORMAT_P010 to Windows only.

### Telemetry
- Fixed timestamps (was hardcoded to January 1st, now uses civil_from_days)
- export_complete sends actual duration and codec (was 0.0 and empty)
- Second context event after pipeline init with real GPU name (was "pending GPU init")
- New calibration_error event for failed auto-calibrations
- 5-second HTTP timeout (was 30s default, blocking on cold Cloud Run)

### Logging
- Log file on all platforms (Mac: ~/Library/Logs, Linux: ~/.local/state/reco, Windows: next to exe)
- Append mode so crash logs survive restart, truncate at 2 MB
- Last 200 lines attached to bug reports
- Device feature requests logged before device creation
- Metal import format logged on first frame (8-bit vs 10-bit)

### Features
- Sync offset slider in GUI Stitching section (-300 to +300 frames)

## Test plan
- [ ] Visual verify GoPro 4K full-range output (colors not washed out)
- [ ] Test sync offset slider in GUI (changes preview, marks dirty, saves to JSON)
- [ ] Verify 10-bit stitch on Mac (was hanging, should now work)
- [ ] Verify Linux AI detections with release binary (was 0, should be non-zero)
- [ ] Check log file created on Mac/Linux in correct location
- [ ] Submit a test bug report and verify logs are attached