### PR TITLE
fix: v0.5.1 bug fixes, telemetry, and color range support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,14 @@ jobs:
           echo "ORT_DLL=$dll" >> $env:GITHUB_ENV
           echo "Bundled ONNX Runtime 1.24.4 DirectML ($('{0:N1}' -f ((Get-Item $dll).Length / 1MB)) MB)"
 
+          # DirectML.dll is in a separate NuGet package (not bundled in ORT DirectML).
+          $dmlPkg = "$env:RUNNER_TEMP\directml.nupkg"
+          Invoke-WebRequest -Uri "https://api.nuget.org/v3-flatcontainer/microsoft.ai.directml/1.15.4/microsoft.ai.directml.1.15.4.nupkg" -OutFile $dmlPkg
+          Expand-Archive -Path $dmlPkg -DestinationPath "$env:RUNNER_TEMP\directml"
+          $dml = "$env:RUNNER_TEMP\directml\bin\x64-win\DirectML.dll"
+          echo "DML_DLL=$dml" >> $env:GITHUB_ENV
+          echo "Bundled DirectML.dll 1.15.4 ($('{0:N1}' -f ((Get-Item $dml).Length / 1MB)) MB)"
+
       - name: Download ONNX Runtime (macOS)
         if: runner.os == 'macOS'
         run: |
@@ -248,6 +256,12 @@ jobs:
           if (Test-Path "$env:FFMPEG_DLL_DIR") {
             Copy-Item "$env:FFMPEG_DLL_DIR\*.dll" "$staging\"
           }
+          if (Test-Path "$env:ORT_DLL") {
+            Copy-Item "$env:ORT_DLL" "$staging\"
+          }
+          if (Test-Path "$env:DML_DLL") {
+            Copy-Item "$env:DML_DLL" "$staging\"
+          }
           Compress-Archive -Path $staging -DestinationPath "$staging.zip"
 
       - name: Package GUI (Windows)
@@ -263,9 +277,12 @@ jobs:
             if (Test-Path "$env:FFMPEG_DLL_DIR") {
               Copy-Item "$env:FFMPEG_DLL_DIR\*.dll" "$staging\"
             }
-            # Bundle ONNX Runtime DirectML for AI detection
+            # Bundle ONNX Runtime + DirectML for AI detection
             if (Test-Path "$env:ORT_DLL") {
               Copy-Item "$env:ORT_DLL" "$staging\"
+            }
+            if (Test-Path "$env:DML_DLL") {
+              Copy-Item "$env:DML_DLL" "$staging\"
             }
             Compress-Archive -Path $staging -DestinationPath "$staging.zip"
           }

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -4,7 +4,12 @@
 
 Download the latest **GUI** release for your platform from the [Releases page](https://github.com/reco-project/video-stitcher/releases). Also download `yolo26n.onnx` from the same release (needed for AI tracking).
 
-Extract and run `reco-gui`. On Mac, right-click > Open the first time (unsigned app).
+Extract and run `reco-gui`.
+
+- **Windows**: If SmartScreen blocks the app, right-click the exe > Properties > check "Unblock" > OK, then run again.
+- **Mac**: Right-click > Open the first time (unsigned app).
+
+For AI tracking, also download `yolo26n.onnx` (1280, higher accuracy) or `yolo26n_640.onnx` (640, faster on integrated GPUs) from the same release.
 
 ## 2. Import & Calibrate
 
@@ -40,9 +45,25 @@ If the image looks warped (curved lines that should be straight):
   - Set mode to **Field** and detection interval to **15**
 - Click **Start**
 
+## 6. Debug AI Tracking (optional)
+
+To see what the AI detected, export pipeline events and visualize them:
+
+```bash
+reco stitch left.mp4 right.mp4 -c cal.json --model yolo26n.onnx \
+    --tracking field --detection-interval 15 --events detections.jsonl -o output.mp4
+
+python3 scripts/visualize_detections.py export detections.jsonl left.mp4 right.mp4 \
+    -c cal.json -o annotated.mp4
+```
+
+This produces a side-by-side video with detection boxes, ROI boundaries, tracking state, and panner decisions overlaid.
+
 ## Tips
 
 - Try a short clip first (set start/end times) before exporting the full video
-- 10-bit footage (e.g. DJI Action 4) may show green on Windows - use CPU Decode in settings as a workaround
+- For football, use **Field** tracking mode with detection interval **10-15** for smooth panning
+- Use the **Sync offset** slider in Stitching to fine-tune camera alignment after calibration
 - Share your calibration file with us if something looks wrong
 - Can't find a lens profile for your camera? Let us know
+- Join the community at [forum.reco-project.org](https://forum.reco-project.org)

--- a/crates/reco-autocam/src/panners/field.rs
+++ b/crates/reco-autocam/src/panners/field.rs
@@ -120,6 +120,20 @@ pub struct FieldPanner {
     last_ball_yaw: f32,
     last_ball_pitch: f32,
     frame_index: u64,
+    last_debug: Option<FieldPannerDebug>,
+}
+
+struct FieldPannerDebug {
+    cluster_yaw: f32,
+    cluster_pitch: f32,
+    cluster_spread: f32,
+    n_players: u32,
+    ball_near_cluster: bool,
+    ball_presence: f32,
+    effective_ball_weight: f32,
+    target_yaw: f32,
+    target_pitch: f32,
+    fov_target: f32,
 }
 
 impl FieldPanner {
@@ -146,6 +160,7 @@ impl FieldPanner {
             last_ball_yaw: 0.0,
             last_ball_pitch: 0.0,
             frame_index: 0,
+            last_debug: None,
         }
     }
 
@@ -452,7 +467,21 @@ impl Panner for FieldPanner {
                     self.current_fov,
                 );
             }
+
+            self.last_debug = Some(FieldPannerDebug {
+                cluster_yaw: c.yaw,
+                cluster_pitch: c.pitch,
+                cluster_spread: c.spread,
+                n_players: c.count as u32,
+                ball_near_cluster,
+                ball_presence: self.ball_presence,
+                effective_ball_weight: effective_w,
+                target_yaw,
+                target_pitch,
+                fov_target: target_fov,
+            });
         } else {
+            self.last_debug = None;
             log::trace!(
                 "FieldPanner: no cluster this frame (players={}, min={})",
                 world.players.len(),
@@ -479,6 +508,28 @@ impl Panner for FieldPanner {
             pitch: self.pitch,
             fov_degrees: Some(self.current_fov),
         }
+    }
+
+    fn debug_event(
+        &self,
+        frame_index: u64,
+    ) -> Option<reco_core::detect::pipeline_event::PipelineEvent> {
+        let d = self.last_debug.as_ref()?;
+        Some(
+            reco_core::detect::pipeline_event::PipelineEvent::PannerDebug {
+                frame_index,
+                cluster_yaw: d.cluster_yaw,
+                cluster_pitch: d.cluster_pitch,
+                cluster_spread: d.cluster_spread,
+                n_players: d.n_players,
+                ball_near_cluster: d.ball_near_cluster,
+                ball_presence: d.ball_presence,
+                effective_ball_weight: d.effective_ball_weight,
+                target_yaw: d.target_yaw,
+                target_pitch: d.target_pitch,
+                fov_target: d.fov_target,
+            },
+        )
     }
 }
 

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -37,7 +37,7 @@ pub struct CameraRunConfig<'a> {
     pub capture_fps: u32,
     pub model_path: Option<&'a str>,
     pub detection_interval: u64,
-    pub crf: Option<u8>,
+    pub quality_value: Option<u8>,
     pub preset: Option<String>,
     /// Output container (`mp4` / `fmp4` / `mkv`). None -> `mp4`.
     /// `mkv` recommended for live recording (crash-safe, streamable).
@@ -87,7 +87,7 @@ pub fn run_camera(
         capture_fps,
         model_path,
         detection_interval,
-        crf,
+        quality_value,
         preset,
         container,
         tracking,
@@ -328,8 +328,8 @@ pub fn run_camera(
     let enc_config = reco_io::ffmpeg::encoder::EncoderConfig {
         encoder_name,
         codec: out_codec.into(),
-        quality: out_quality.into(),
-        crf,
+        quality_preset: out_quality.into(),
+        quality: quality_value,
         preset,
         container: out_format.into(),
         gop_size: Some(60),

--- a/crates/reco-cli/src/libcamera_cmd.rs
+++ b/crates/reco-cli/src/libcamera_cmd.rs
@@ -33,7 +33,7 @@ pub struct LibcameraRunConfig<'a> {
     pub capture_fps: u32,
     pub model_path: Option<&'a str>,
     pub detection_interval: u64,
-    pub crf: Option<u8>,
+    pub quality_value: Option<u8>,
     pub preset: Option<String>,
 }
 
@@ -56,7 +56,7 @@ pub fn run_libcamera(
         capture_fps,
         model_path,
         detection_interval,
-        crf,
+        quality_value,
         preset,
     } = config;
     anyhow::ensure!(
@@ -131,8 +131,8 @@ pub fn run_libcamera(
     let enc_config = reco_io::ffmpeg::encoder::EncoderConfig {
         encoder_name,
         codec: out_codec.into(),
-        quality: out_quality.into(),
-        crf,
+        quality_preset: out_quality.into(),
+        quality: quality_value,
         preset,
         ..Default::default()
     };

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -185,9 +185,13 @@ enum Commands {
         #[arg(long, default_value = "ball")]
         tracking: String,
 
-        /// Override encoder CRF/quality value (lower = better, typical 18-28).
-        #[arg(long)]
-        crf: Option<u8>,
+        /// Encoder quality on a 0-100 scale (higher = better). Overrides the
+        /// quality preset with a precise value. Converted per encoder:
+        /// CRF-style encoders map to `crf = 40 - (quality/100)*28`,
+        /// VideoToolbox passes through as `global_quality`. Examples:
+        /// 80 = high quality, 65 = balanced, 50 = smaller files.
+        #[arg(long = "quality-value")]
+        quality_value: Option<u8>,
 
         /// Override encoder preset (e.g. ultrafast, veryfast, fast for x264; p1-p7 for NVENC).
         #[arg(long)]
@@ -344,9 +348,10 @@ enum Commands {
         #[arg(long, default_value_t = 1)]
         detection_interval: u64,
 
-        /// Override encoder CRF/quality value (lower = better, typical 18-28).
-        #[arg(long)]
-        crf: Option<u8>,
+        /// Encoder quality on a 0-100 scale (higher = better). Overrides the
+        /// quality preset. See `stitch --help` for the full mapping table.
+        #[arg(long = "quality-value")]
+        quality_value: Option<u8>,
 
         /// Override encoder preset (e.g. ultrafast, veryfast, fast for x264; p1-p7 for NVENC).
         #[arg(long)]
@@ -498,9 +503,10 @@ enum Commands {
         #[arg(long, default_value_t = 1)]
         detection_interval: u64,
 
-        /// Override encoder CRF/quality value (lower = better, typical 18-28).
-        #[arg(long)]
-        crf: Option<u8>,
+        /// Encoder quality on a 0-100 scale (higher = better). Overrides the
+        /// quality preset. See `stitch --help` for the full mapping table.
+        #[arg(long = "quality-value")]
+        quality_value: Option<u8>,
 
         /// Override encoder preset (e.g. ultrafast, veryfast, fast for x264).
         #[arg(long)]
@@ -723,7 +729,7 @@ fn main() -> anyhow::Result<()> {
             detection_interval,
             lead_time,
             tracking,
-            crf,
+            quality_value,
             preset,
             container,
             replay,
@@ -751,7 +757,7 @@ fn main() -> anyhow::Result<()> {
                 detection_interval,
                 lead_time,
                 tracking_mode: &tracking,
-                crf,
+                quality_value,
                 preset,
                 container: container.as_deref(),
                 replay_path: replay.as_deref(),
@@ -814,7 +820,7 @@ fn main() -> anyhow::Result<()> {
             end_time,
             model,
             detection_interval,
-            crf,
+            quality_value,
             preset,
             container,
             stream_url,
@@ -878,7 +884,7 @@ fn main() -> anyhow::Result<()> {
                     capture_fps,
                     model_path: model.as_deref(),
                     detection_interval,
-                    crf,
+                    quality_value,
                     preset,
                     container: container.as_deref(),
                     tracking: &tracking,
@@ -923,7 +929,7 @@ fn main() -> anyhow::Result<()> {
             end_time,
             model,
             detection_interval,
-            crf,
+            quality_value,
             preset,
         } => {
             use reco_io::libcamera::LibcameraConfig;
@@ -962,7 +968,7 @@ fn main() -> anyhow::Result<()> {
                     capture_fps,
                     model_path: model.as_deref(),
                     detection_interval,
-                    crf,
+                    quality_value,
                     preset,
                 },
                 &interrupted,

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -47,7 +47,8 @@ fn init_tracing() {
     // errors so tests that construct multiple CLIs don't panic.
     let _ = tracing_log::LogTracer::init();
 
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,ort::logging=warn"));
     let fmt_layer = fmt::layer().with_target(true).with_level(true);
 
     let _ = tracing_subscriber::registry()

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -35,7 +35,7 @@ pub struct StitchArgs<'a> {
     pub detection_interval: u64,
     pub lead_time: f64,
     pub tracking_mode: &'a str,
-    pub crf: Option<u8>,
+    pub quality_value: Option<u8>,
     pub preset: Option<String>,
     /// Output container selector (`mp4` / `fmp4` / `mkv`). None
     /// means default (plain MP4, finalized at close). `mkv` or
@@ -116,8 +116,8 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
     if let Some(ref enc) = args.encoder_name {
         job = job.encoder_name(enc);
     }
-    if let Some(crf) = args.crf {
-        job = job.crf(crf);
+    if let Some(qv) = args.quality_value {
+        job = job.quality_value(qv);
     }
     if let Some(ref preset) = args.preset {
         job = job.preset(preset);

--- a/crates/reco-core/src/detect/panner.rs
+++ b/crates/reco-core/src/detect/panner.rs
@@ -73,6 +73,11 @@ pub struct PanContext<'a> {
 pub trait Panner: Send {
     /// Decide where the virtual camera should look this frame.
     fn decide(&mut self, world: &WorldState, ctx: &PanContext<'_>) -> ViewportPosition;
+
+    /// Optional debug snapshot from the last `decide()` call.
+    fn debug_event(&self, _frame_index: u64) -> Option<PipelineEvent> {
+        None
+    }
 }
 
 /// Scalar inputs to [`dispatch`] bundled so the function stays under
@@ -183,6 +188,9 @@ pub(crate) fn dispatch(
             frame_index: ctx.frame_index,
             pose,
         });
+        if let Some(debug) = panner.debug_event(ctx.frame_index) {
+            sink.emit(debug);
+        }
     }
 
     Some(DispatchResult {

--- a/crates/reco-core/src/detect/pipeline_event.rs
+++ b/crates/reco-core/src/detect/pipeline_event.rs
@@ -94,6 +94,21 @@ pub enum PipelineEvent {
         pose: ViewportPosition,
     },
 
+    /// Panner internal state for debugging camera movement decisions.
+    PannerDebug {
+        frame_index: u64,
+        cluster_yaw: f32,
+        cluster_pitch: f32,
+        cluster_spread: f32,
+        n_players: u32,
+        ball_near_cluster: bool,
+        ball_presence: f32,
+        effective_ball_weight: f32,
+        target_yaw: f32,
+        target_pitch: f32,
+        fov_target: f32,
+    },
+
     /// Final pose the renderer received this frame (post-clamp).
     PosePresented {
         frame_index: u64,
@@ -148,6 +163,7 @@ impl PipelineEvent {
             | PipelineEvent::DetectionFilter { frame_index, .. }
             | PipelineEvent::WorldState { frame_index, .. }
             | PipelineEvent::PanDecision { frame_index, .. }
+            | PipelineEvent::PannerDebug { frame_index, .. }
             | PipelineEvent::PosePresented { frame_index, .. }
             | PipelineEvent::FrameComplete { frame_index, .. } => *frame_index,
         }

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -398,6 +398,21 @@ pub trait FrameSource: Send {
         0
     }
 
+    /// Skip N frames without processing them.
+    ///
+    /// The default implementation calls `next_frame()` in a loop, which
+    /// works for CPU and D3D11VA sources. GPU zero-copy sources override
+    /// this to receive and immediately release decode slots, avoiding
+    /// deadlock from the bounded slot channel.
+    fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
+        for i in 0..count {
+            if self.next_frame()?.is_none() {
+                return Ok(i);
+            }
+        }
+        Ok(count)
+    }
+
     /// Seek to a specific frame number.
     ///
     /// File-based sources should implement this for interactive scrubbing.

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -801,7 +801,7 @@ impl AppState {
 
     fn set_rig_tilt(&mut self, deg: f32) {
         if let Some(cal) = self.calibration.as_mut() {
-            cal.rig_tilt = deg as f64;
+            cal.rig_tilt = (deg as f64).to_radians();
         }
         if let Some(bridge) = self.bridge.as_mut() {
             bridge.renderer_mut().set_rig_tilt(deg.to_radians());
@@ -829,7 +829,7 @@ impl AppState {
 
     fn set_rig_roll(&mut self, deg: f32) {
         if let Some(cal) = self.calibration.as_mut() {
-            cal.rig_roll = deg as f64;
+            cal.rig_roll = (deg as f64).to_radians();
         }
         if let Some(bridge) = self.bridge.as_mut() {
             bridge.renderer_mut().set_rig_roll(deg.to_radians());

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3362,7 +3362,8 @@ fn main() -> anyhow::Result<()> {
                             };
                             let msg = format!("{err}");
                             if let Some(ref t) = s.telemetry {
-                                t.export_error(&msg);
+                                let codec = app.get_export_codec().to_string();
+                                t.export_error(&msg, &codec);
                             }
                             s.toasts.push(Severity::Error, title, body);
                             crate::toast::sync_to_ui(&s.toasts, &app);
@@ -3691,6 +3692,15 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     let os = format!("{} {}", std::env::consts::OS, std::env::consts::ARCH);
                     let (ai_status, _) = ai_capability_summary();
                     t.context(&gpu, &os, &ai_status);
+                    let (w, h) = s.playback.input_dimensions().unwrap_or((0, 0));
+                    let fps = s.playback.fps();
+                    let decoder = s
+                        .bridge
+                        .as_ref()
+                        .map(|_| "D3D11VA/NVDEC/VT")
+                        .unwrap_or("unknown");
+                    let sync = s.calibration.as_ref().map(|c| c.sync_offset).unwrap_or(0);
+                    t.source_info(w, h, fps, decoder, sync);
                 }
             }
         }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1076,7 +1076,8 @@ fn init_tracing() {
     use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
     let _ = tracing_log::LogTracer::init();
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,ort::logging=warn"));
 
     // In release builds, write logs to a file so bug reports have context.
     // Debug builds just use stderr.

--- a/crates/reco-gui/src/telemetry_client.rs
+++ b/crates/reco-gui/src/telemetry_client.rs
@@ -143,14 +143,7 @@ impl TelemetryClient {
         );
     }
 
-    pub fn source_info(
-        &self,
-        width: u32,
-        height: u32,
-        fps: f64,
-        decoder: &str,
-        sync_offset: i64,
-    ) {
+    pub fn source_info(&self, width: u32, height: u32, fps: f64, decoder: &str, sync_offset: i64) {
         self.send(
             "source_info",
             Some(serde_json::json!({

--- a/crates/reco-gui/src/telemetry_client.rs
+++ b/crates/reco-gui/src/telemetry_client.rs
@@ -143,6 +143,26 @@ impl TelemetryClient {
         );
     }
 
+    pub fn source_info(
+        &self,
+        width: u32,
+        height: u32,
+        fps: f64,
+        decoder: &str,
+        sync_offset: i64,
+    ) {
+        self.send(
+            "source_info",
+            Some(serde_json::json!({
+                "width": width,
+                "height": height,
+                "fps": fps,
+                "decoder": decoder,
+                "sync_offset": sync_offset,
+            })),
+        );
+    }
+
     pub fn bug_report(&self, report: &str) {
         self.send(
             "bug_report",
@@ -163,12 +183,13 @@ impl TelemetryClient {
         );
     }
 
-    pub fn export_error(&self, error: &str) {
+    pub fn export_error(&self, error: &str, codec: &str) {
         self.send(
             "export_error",
             Some(serde_json::json!({
                 "error_type": "export_failed",
                 "error_message": &error[..error.len().min(500)],
+                "codec": codec,
             })),
         );
     }

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -462,7 +462,7 @@ pub fn detect_zero_copy(source: &FfmpegFileSource, gpu: &reco_core::gpu::GpuCont
 /// * `codec` - Codec name: `"h264"`, `"hevc"`, or `"av1"`.
 /// * `quality` - Quality preset: `"fast"`, `"balanced"`, or `"high"`.
 /// * `encoder_name` - Force a specific encoder by name, or `None` for auto-detection.
-/// * `crf` - Override the CRF/quality value, or `None` to use the quality tier default.
+/// * `quality_value` - Normalized quality override (0-100, higher = better), or `None` to use preset default.
 /// * `preset` - Override the encoder preset string, or `None` to use the quality tier default.
 #[cfg(feature = "ffmpeg")]
 #[allow(clippy::too_many_arguments)]
@@ -474,7 +474,7 @@ pub fn create_encoder(
     codec: &str,
     quality: &str,
     encoder_name: Option<String>,
-    crf: Option<u8>,
+    quality_value: Option<u8>,
     preset: Option<String>,
 ) -> Result<(FfmpegFileEncoder, String), reco_core::encoder::EncodeError> {
     use crate::output;
@@ -490,8 +490,8 @@ pub fn create_encoder(
     let enc_config = ffmpeg::encoder::EncoderConfig {
         encoder_name,
         codec: out_codec.into(),
-        quality: out_quality.into(),
-        crf,
+        quality_preset: out_quality.into(),
+        quality: quality_value,
         preset,
         audio_source: None,
         container: ffmpeg::encoder::Container::default(),

--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -1386,13 +1386,22 @@ fn build_encoder_opts(
 ) -> ffmpeg::Dictionary<'static> {
     let mut opts = ffmpeg::Dictionary::new();
 
+    // When a quality override is set, derive the effective preset from
+    // the quality value so NVENC preset/maxrate scale with the CQ.
+    let effective_preset = match quality_override {
+        Some(q) if q >= 75 => Quality::High,
+        Some(q) if q >= 40 => Quality::Balanced,
+        Some(_) => Quality::Fast,
+        None => quality_preset,
+    };
+
     match name {
         "h264_nvenc" => {
             // NVENC VBR with per-quality bitrate ceiling. Prior defaults
             // (10M / 15M across all quality presets) artificially capped
             // High output at ~15 Mbps even with cq=19. Scale the ceilings
             // with quality so "high" actually delivers the visual bump.
-            let (preset, cq, bv, maxrate) = match quality_preset {
+            let (preset, cq, bv, maxrate) = match effective_preset {
                 Quality::Fast => ("p3", "28", "8M", "12M"),
                 Quality::Balanced => ("p4", "23", "12M", "18M"),
                 Quality::High => ("p5", "19", "20M", "30M"),
@@ -1409,7 +1418,7 @@ fn build_encoder_opts(
         }
         "hevc_nvenc" => {
             // HEVC ~30% more efficient than H264, so ceilings scale down.
-            let (preset, cq, bv, maxrate) = match quality_preset {
+            let (preset, cq, bv, maxrate) = match effective_preset {
                 Quality::Fast => ("p3", "28", "6M", "10M"),
                 Quality::Balanced => ("p4", "23", "9M", "14M"),
                 Quality::High => ("p5", "19", "15M", "22M"),
@@ -1426,7 +1435,7 @@ fn build_encoder_opts(
         }
         "av1_nvenc" => {
             // AV1 another ~20% tighter than HEVC.
-            let (preset, cq, bv, maxrate) = match quality_preset {
+            let (preset, cq, bv, maxrate) = match effective_preset {
                 Quality::Fast => ("p3", "32", "5M", "8M"),
                 Quality::Balanced => ("p4", "27", "7M", "11M"),
                 Quality::High => ("p5", "22", "12M", "18M"),
@@ -1439,7 +1448,7 @@ fn build_encoder_opts(
             opts.set("maxrate", maxrate);
         }
         "h264_qsv" => {
-            let gq = match quality_preset {
+            let gq = match effective_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1451,7 +1460,7 @@ fn build_encoder_opts(
         "h264_videotoolbox" => {
             // global_quality maps to VTCompressionPropertyKey_Quality (0-100).
             // "q:v" doesn't work through the C API dictionary (colon is CLI syntax).
-            let q = match quality_preset {
+            let q = match effective_preset {
                 Quality::Fast => "55",
                 Quality::Balanced => "65",
                 Quality::High => "80",
@@ -1460,7 +1469,7 @@ fn build_encoder_opts(
             opts.set("profile", "high");
         }
         "hevc_videotoolbox" => {
-            let q = match quality_preset {
+            let q = match effective_preset {
                 Quality::Fast => "55",
                 Quality::Balanced => "65",
                 Quality::High => "80",
@@ -1469,7 +1478,7 @@ fn build_encoder_opts(
             opts.set("profile", "main");
         }
         "h264_vaapi" | "hevc_vaapi" | "av1_vaapi" => {
-            let qp = match quality_preset {
+            let qp = match effective_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1480,7 +1489,7 @@ fn build_encoder_opts(
             }
         }
         "h264_v4l2m2m" | "hevc_v4l2m2m" => {
-            let qp = match quality_preset {
+            let qp = match effective_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1489,7 +1498,7 @@ fn build_encoder_opts(
             // Don't set profile - v4l2m2m drivers pick appropriate defaults.
         }
         "h264_amf" | "hevc_amf" | "av1_amf" => {
-            let q = match quality_preset {
+            let q = match effective_preset {
                 Quality::Fast => "22",
                 Quality::Balanced => "18",
                 Quality::High => "14",
@@ -1500,7 +1509,7 @@ fn build_encoder_opts(
             opts.set("rc", "cqp");
         }
         "libx265" => {
-            let (preset, crf_val) = match quality_preset {
+            let (preset, crf_val) = match effective_preset {
                 Quality::Fast => ("veryfast", "28"),
                 Quality::Balanced => ("fast", "25"),
                 Quality::High => ("medium", "21"),
@@ -1510,7 +1519,7 @@ fn build_encoder_opts(
             opts.set("profile", "main");
         }
         "libsvtav1" => {
-            let (preset, crf_val) = match quality_preset {
+            let (preset, crf_val) = match effective_preset {
                 Quality::Fast => ("10", "35"),
                 Quality::Balanced => ("7", "30"),
                 Quality::High => ("4", "25"),
@@ -1519,7 +1528,7 @@ fn build_encoder_opts(
             opts.set("crf", crf_val);
         }
         "libaom-av1" => {
-            let (crf_val, cpu_used) = match quality_preset {
+            let (crf_val, cpu_used) = match effective_preset {
                 Quality::Fast => ("35", "8"),
                 Quality::Balanced => ("30", "6"),
                 Quality::High => ("25", "4"),
@@ -1529,7 +1538,7 @@ fn build_encoder_opts(
             opts.set("row-mt", "1");
         }
         "libx264" => {
-            let (preset, crf_val) = match quality_preset {
+            let (preset, crf_val) = match effective_preset {
                 Quality::Fast => ("ultrafast", "32"),
                 Quality::Balanced => ("veryfast", "28"),
                 Quality::High => ("fast", "23"),

--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -348,10 +348,15 @@ pub struct EncoderConfig {
     pub encoder_name: Option<String>,
     /// Output video codec (H.264, HEVC, AV1). Default: H.264.
     pub codec: VideoCodec,
-    /// Quality preset.
-    pub quality: Quality,
-    /// Override the CRF/quality value (passed through to the encoder).
-    pub crf: Option<u8>,
+    /// Quality preset (Fast / Balanced / High). Controls default encoder
+    /// tuning when no explicit [`quality`](Self::quality) override is set.
+    pub quality_preset: Quality,
+    /// Normalized quality override (0-100, higher = better). When set,
+    /// replaces the encoder's default quality parameter with a value
+    /// derived from this scale. The conversion is per-encoder:
+    /// CRF-style encoders use `crf = 40.0 - (quality / 100.0) * 28.0`,
+    /// VideoToolbox passes `global_quality = quality` directly.
+    pub quality: Option<u8>,
     /// Override the encoder preset string (passed through to the encoder).
     pub preset: Option<String>,
     /// Path to a source file to copy audio from (stream copy, no re-encoding).
@@ -694,8 +699,12 @@ impl VideoEncoder {
         // canonical ffmpeg-next transcode example follows the same
         // pattern: set params, open, re-set params.
         ost.set_parameters(&enc);
-        let mut opts =
-            build_encoder_opts(name, config.quality, config.crf, config.preset.as_deref());
+        let mut opts = build_encoder_opts(
+            name,
+            config.quality_preset,
+            config.quality,
+            config.preset.as_deref(),
+        );
         // B-frames cause negative initial PTS offsets and frame reordering
         // in the encoded output. For real-time stitching they add latency
         // with no visual benefit, so disable unconditionally.
@@ -1371,8 +1380,8 @@ impl SilentAudio {
 /// Build encoder-specific FFmpeg options.
 fn build_encoder_opts(
     name: &str,
-    quality: Quality,
-    crf_override: Option<u8>,
+    quality_preset: Quality,
+    quality_override: Option<u8>,
     preset_override: Option<&str>,
 ) -> ffmpeg::Dictionary<'static> {
     let mut opts = ffmpeg::Dictionary::new();
@@ -1383,7 +1392,7 @@ fn build_encoder_opts(
             // (10M / 15M across all quality presets) artificially capped
             // High output at ~15 Mbps even with cq=19. Scale the ceilings
             // with quality so "high" actually delivers the visual bump.
-            let (preset, cq, bv, maxrate) = match quality {
+            let (preset, cq, bv, maxrate) = match quality_preset {
                 Quality::Fast => ("p3", "28", "8M", "12M"),
                 Quality::Balanced => ("p4", "23", "12M", "18M"),
                 Quality::High => ("p5", "19", "20M", "30M"),
@@ -1400,7 +1409,7 @@ fn build_encoder_opts(
         }
         "hevc_nvenc" => {
             // HEVC ~30% more efficient than H264, so ceilings scale down.
-            let (preset, cq, bv, maxrate) = match quality {
+            let (preset, cq, bv, maxrate) = match quality_preset {
                 Quality::Fast => ("p3", "28", "6M", "10M"),
                 Quality::Balanced => ("p4", "23", "9M", "14M"),
                 Quality::High => ("p5", "19", "15M", "22M"),
@@ -1417,7 +1426,7 @@ fn build_encoder_opts(
         }
         "av1_nvenc" => {
             // AV1 another ~20% tighter than HEVC.
-            let (preset, cq, bv, maxrate) = match quality {
+            let (preset, cq, bv, maxrate) = match quality_preset {
                 Quality::Fast => ("p3", "32", "5M", "8M"),
                 Quality::Balanced => ("p4", "27", "7M", "11M"),
                 Quality::High => ("p5", "22", "12M", "18M"),
@@ -1430,7 +1439,7 @@ fn build_encoder_opts(
             opts.set("maxrate", maxrate);
         }
         "h264_qsv" => {
-            let gq = match quality {
+            let gq = match quality_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1442,7 +1451,7 @@ fn build_encoder_opts(
         "h264_videotoolbox" => {
             // global_quality maps to VTCompressionPropertyKey_Quality (0-100).
             // "q:v" doesn't work through the C API dictionary (colon is CLI syntax).
-            let q = match quality {
+            let q = match quality_preset {
                 Quality::Fast => "55",
                 Quality::Balanced => "65",
                 Quality::High => "80",
@@ -1451,7 +1460,7 @@ fn build_encoder_opts(
             opts.set("profile", "high");
         }
         "hevc_videotoolbox" => {
-            let q = match quality {
+            let q = match quality_preset {
                 Quality::Fast => "55",
                 Quality::Balanced => "65",
                 Quality::High => "80",
@@ -1460,7 +1469,7 @@ fn build_encoder_opts(
             opts.set("profile", "main");
         }
         "h264_vaapi" | "hevc_vaapi" | "av1_vaapi" => {
-            let qp = match quality {
+            let qp = match quality_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1471,7 +1480,7 @@ fn build_encoder_opts(
             }
         }
         "h264_v4l2m2m" | "hevc_v4l2m2m" => {
-            let qp = match quality {
+            let qp = match quality_preset {
                 Quality::Fast => "28",
                 Quality::Balanced => "23",
                 Quality::High => "19",
@@ -1480,7 +1489,7 @@ fn build_encoder_opts(
             // Don't set profile - v4l2m2m drivers pick appropriate defaults.
         }
         "h264_amf" | "hevc_amf" | "av1_amf" => {
-            let q = match quality {
+            let q = match quality_preset {
                 Quality::Fast => "22",
                 Quality::Balanced => "18",
                 Quality::High => "14",
@@ -1491,42 +1500,42 @@ fn build_encoder_opts(
             opts.set("rc", "cqp");
         }
         "libx265" => {
-            let (preset, crf) = match quality {
+            let (preset, crf_val) = match quality_preset {
                 Quality::Fast => ("veryfast", "28"),
                 Quality::Balanced => ("fast", "25"),
                 Quality::High => ("medium", "21"),
             };
             opts.set("preset", preset);
-            opts.set("crf", crf);
+            opts.set("crf", crf_val);
             opts.set("profile", "main");
         }
         "libsvtav1" => {
-            let (preset, crf) = match quality {
+            let (preset, crf_val) = match quality_preset {
                 Quality::Fast => ("10", "35"),
                 Quality::Balanced => ("7", "30"),
                 Quality::High => ("4", "25"),
             };
             opts.set("preset", preset);
-            opts.set("crf", crf);
+            opts.set("crf", crf_val);
         }
         "libaom-av1" => {
-            let (crf, cpu_used) = match quality {
+            let (crf_val, cpu_used) = match quality_preset {
                 Quality::Fast => ("35", "8"),
                 Quality::Balanced => ("30", "6"),
                 Quality::High => ("25", "4"),
             };
-            opts.set("crf", crf);
+            opts.set("crf", crf_val);
             opts.set("cpu-used", cpu_used);
             opts.set("row-mt", "1");
         }
         "libx264" => {
-            let (preset, crf) = match quality {
+            let (preset, crf_val) = match quality_preset {
                 Quality::Fast => ("ultrafast", "32"),
                 Quality::Balanced => ("veryfast", "28"),
                 Quality::High => ("fast", "23"),
             };
             opts.set("preset", preset);
-            opts.set("crf", crf);
+            opts.set("crf", crf_val);
             opts.set("profile", "high");
             // On Tegra (Jetson), limit threads to avoid starving other
             // pipeline stages (capture + pairing threads need CPU too).
@@ -1545,26 +1554,39 @@ fn build_encoder_opts(
         }
     }
 
-    // Apply CRF override: detect which quality key the encoder uses and replace it.
-    if let Some(crf_val) = crf_override {
-        let val = crf_val.to_string();
-        // Check known quality keys in priority order.
-        let quality_keys: &[&str] = &["crf", "cq", "global_quality", "qp", "qp_i", "q:v"];
-        let mut found = false;
-        for &key in quality_keys {
-            if opts.get(key).is_some() {
-                opts.set(key, &val);
-                // Also override qp_p when qp_i is present (AMF uses paired keys).
-                if key == "qp_i" && opts.get("qp_p").is_some() {
-                    opts.set("qp_p", &val);
+    // Apply normalized quality override (0-100, higher = better).
+    // Converts from the consumer-facing scale to encoder-specific parameters.
+    if let Some(q) = quality_override {
+        let is_videotoolbox = name.contains("videotoolbox");
+        if is_videotoolbox {
+            // VideoToolbox: global_quality is already 0-100, pass through.
+            let val = q.to_string();
+            opts.set("global_quality", &val);
+            log::info!("Encoder quality: {q} -> {name} global_quality={q}");
+        } else {
+            // CRF-style encoders: crf = 40.0 - (quality / 100.0) * 28.0
+            let crf = 40.0 - (q as f64 / 100.0) * 28.0;
+            let crf_str = format!("{crf:.2}");
+            // Detect which quality key the encoder uses and replace it.
+            let quality_keys: &[&str] = &["crf", "cq", "global_quality", "qp", "qp_i"];
+            let mut found = false;
+            for &key in quality_keys {
+                if opts.get(key).is_some() {
+                    opts.set(key, &crf_str);
+                    // Also override qp_p when qp_i is present (AMF uses paired keys).
+                    if key == "qp_i" && opts.get("qp_p").is_some() {
+                        opts.set("qp_p", &crf_str);
+                    }
+                    log::info!("Encoder quality: {q} -> {name} {key}={crf_str}");
+                    found = true;
+                    break;
                 }
-                found = true;
-                break;
             }
-        }
-        if !found {
-            // Fallback: set "crf" for unknown encoders.
-            opts.set("crf", &val);
+            if !found {
+                // Fallback: set "crf" for unknown encoders.
+                opts.set("crf", &crf_str);
+                log::info!("Encoder quality: {q} -> {name} crf={crf_str}");
+            }
         }
     }
 

--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -355,7 +355,8 @@ pub struct EncoderConfig {
     /// replaces the encoder's default quality parameter with a value
     /// derived from this scale. The conversion is per-encoder:
     /// CRF-style encoders use `crf = 40.0 - (quality / 100.0) * 28.0`,
-    /// VideoToolbox passes `global_quality = quality` directly.
+    /// VideoToolbox compresses to `global_quality = 40 + quality * 0.35`
+    /// (range 40-75) with a maxrate cap to tame exponential bitrate growth.
     pub quality: Option<u8>,
     /// Override the encoder preset string (passed through to the encoder).
     pub preset: Option<String>,
@@ -1458,23 +1459,32 @@ fn build_encoder_opts(
             opts.set("profile", "high");
         }
         "h264_videotoolbox" => {
-            // global_quality maps to VTCompressionPropertyKey_Quality (0-100).
-            // "q:v" doesn't work through the C API dictionary (colon is CLI syntax).
-            let q = match effective_preset {
-                Quality::Fast => "55",
-                Quality::Balanced => "65",
-                Quality::High => "80",
+            // VideoToolbox quality maps to kVTCompressionPropertyKey_Quality
+            // (0.0-1.0 float, FFmpeg divides global_quality by 100). The
+            // relationship between VT quality and bitrate is exponential:
+            // 0.80 -> ~104 Mbps, 1.0 -> ~297 Mbps (near-lossless). To keep
+            // bitrates comparable with NVENC / software CRF at the same
+            // --quality-value, we cap values at 75 (Apple's "high" tier)
+            // and enforce a maxrate ceiling via kVTCompressionPropertyKey_DataRateLimits.
+            let (q, maxrate) = match effective_preset {
+                Quality::Fast => ("50", "12000000"),
+                Quality::Balanced => ("60", "18000000"),
+                Quality::High => ("70", "30000000"),
             };
             opts.set("global_quality", q);
+            opts.set("maxrate", maxrate);
             opts.set("profile", "high");
         }
         "hevc_videotoolbox" => {
-            let q = match effective_preset {
-                Quality::Fast => "55",
-                Quality::Balanced => "65",
-                Quality::High => "80",
+            // Same VT quality model as H.264; HEVC is ~30% more efficient
+            // so we use slightly lower ceilings.
+            let (q, maxrate) = match effective_preset {
+                Quality::Fast => ("50", "10000000"),
+                Quality::Balanced => ("60", "14000000"),
+                Quality::High => ("70", "22000000"),
             };
             opts.set("global_quality", q);
+            opts.set("maxrate", maxrate);
             opts.set("profile", "main");
         }
         "h264_vaapi" | "hevc_vaapi" | "av1_vaapi" => {
@@ -1568,10 +1578,28 @@ fn build_encoder_opts(
     if let Some(q) = quality_override {
         let is_videotoolbox = name.contains("videotoolbox");
         if is_videotoolbox {
-            // VideoToolbox: global_quality is already 0-100, pass through.
-            let val = q.to_string();
+            // VideoToolbox quality is exponential: VT 0.80 -> ~104 Mbps,
+            // VT 1.0 -> ~297 Mbps (near-lossless). To produce bitrates
+            // comparable with NVENC at the same --quality-value, compress
+            // the consumer 0-100 range into VT 40-75 and enforce a maxrate
+            // ceiling via DataRateLimits. VT 0.75 is Apple's "high" tier;
+            // anything above produces diminishing-returns bitrate inflation.
+            let vt_q = 40.0 + (q as f64 / 100.0) * 35.0;
+            let val = format!("{:.0}", vt_q);
             opts.set("global_quality", &val);
-            log::info!("Encoder quality: {q} -> {name} global_quality={q}");
+            // Tiered maxrate matches NVENC ceilings (in bits/sec).
+            let maxrate = if q >= 75 {
+                "30000000"
+            } else if q >= 40 {
+                "18000000"
+            } else {
+                "12000000"
+            };
+            opts.set("maxrate", maxrate);
+            log::info!(
+                "Encoder quality: {q} -> {name} global_quality={val} (VT {:.2}), maxrate={maxrate}",
+                vt_q / 100.0
+            );
         } else {
             // CRF-style encoders: crf = 40.0 - (quality / 100.0) * 28.0
             let crf = 40.0 - (q as f64 / 100.0) * 28.0;

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -679,6 +679,42 @@ impl FrameSource for SmartFileSource {
         !matches!(self.mode, SourceMode::Cpu(_))
     }
 
+    fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
+        match &mut self.mode {
+            #[cfg(target_os = "linux")]
+            SourceMode::GpuZeroCopy(state) => {
+                let rx = state
+                    .frame_rx
+                    .as_ref()
+                    .expect("frame_rx taken during shutdown");
+                let left_tx = &state.shared.left_slot_free_tx;
+                let right_tx = &state.shared.right_slot_free_tx;
+                for i in 0..count {
+                    match rx.recv() {
+                        Ok(signal) => {
+                            let _ = left_tx.send(signal.left_slot);
+                            let _ = right_tx.send(signal.right_slot);
+                        }
+                        Err(_) => {
+                            self.exhausted = true;
+                            return Ok(i);
+                        }
+                    }
+                }
+                log::info!("GPU zero-copy: skipped {count} frames for start_time");
+                Ok(count)
+            }
+            _ => {
+                for i in 0..count {
+                    if self.next_frame()?.is_none() {
+                        return Ok(i);
+                    }
+                }
+                Ok(count)
+            }
+        }
+    }
+
     fn gpu_pixel_format(&self) -> GpuPixelFormat {
         self.pixel_format
     }

--- a/crates/reco-io/src/stacked_video/encoder.rs
+++ b/crates/reco-io/src/stacked_video/encoder.rs
@@ -68,9 +68,9 @@ impl Default for StackedEncoderConfig {
                 // hit it.
                 container: Container::Matroska,
                 codec: VideoCodec::H264,
-                quality: Quality::Fast,
+                quality_preset: Quality::Fast,
                 encoder_name: None,
-                crf: None,
+                quality: None,
                 preset: None,
                 audio_source: None,
                 // Short GOP so replay readers see recent

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -45,7 +45,7 @@ pub struct StitchJob {
     audio: AudioMode,
     resolution: Option<(u32, u32)>,
     encoder_name: Option<String>,
-    crf: Option<u8>,
+    quality_value: Option<u8>,
     preset: Option<String>,
 
     // Processing window
@@ -227,7 +227,7 @@ impl StitchJob {
             audio: AudioMode::default(),
             resolution: None,
             encoder_name: None,
-            crf: None,
+            quality_value: None,
             preset: None,
             start_time: None,
             end_time: None,
@@ -299,9 +299,11 @@ impl StitchJob {
         self
     }
 
-    /// Override the CRF/quality value (passed through to the encoder).
-    pub fn crf(mut self, crf: u8) -> Self {
-        self.crf = Some(crf);
+    /// Override encoder quality on a normalized 0-100 scale (higher = better).
+    /// Converted to encoder-specific parameters (CRF, CQ, global_quality)
+    /// internally. See [`crate::ffmpeg::encoder::EncoderConfig::quality`].
+    pub fn quality_value(mut self, quality: u8) -> Self {
+        self.quality_value = Some(quality);
         self
     }
 
@@ -627,8 +629,8 @@ impl StitchJob {
         let enc_config = crate::ffmpeg::encoder::EncoderConfig {
             encoder_name: self.encoder_name.clone(),
             codec: self.codec.into(),
-            quality,
-            crf: self.crf,
+            quality_preset: quality,
+            quality: self.quality_value,
             preset: self.preset.clone(),
             audio_source,
             container: self.format.into(),

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::AtomicBool;
 use std::time::Duration;
 
 use crate::output::{AudioMode, Bitrate, Codec, Format, Quality};
@@ -686,14 +686,9 @@ impl StitchJob {
         // Skip frames to reach start position.
         if skip_frames > 0 {
             log::info!("skipping {skip_frames} frames (start_time={start_secs:.2}s)");
-            for skipped in 0..skip_frames {
-                if interrupted.load(Ordering::Relaxed) {
-                    return Err(StitchError::Other("cancelled during start skip".into()));
-                }
-                if source.next_frame()?.is_none() {
-                    log::warn!("source ended during skip at frame {skipped}/{skip_frames}");
-                    break;
-                }
+            let skipped = source.skip_frames(skip_frames)?;
+            if skipped < skip_frames {
+                log::warn!("source ended during skip at frame {skipped}/{skip_frames}");
             }
         }
 

--- a/crates/reco-io/tests/stacked_video_roundtrip.rs
+++ b/crates/reco-io/tests/stacked_video_roundtrip.rs
@@ -71,7 +71,7 @@ fn encoder_config(container: Container) -> StackedEncoderConfig {
     StackedEncoderConfig {
         inner: reco_io::ffmpeg::encoder::EncoderConfig {
             container,
-            quality: Quality::Fast,
+            quality_preset: Quality::Fast,
             gop_size: Some(10),
             ..base.inner
         },

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -44,19 +44,20 @@ DEFAULT_COLOR = (200, 200, 200)
 FONT = cv2.FONT_HERSHEY_SIMPLEX
 
 
-def load_calibration_roi(cal_path):
-    """Load ROI polygons from a calibration JSON. Returns (left, right) as numpy arrays or None."""
+def load_calibration(cal_path):
+    """Load ROI polygons and sync_offset from a calibration JSON."""
     if not cal_path:
-        return None, None
+        return None, None, 0
     try:
         with open(cal_path) as f:
             cal = json.load(f)
         roi = cal.get("field_roi", {})
         left = np.array(roi["left"], dtype=np.float32) if roi.get("left") else None
         right = np.array(roi["right"], dtype=np.float32) if roi.get("right") else None
-        return left, right
+        sync_offset = cal.get("sync_offset", 0)
+        return left, right, sync_offset
     except (json.JSONDecodeError, FileNotFoundError, KeyError):
-        return None, None
+        return None, None, 0
 
 
 def draw_roi(img, roi_points, h, w):
@@ -294,9 +295,11 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames,
                 cal_path, hstack):
     """Export an annotated video (vstack by default, hstack with --hstack)."""
     frames, total = load_events(events_path)
-    roi_left, roi_right = load_calibration_roi(cal_path)
+    roi_left, roi_right, sync_offset = load_calibration(cal_path)
     if roi_left is not None:
         print(f"ROI: left={len(roi_left)} pts, right={len(roi_right) if roi_right is not None else 0} pts")
+    if sync_offset != 0:
+        print(f"Sync offset: {sync_offset} frames (positive = skip right)")
 
     cap_l = cv2.VideoCapture(str(left_path))
     if not cap_l.isOpened():
@@ -309,6 +312,12 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames,
         if not cap_r.isOpened():
             print(f"Warning: cannot open {right_path}, single camera mode", file=sys.stderr)
             cap_r = None
+
+    # Apply sync offset: skip frames on the appropriate camera
+    if sync_offset > 0 and cap_r:
+        cap_r.set(cv2.CAP_PROP_POS_FRAMES, sync_offset)
+    elif sync_offset < 0:
+        cap_l.set(cv2.CAP_PROP_POS_FRAMES, abs(sync_offset))
 
     fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
     src_w = int(cap_l.get(cv2.CAP_PROP_FRAME_WIDTH))
@@ -369,7 +378,7 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames,
 def browse_mode(events_path, left_path, right_path, cal_path, hstack):
     """Interactive frame-by-frame browser."""
     frames, total = load_events(events_path)
-    roi_left, roi_right = load_calibration_roi(cal_path)
+    roi_left, roi_right, sync_offset = load_calibration(cal_path)
 
     cap_l = cv2.VideoCapture(str(left_path))
     if not cap_l.isOpened():
@@ -405,16 +414,20 @@ def browse_mode(events_path, left_path, right_path, cal_path, hstack):
     needs_redraw = True
     last_det = []
 
+    # Compute per-camera frame offsets
+    left_offset = abs(sync_offset) if sync_offset < 0 else 0
+    right_offset = sync_offset if sync_offset > 0 else 0
+
     def seek_and_draw(idx, last_detections):
         idx = max(0, min(idx, total))
-        cap_l.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        cap_l.set(cv2.CAP_PROP_POS_FRAMES, idx + left_offset)
         ret_l, raw_l = cap_l.read()
         if not ret_l:
             return None, idx, last_detections
 
         raw_r = None
         if cap_r:
-            cap_r.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            cap_r.set(cv2.CAP_PROP_POS_FRAMES, idx + right_offset)
             ret_r, raw_r = cap_r.read()
             if not ret_r:
                 raw_r = None

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -2,24 +2,23 @@
 """Visualize AI detections from a reco pipeline events JSONL file.
 
 Two modes:
-  --export: Render an annotated video with detection boxes, tracking info,
-            frame counter, and timestamp overlay. Output is 1080p h264.
-  --browse: Interactive frame-by-frame browser. Arrow keys to step,
-            click to seek, 'q' to quit.
+  export: Render an annotated side-by-side video (left + right cameras)
+          with detection boxes, tracking info, frame counter, and timestamp.
+  browse: Interactive frame-by-frame browser with keyboard navigation.
 
 Usage:
   # Generate the events file with reco CLI:
   reco stitch left.mp4 right.mp4 -c cal.json --model yolo26n.onnx \
       --events detections.jsonl -o output.mp4
 
-  # Export annotated video:
-  python3 visualize_detections.py --export detections.jsonl left.mp4
+  # Export annotated side-by-side video:
+  python3 visualize_detections.py export detections.jsonl left.mp4 right.mp4
+
+  # Single camera only:
+  python3 visualize_detections.py export detections.jsonl left.mp4 --camera left
 
   # Browse frame by frame:
-  python3 visualize_detections.py --browse detections.jsonl left.mp4
-
-  # Use right camera instead:
-  python3 visualize_detections.py --export detections.jsonl right.mp4 --camera right
+  python3 visualize_detections.py browse detections.jsonl left.mp4 right.mp4
 """
 
 import argparse
@@ -43,6 +42,31 @@ CLASS_COLORS = {
 DEFAULT_COLOR = (200, 200, 200)
 
 FONT = cv2.FONT_HERSHEY_SIMPLEX
+
+
+def load_calibration_roi(cal_path):
+    """Load ROI polygons from a calibration JSON. Returns (left, right) as numpy arrays or None."""
+    if not cal_path:
+        return None, None
+    try:
+        with open(cal_path) as f:
+            cal = json.load(f)
+        roi = cal.get("field_roi", {})
+        left = np.array(roi["left"], dtype=np.float32) if roi.get("left") else None
+        right = np.array(roi["right"], dtype=np.float32) if roi.get("right") else None
+        return left, right
+    except (json.JSONDecodeError, FileNotFoundError, KeyError):
+        return None, None
+
+
+def draw_roi(img, roi_points, h, w):
+    """Draw ROI polygon boundary on the image."""
+    if roi_points is None:
+        return
+    pts = (roi_points * np.array([w, h])).astype(np.int32)
+    cv2.polylines(img, [pts], isClosed=True, color=(255, 200, 0), thickness=2)
+    cv2.putText(img, "ROI", (pts[0][0], pts[0][1] - 8),
+                FONT, 0.4, (255, 200, 0), 1, cv2.LINE_AA)
 
 
 def load_events(path):
@@ -86,7 +110,7 @@ def load_events(path):
 
 
 def draw_detections(img, detections, camera_filter, h, w):
-    """Draw bounding boxes from DetectionsRaw."""
+    """Draw bounding boxes from DetectionsRaw. Returns detection count."""
     count = 0
     for det in detections:
         cam = det.get("camera", "").lower()
@@ -139,8 +163,16 @@ def draw_filter_removed(img, filter_events, camera_filter, h, w):
                         FONT, 0.35, (100, 100, 100), 1, cv2.LINE_AA)
 
 
-def draw_overlay(img, frame_idx, frame_data, total_frames, fps):
-    """Draw frame counter, timestamp, and tracking info."""
+def draw_camera_label(img, label, h, w):
+    """Draw camera label (L/R) in the top corner."""
+    cv2.putText(img, label, (w - 40, 30), FONT, 0.8,
+                (255, 255, 255), 3, cv2.LINE_AA)
+    cv2.putText(img, label, (w - 40, 30), FONT, 0.8,
+                (0, 200, 255), 2, cv2.LINE_AA)
+
+
+def draw_shared_overlay(img, frame_idx, frame_data, total_frames, fps):
+    """Draw frame counter, timestamp, tracking, and pan info on combined image."""
     h, w = img.shape[:2]
     ts_ms = frame_data["timestamp_ms"]
     ts_sec = ts_ms / 1000.0
@@ -152,18 +184,23 @@ def draw_overlay(img, frame_idx, frame_data, total_frames, fps):
     cv2.putText(img, text, (10, 28), FONT, 0.7, (255, 255, 255), 2, cv2.LINE_AA)
     cv2.putText(img, text, (10, 28), FONT, 0.7, (0, 0, 0), 1, cv2.LINE_AA)
 
-    # Tracking state (top right)
+    # Detection count vs track count (top center)
+    n_dets = len(frame_data["detections_raw"])
     ws = frame_data.get("world_state")
-    if ws:
-        n_players = len(ws.get("players", []))
-        ball = ws.get("ball")
-        ball_text = f"ball: ({ball['yaw']:.2f}, {ball['pitch']:.2f})" if ball else "ball: -"
-        info = f"players: {n_players}  {ball_text}"
-        tw = cv2.getTextSize(info, FONT, 0.5, 1)[0][0]
-        cv2.putText(img, info, (w - tw - 10, 28),
-                    FONT, 0.5, (255, 255, 255), 2, cv2.LINE_AA)
-        cv2.putText(img, info, (w - tw - 10, 28),
-                    FONT, 0.5, (0, 200, 200), 1, cv2.LINE_AA)
+    n_tracks = len(ws.get("players", [])) if ws else 0
+    ball = ws.get("ball") if ws else None
+    ball_state = ""
+    if ball:
+        state = ball.get("state", "")
+        ball_state = f"ball: {state} ({ball['yaw']:.2f}, {ball['pitch']:.2f})"
+    else:
+        ball_state = "ball: -"
+
+    info = f"det: {n_dets}  tracks: {n_tracks}  {ball_state}"
+    tw = cv2.getTextSize(info, FONT, 0.5, 1)[0][0]
+    cx = (w - tw) // 2
+    cv2.putText(img, info, (cx, 28), FONT, 0.5, (255, 255, 255), 2, cv2.LINE_AA)
+    cv2.putText(img, info, (cx, 28), FONT, 0.5, (0, 200, 200), 1, cv2.LINE_AA)
 
     # Pan decision (bottom left)
     pose = frame_data.get("pose_presented")
@@ -192,92 +229,179 @@ def draw_overlay(img, frame_idx, frame_data, total_frames, fps):
                     FONT, 0.45, (180, 180, 180), 1, cv2.LINE_AA)
 
 
-def export_mode(events_path, video_path, output_path, camera, max_frames):
-    """Export an annotated video."""
+def draw_stale_detections(img, detections, camera_filter, h, w):
+    """Draw last-known detections dimmed (for non-detection interval frames)."""
+    for det in detections:
+        cam = det.get("camera", "").lower()
+        if cam != camera_filter:
+            continue
+        cx, cy = det["camera_center"]
+        sw, sh = det["camera_size"]
+        x1 = int((cx - sw / 2) * w)
+        y1 = int((cy - sh / 2) * h)
+        x2 = int((cx + sw / 2) * w)
+        y2 = int((cy + sh / 2) * h)
+        cv2.rectangle(img, (x1, y1), (x2, y2), (80, 80, 80), 1)
+
+
+def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
+                   total, fps, panel_h, panel_w, roi_left, roi_right):
+    """Annotate and combine left+right into a single frame."""
+    left = cv2.resize(left_img, (panel_w, panel_h))
+    fresh = len(frame_data["detections_raw"]) > 0
+    if fresh:
+        draw_detections(left, frame_data["detections_raw"], "left", panel_h, panel_w)
+    elif last_detections:
+        draw_stale_detections(left, last_detections, "left", panel_h, panel_w)
+    draw_filter_removed(left, frame_data["detection_filter"], "left", panel_h, panel_w)
+    draw_roi(left, roi_left, panel_h, panel_w)
+    draw_camera_label(left, "L", panel_h, panel_w)
+
+    if right_img is not None:
+        right = cv2.resize(right_img, (panel_w, panel_h))
+        if fresh:
+            draw_detections(right, frame_data["detections_raw"], "right", panel_h, panel_w)
+        elif last_detections:
+            draw_stale_detections(right, last_detections, "right", panel_h, panel_w)
+        draw_filter_removed(right, frame_data["detection_filter"], "right", panel_h, panel_w)
+        draw_roi(right, roi_right, panel_h, panel_w)
+        draw_camera_label(right, "R", panel_h, panel_w)
+        combined = np.hstack([left, right])
+    else:
+        combined = left
+
+    draw_shared_overlay(combined, frame_idx, frame_data, total, fps)
+
+    # Detection freshness indicator
+    h, w = combined.shape[:2]
+    status = "DETECT" if fresh else "coast"
+    color = (0, 255, 0) if fresh else (100, 100, 100)
+    cv2.putText(combined, status, (10, 50), FONT, 0.45, color, 1, cv2.LINE_AA)
+
+    return combined
+
+
+def export_mode(events_path, left_path, right_path, output_path, max_frames, cal_path):
+    """Export an annotated side-by-side video."""
     frames, total = load_events(events_path)
-    cap = cv2.VideoCapture(str(video_path))
-    if not cap.isOpened():
-        print(f"Error: cannot open {video_path}", file=sys.stderr)
+    roi_left, roi_right = load_calibration_roi(cal_path)
+    if roi_left is not None:
+        print(f"ROI: left={len(roi_left)} pts, right={len(roi_right) if roi_right is not None else 0} pts")
+
+    cap_l = cv2.VideoCapture(str(left_path))
+    if not cap_l.isOpened():
+        print(f"Error: cannot open {left_path}", file=sys.stderr)
         return 1
 
-    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    cap_r = None
+    if right_path:
+        cap_r = cv2.VideoCapture(str(right_path))
+        if not cap_r.isOpened():
+            print(f"Warning: cannot open {right_path}, single camera mode", file=sys.stderr)
+            cap_r = None
 
-    out_w, out_h = 1920, 1080
+    fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
+    panel_w, panel_h = 960, 540
+    out_w = panel_w * 2 if cap_r else panel_w
+    out_h = panel_h
+
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(str(output_path), fourcc, fps, (out_w, out_h))
 
-    print(f"Source: {src_w}x{src_h} @ {fps:.1f} fps")
     print(f"Events: {total + 1} frames")
     print(f"Output: {output_path} ({out_w}x{out_h})")
 
     frame_idx = 0
+    last_detections = []
     limit = max_frames if max_frames else total + 1
     while frame_idx <= min(total, limit - 1):
-        ret, raw = cap.read()
-        if not ret:
+        ret_l, raw_l = cap_l.read()
+        if not ret_l:
             break
 
-        img = cv2.resize(raw, (out_w, out_h))
+        raw_r = None
+        if cap_r:
+            ret_r, raw_r = cap_r.read()
+            if not ret_r:
+                raw_r = None
+
         fd = frames[frame_idx]
+        if fd["detections_raw"]:
+            last_detections = fd["detections_raw"]
 
-        n = draw_detections(img, fd["detections_raw"], camera, out_h, out_w)
-        draw_filter_removed(img, fd["detection_filter"], camera, out_h, out_w)
-        draw_overlay(img, frame_idx, fd, total, fps)
-
-        out.write(img)
+        combined = annotate_frame(raw_l, raw_r, frame_idx, fd, last_detections,
+                                  total, fps, panel_h, panel_w, roi_left, roi_right)
+        out.write(combined)
         frame_idx += 1
         if frame_idx % 100 == 0:
             print(f"  {frame_idx}/{total + 1} frames...", flush=True)
 
     out.release()
-    cap.release()
+    cap_l.release()
+    if cap_r:
+        cap_r.release()
     print(f"Done: {frame_idx} frames written to {output_path}")
     return 0
 
 
-def browse_mode(events_path, video_path, camera):
+def browse_mode(events_path, left_path, right_path, cal_path):
     """Interactive frame-by-frame browser."""
     frames, total = load_events(events_path)
-    cap = cv2.VideoCapture(str(video_path))
-    if not cap.isOpened():
-        print(f"Error: cannot open {video_path}", file=sys.stderr)
+    roi_left, roi_right = load_calibration_roi(cal_path)
+
+    cap_l = cv2.VideoCapture(str(left_path))
+    if not cap_l.isOpened():
+        print(f"Error: cannot open {left_path}", file=sys.stderr)
         return 1
 
-    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    cap_r = None
+    if right_path:
+        cap_r = cv2.VideoCapture(str(right_path))
+        if not cap_r.isOpened():
+            cap_r = None
 
-    disp_w, disp_h = 1920, 1080
-    current = 0
-    needs_redraw = True
+    fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
+    panel_w, panel_h = 960, 540
 
-    print(f"Source: {src_w}x{src_h} @ {fps:.1f} fps, {total + 1} event frames")
+    print(f"{total + 1} event frames")
     print("Controls: Right/D = next, Left/A = prev, PgDn = +30, PgUp = -30")
     print("          Home = first, End = last, Q = quit")
 
-    cv2.namedWindow("Reco Detection Browser", cv2.WINDOW_NORMAL)
-    cv2.resizeWindow("Reco Detection Browser", disp_w, disp_h)
+    win = "Reco Detection Browser"
+    cv2.namedWindow(win, cv2.WINDOW_NORMAL)
+    out_w = panel_w * 2 if cap_r else panel_w
+    cv2.resizeWindow(win, out_w, panel_h)
 
-    def seek_and_draw(idx):
+    current = 0
+    needs_redraw = True
+    last_det = []
+
+    def seek_and_draw(idx, last_detections):
         idx = max(0, min(idx, total))
-        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
-        ret, raw = cap.read()
-        if not ret:
-            return None, idx
-        img = cv2.resize(raw, (disp_w, disp_h))
+        cap_l.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ret_l, raw_l = cap_l.read()
+        if not ret_l:
+            return None, idx, last_detections
+
+        raw_r = None
+        if cap_r:
+            cap_r.set(cv2.CAP_PROP_POS_FRAMES, idx)
+            ret_r, raw_r = cap_r.read()
+            if not ret_r:
+                raw_r = None
+
         fd = frames[idx]
-        draw_detections(img, fd["detections_raw"], camera, disp_h, disp_w)
-        draw_filter_removed(img, fd["detection_filter"], camera, disp_h, disp_w)
-        draw_overlay(img, idx, fd, total, fps)
-        return img, idx
+        if fd["detections_raw"]:
+            last_detections = fd["detections_raw"]
+        combined = annotate_frame(raw_l, raw_r, idx, fd, last_detections,
+                                  total, fps, panel_h, panel_w, roi_left, roi_right)
+        return combined, idx, last_detections
 
     while True:
         if needs_redraw:
-            img, current = seek_and_draw(current)
+            img, current, last_det = seek_and_draw(current, last_det)
             if img is not None:
-                cv2.imshow("Reco Detection Browser", img)
+                cv2.imshow(win, img)
             needs_redraw = False
 
         key = cv2.waitKey(0) & 0xFF
@@ -303,7 +427,9 @@ def browse_mode(events_path, video_path, camera):
             needs_redraw = True
 
     cv2.destroyAllWindows()
-    cap.release()
+    cap_l.release()
+    if cap_r:
+        cap_r.release()
     return 0
 
 
@@ -313,29 +439,34 @@ def main():
     )
     sub = parser.add_subparsers(dest="mode", required=True)
 
-    exp = sub.add_parser("export", help="Export annotated video")
+    exp = sub.add_parser("export", help="Export annotated side-by-side video")
     exp.add_argument("events", type=Path, help="Pipeline events JSONL file")
-    exp.add_argument("video", type=Path, help="Source video (left or right)")
+    exp.add_argument("left_video", type=Path, help="Left camera video")
+    exp.add_argument("right_video", type=Path, nargs="?", default=None,
+                     help="Right camera video (omit for single camera)")
     exp.add_argument("-o", "--output", type=Path, default=Path("annotated.mp4"),
-                     help="Output video path (default: annotated.mp4)")
-    exp.add_argument("--camera", choices=["left", "right"], default="left",
-                     help="Which camera's detections to show (default: left)")
+                     help="Output path (default: annotated.mp4)")
     exp.add_argument("--max-frames", type=int, default=0,
-                     help="Limit frames to process (0 = all)")
+                     help="Limit frames (0 = all)")
+    exp.add_argument("-c", "--calibration", type=Path, default=None,
+                     help="Calibration JSON (for ROI polygon overlay)")
 
     brw = sub.add_parser("browse", help="Interactive frame browser")
     brw.add_argument("events", type=Path, help="Pipeline events JSONL file")
-    brw.add_argument("video", type=Path, help="Source video (left or right)")
-    brw.add_argument("--camera", choices=["left", "right"], default="left",
-                     help="Which camera's detections to show (default: left)")
+    brw.add_argument("left_video", type=Path, help="Left camera video")
+    brw.add_argument("right_video", type=Path, nargs="?", default=None,
+                     help="Right camera video (omit for single camera)")
+    brw.add_argument("-c", "--calibration", type=Path, default=None,
+                     help="Calibration JSON (for ROI polygon overlay)")
 
     args = parser.parse_args()
 
     if args.mode == "export":
-        return export_mode(args.events, args.video, args.output,
-                           args.camera, args.max_frames)
+        return export_mode(args.events, args.left_video, args.right_video,
+                           args.output, args.max_frames, args.calibration)
     elif args.mode == "browse":
-        return browse_mode(args.events, args.video, args.camera)
+        return browse_mode(args.events, args.left_video, args.right_video,
+                           args.calibration)
 
 
 if __name__ == "__main__":

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -244,10 +244,18 @@ def draw_stale_detections(img, detections, camera_filter, h, w):
         cv2.rectangle(img, (x1, y1), (x2, y2), (80, 80, 80), 1)
 
 
+def resize_keep_aspect(img, target_w):
+    """Resize to target width, preserving aspect ratio."""
+    h, w = img.shape[:2]
+    scale = target_w / w
+    return cv2.resize(img, (target_w, int(h * scale)))
+
+
 def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
-                   total, fps, panel_h, panel_w, roi_left, roi_right):
+                   total, fps, panel_w, roi_left, roi_right, hstack):
     """Annotate and combine left+right into a single frame."""
-    left = cv2.resize(left_img, (panel_w, panel_h))
+    left = resize_keep_aspect(left_img, panel_w)
+    panel_h = left.shape[0]
     fresh = len(frame_data["detections_raw"]) > 0
     if fresh:
         draw_detections(left, frame_data["detections_raw"], "left", panel_h, panel_w)
@@ -258,15 +266,16 @@ def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
     draw_camera_label(left, "L", panel_h, panel_w)
 
     if right_img is not None:
-        right = cv2.resize(right_img, (panel_w, panel_h))
+        right = resize_keep_aspect(right_img, panel_w)
+        rh = right.shape[0]
         if fresh:
-            draw_detections(right, frame_data["detections_raw"], "right", panel_h, panel_w)
+            draw_detections(right, frame_data["detections_raw"], "right", rh, panel_w)
         elif last_detections:
-            draw_stale_detections(right, last_detections, "right", panel_h, panel_w)
-        draw_filter_removed(right, frame_data["detection_filter"], "right", panel_h, panel_w)
-        draw_roi(right, roi_right, panel_h, panel_w)
-        draw_camera_label(right, "R", panel_h, panel_w)
-        combined = np.vstack([left, right])
+            draw_stale_detections(right, last_detections, "right", rh, panel_w)
+        draw_filter_removed(right, frame_data["detection_filter"], "right", rh, panel_w)
+        draw_roi(right, roi_right, rh, panel_w)
+        draw_camera_label(right, "R", rh, panel_w)
+        combined = np.hstack([left, right]) if hstack else np.vstack([left, right])
     else:
         combined = left
 
@@ -281,8 +290,9 @@ def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
     return combined
 
 
-def export_mode(events_path, left_path, right_path, output_path, max_frames, cal_path):
-    """Export an annotated side-by-side video."""
+def export_mode(events_path, left_path, right_path, output_path, max_frames,
+                cal_path, hstack):
+    """Export an annotated video (vstack by default, hstack with --hstack)."""
     frames, total = load_events(events_path)
     roi_left, roi_right = load_calibration_roi(cal_path)
     if roi_left is not None:
@@ -301,9 +311,21 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames, cal
             cap_r = None
 
     fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
-    panel_w, panel_h = 1920, 540
-    out_w = panel_w
-    out_h = panel_h * 2 if cap_r else panel_h
+    src_w = int(cap_l.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap_l.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    if hstack:
+        panel_w = 960
+    else:
+        panel_w = min(1920, src_w)
+    panel_h = int(src_h * panel_w / src_w)
+    if not hstack and cap_r and panel_h * 2 > 1080:
+        panel_h = 540
+        panel_w = int(src_w * panel_h / src_h)
+    if cap_r:
+        out_w = panel_w * 2 if hstack else panel_w
+        out_h = panel_h if hstack else panel_h * 2
+    else:
+        out_w, out_h = panel_w, panel_h
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(str(output_path), fourcc, fps, (out_w, out_h))
@@ -330,7 +352,7 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames, cal
             last_detections = fd["detections_raw"]
 
         combined = annotate_frame(raw_l, raw_r, frame_idx, fd, last_detections,
-                                  total, fps, panel_h, panel_w, roi_left, roi_right)
+                                  total, fps, panel_w, roi_left, roi_right, hstack)
         out.write(combined)
         frame_idx += 1
         if frame_idx % 100 == 0:
@@ -344,7 +366,7 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames, cal
     return 0
 
 
-def browse_mode(events_path, left_path, right_path, cal_path):
+def browse_mode(events_path, left_path, right_path, cal_path, hstack):
     """Interactive frame-by-frame browser."""
     frames, total = load_events(events_path)
     roi_left, roi_right = load_calibration_roi(cal_path)
@@ -361,7 +383,15 @@ def browse_mode(events_path, left_path, right_path, cal_path):
             cap_r = None
 
     fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
-    panel_w, panel_h = 960, 540
+    src_w = int(cap_l.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap_l.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    panel_w = 960 if hstack else 1920
+    panel_h = int(src_h * panel_w / src_w)
+    if cap_r:
+        out_w = panel_w * 2 if hstack else panel_w
+        out_h = panel_h if hstack else panel_h * 2
+    else:
+        out_w, out_h = panel_w, panel_h
 
     print(f"{total + 1} event frames")
     print("Controls: Right/D = next, Left/A = prev, PgDn = +30, PgUp = -30")
@@ -369,8 +399,7 @@ def browse_mode(events_path, left_path, right_path, cal_path):
 
     win = "Reco Detection Browser"
     cv2.namedWindow(win, cv2.WINDOW_NORMAL)
-    out_h = panel_h * 2 if cap_r else panel_h
-    cv2.resizeWindow(win, panel_w, out_h)
+    cv2.resizeWindow(win, out_w, out_h)
 
     current = 0
     needs_redraw = True
@@ -394,7 +423,7 @@ def browse_mode(events_path, left_path, right_path, cal_path):
         if fd["detections_raw"]:
             last_detections = fd["detections_raw"]
         combined = annotate_frame(raw_l, raw_r, idx, fd, last_detections,
-                                  total, fps, panel_h, panel_w, roi_left, roi_right)
+                                  total, fps, panel_w, roi_left, roi_right, hstack)
         return combined, idx, last_detections
 
     while True:
@@ -450,6 +479,8 @@ def main():
                      help="Limit frames (0 = all)")
     exp.add_argument("-c", "--calibration", type=Path, default=None,
                      help="Calibration JSON (for ROI polygon overlay)")
+    exp.add_argument("--hstack", action="store_true",
+                     help="Side-by-side layout instead of vertical stack")
 
     brw = sub.add_parser("browse", help="Interactive frame browser")
     brw.add_argument("events", type=Path, help="Pipeline events JSONL file")
@@ -458,15 +489,18 @@ def main():
                      help="Right camera video (omit for single camera)")
     brw.add_argument("-c", "--calibration", type=Path, default=None,
                      help="Calibration JSON (for ROI polygon overlay)")
+    brw.add_argument("--hstack", action="store_true",
+                     help="Side-by-side layout instead of vertical stack")
 
     args = parser.parse_args()
 
     if args.mode == "export":
         return export_mode(args.events, args.left_video, args.right_video,
-                           args.output, args.max_frames, args.calibration)
+                           args.output, args.max_frames, args.calibration,
+                           args.hstack)
     elif args.mode == "browse":
         return browse_mode(args.events, args.left_video, args.right_video,
-                           args.calibration)
+                           args.calibration, args.hstack)
 
 
 if __name__ == "__main__":

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Visualize AI detections from a reco pipeline events JSONL file.
+
+Two modes:
+  --export: Render an annotated video with detection boxes, tracking info,
+            frame counter, and timestamp overlay. Output is 1080p h264.
+  --browse: Interactive frame-by-frame browser. Arrow keys to step,
+            click to seek, 'q' to quit.
+
+Usage:
+  # Generate the events file with reco CLI:
+  reco stitch left.mp4 right.mp4 -c cal.json --model yolo26n.onnx \
+      --events detections.jsonl -o output.mp4
+
+  # Export annotated video:
+  python3 visualize_detections.py --export detections.jsonl left.mp4
+
+  # Browse frame by frame:
+  python3 visualize_detections.py --browse detections.jsonl left.mp4
+
+  # Use right camera instead:
+  python3 visualize_detections.py --export detections.jsonl right.mp4 --camera right
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+COCO_NAMES = {
+    0: "person", 32: "sports ball", 37: "skateboard",
+    38: "surfboard", 39: "tennis racket",
+}
+
+CLASS_COLORS = {
+    0: (0, 200, 0),      # person - green
+    32: (0, 100, 255),    # ball - orange
+}
+DEFAULT_COLOR = (200, 200, 200)
+
+FONT = cv2.FONT_HERSHEY_SIMPLEX
+
+
+def load_events(path):
+    """Load JSONL events grouped by frame_index."""
+    frames = defaultdict(lambda: {
+        "detections_raw": [],
+        "detection_filter": [],
+        "world_state": None,
+        "pan_decision": None,
+        "pose_presented": None,
+        "frame_complete": None,
+        "timestamp_ms": 0.0,
+    })
+    max_frame = 0
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            ev = json.loads(line)
+            kind = ev.get("kind", "")
+            idx = ev.get("frame_index", -1)
+            if idx < 0:
+                continue
+            max_frame = max(max_frame, idx)
+            if kind == "frame_start":
+                frames[idx]["timestamp_ms"] = ev.get("timestamp_ms", 0.0)
+            elif kind == "detections_raw":
+                frames[idx]["detections_raw"] = ev.get("detections", [])
+            elif kind == "detection_filter":
+                frames[idx]["detection_filter"].append(ev)
+            elif kind == "world_state":
+                frames[idx]["world_state"] = ev
+            elif kind == "pan_decision":
+                frames[idx]["pan_decision"] = ev
+            elif kind == "pose_presented":
+                frames[idx]["pose_presented"] = ev
+            elif kind == "frame_complete":
+                frames[idx]["frame_complete"] = ev
+    return frames, max_frame
+
+
+def draw_detections(img, detections, camera_filter, h, w):
+    """Draw bounding boxes from DetectionsRaw."""
+    count = 0
+    for det in detections:
+        cam = det.get("camera", "").lower()
+        if cam != camera_filter:
+            continue
+        cx, cy = det["camera_center"]
+        sw, sh = det["camera_size"]
+        conf = det.get("confidence", 0)
+        class_id = det.get("class_id", -1)
+
+        x1 = int((cx - sw / 2) * w)
+        y1 = int((cy - sh / 2) * h)
+        x2 = int((cx + sw / 2) * w)
+        y2 = int((cy + sh / 2) * h)
+
+        color = CLASS_COLORS.get(class_id, DEFAULT_COLOR)
+        cv2.rectangle(img, (x1, y1), (x2, y2), color, 2)
+
+        label = COCO_NAMES.get(class_id, f"c{class_id}")
+        cv2.putText(img, f"{label} {conf:.2f}", (x1, y1 - 6),
+                    FONT, 0.45, color, 1, cv2.LINE_AA)
+        count += 1
+    return count
+
+
+def draw_filter_removed(img, filter_events, camera_filter, h, w):
+    """Draw detections removed by ROI/filter stages as grey dashed boxes."""
+    for fev in filter_events:
+        before_ids = {(d["camera_center"][0], d["camera_center"][1])
+                      for d in fev.get("before", [])}
+        after_ids = {(d["camera_center"][0], d["camera_center"][1])
+                     for d in fev.get("after", [])}
+        removed = before_ids - after_ids
+
+        for det in fev.get("before", []):
+            cam = det.get("camera", "").lower()
+            if cam != camera_filter:
+                continue
+            key = (det["camera_center"][0], det["camera_center"][1])
+            if key not in removed:
+                continue
+            cx, cy = det["camera_center"]
+            sw, sh = det["camera_size"]
+            x1 = int((cx - sw / 2) * w)
+            y1 = int((cy - sh / 2) * h)
+            x2 = int((cx + sw / 2) * w)
+            y2 = int((cy + sh / 2) * h)
+            cv2.rectangle(img, (x1, y1), (x2, y2), (100, 100, 100), 1)
+            cv2.putText(img, "filtered", (x1, y1 - 6),
+                        FONT, 0.35, (100, 100, 100), 1, cv2.LINE_AA)
+
+
+def draw_overlay(img, frame_idx, frame_data, total_frames, fps):
+    """Draw frame counter, timestamp, and tracking info."""
+    h, w = img.shape[:2]
+    ts_ms = frame_data["timestamp_ms"]
+    ts_sec = ts_ms / 1000.0
+    minutes = int(ts_sec // 60)
+    seconds = ts_sec % 60
+
+    # Frame counter + timestamp (top left)
+    text = f"Frame {frame_idx}/{total_frames}  {minutes:02d}:{seconds:05.2f}"
+    cv2.putText(img, text, (10, 28), FONT, 0.7, (255, 255, 255), 2, cv2.LINE_AA)
+    cv2.putText(img, text, (10, 28), FONT, 0.7, (0, 0, 0), 1, cv2.LINE_AA)
+
+    # Tracking state (top right)
+    ws = frame_data.get("world_state")
+    if ws:
+        n_players = len(ws.get("players", []))
+        ball = ws.get("ball")
+        ball_text = f"ball: ({ball['yaw']:.2f}, {ball['pitch']:.2f})" if ball else "ball: -"
+        info = f"players: {n_players}  {ball_text}"
+        tw = cv2.getTextSize(info, FONT, 0.5, 1)[0][0]
+        cv2.putText(img, info, (w - tw - 10, 28),
+                    FONT, 0.5, (255, 255, 255), 2, cv2.LINE_AA)
+        cv2.putText(img, info, (w - tw - 10, 28),
+                    FONT, 0.5, (0, 200, 200), 1, cv2.LINE_AA)
+
+    # Pan decision (bottom left)
+    pose = frame_data.get("pose_presented")
+    if pose and "pose" in pose:
+        p = pose["pose"]
+        yaw_deg = p.get("yaw", 0) * 57.2958
+        pitch_deg = p.get("pitch", 0) * 57.2958
+        fov = p.get("fov_deg", 0)
+        pan_text = f"pan: yaw={yaw_deg:.1f} pitch={pitch_deg:.1f} fov={fov:.0f}"
+        cv2.putText(img, pan_text, (10, h - 12),
+                    FONT, 0.5, (255, 255, 255), 2, cv2.LINE_AA)
+        cv2.putText(img, pan_text, (10, h - 12),
+                    FONT, 0.5, (200, 200, 0), 1, cv2.LINE_AA)
+
+    # Timing (bottom right)
+    fc = frame_data.get("frame_complete")
+    if fc and "timing" in fc:
+        t = fc["timing"]
+        det_ms = (t.get("detect_us") or 0) / 1000
+        total_ms = (t.get("total_us") or 0) / 1000
+        timing_text = f"detect: {det_ms:.0f}ms  total: {total_ms:.0f}ms"
+        tw = cv2.getTextSize(timing_text, FONT, 0.45, 1)[0][0]
+        cv2.putText(img, timing_text, (w - tw - 10, h - 12),
+                    FONT, 0.45, (255, 255, 255), 2, cv2.LINE_AA)
+        cv2.putText(img, timing_text, (w - tw - 10, h - 12),
+                    FONT, 0.45, (180, 180, 180), 1, cv2.LINE_AA)
+
+
+def export_mode(events_path, video_path, output_path, camera, max_frames):
+    """Export an annotated video."""
+    frames, total = load_events(events_path)
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        print(f"Error: cannot open {video_path}", file=sys.stderr)
+        return 1
+
+    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+
+    out_w, out_h = 1920, 1080
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    out = cv2.VideoWriter(str(output_path), fourcc, fps, (out_w, out_h))
+
+    print(f"Source: {src_w}x{src_h} @ {fps:.1f} fps")
+    print(f"Events: {total + 1} frames")
+    print(f"Output: {output_path} ({out_w}x{out_h})")
+
+    frame_idx = 0
+    limit = max_frames if max_frames else total + 1
+    while frame_idx <= min(total, limit - 1):
+        ret, raw = cap.read()
+        if not ret:
+            break
+
+        img = cv2.resize(raw, (out_w, out_h))
+        fd = frames[frame_idx]
+
+        n = draw_detections(img, fd["detections_raw"], camera, out_h, out_w)
+        draw_filter_removed(img, fd["detection_filter"], camera, out_h, out_w)
+        draw_overlay(img, frame_idx, fd, total, fps)
+
+        out.write(img)
+        frame_idx += 1
+        if frame_idx % 100 == 0:
+            print(f"  {frame_idx}/{total + 1} frames...", flush=True)
+
+    out.release()
+    cap.release()
+    print(f"Done: {frame_idx} frames written to {output_path}")
+    return 0
+
+
+def browse_mode(events_path, video_path, camera):
+    """Interactive frame-by-frame browser."""
+    frames, total = load_events(events_path)
+    cap = cv2.VideoCapture(str(video_path))
+    if not cap.isOpened():
+        print(f"Error: cannot open {video_path}", file=sys.stderr)
+        return 1
+
+    src_w = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    src_h = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+
+    disp_w, disp_h = 1920, 1080
+    current = 0
+    needs_redraw = True
+
+    print(f"Source: {src_w}x{src_h} @ {fps:.1f} fps, {total + 1} event frames")
+    print("Controls: Right/D = next, Left/A = prev, PgDn = +30, PgUp = -30")
+    print("          Home = first, End = last, Q = quit")
+
+    cv2.namedWindow("Reco Detection Browser", cv2.WINDOW_NORMAL)
+    cv2.resizeWindow("Reco Detection Browser", disp_w, disp_h)
+
+    def seek_and_draw(idx):
+        idx = max(0, min(idx, total))
+        cap.set(cv2.CAP_PROP_POS_FRAMES, idx)
+        ret, raw = cap.read()
+        if not ret:
+            return None, idx
+        img = cv2.resize(raw, (disp_w, disp_h))
+        fd = frames[idx]
+        draw_detections(img, fd["detections_raw"], camera, disp_h, disp_w)
+        draw_filter_removed(img, fd["detection_filter"], camera, disp_h, disp_w)
+        draw_overlay(img, idx, fd, total, fps)
+        return img, idx
+
+    while True:
+        if needs_redraw:
+            img, current = seek_and_draw(current)
+            if img is not None:
+                cv2.imshow("Reco Detection Browser", img)
+            needs_redraw = False
+
+        key = cv2.waitKey(0) & 0xFF
+        if key == ord("q") or key == 27:
+            break
+        elif key == ord("d") or key == 83:  # right arrow
+            current += 1
+            needs_redraw = True
+        elif key == ord("a") or key == 81:  # left arrow
+            current -= 1
+            needs_redraw = True
+        elif key == 85:  # page up
+            current -= 30
+            needs_redraw = True
+        elif key == 86:  # page down
+            current += 30
+            needs_redraw = True
+        elif key == 80:  # home
+            current = 0
+            needs_redraw = True
+        elif key == 87:  # end
+            current = total
+            needs_redraw = True
+
+    cv2.destroyAllWindows()
+    cap.release()
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Visualize reco AI detection events on source video."
+    )
+    sub = parser.add_subparsers(dest="mode", required=True)
+
+    exp = sub.add_parser("export", help="Export annotated video")
+    exp.add_argument("events", type=Path, help="Pipeline events JSONL file")
+    exp.add_argument("video", type=Path, help="Source video (left or right)")
+    exp.add_argument("-o", "--output", type=Path, default=Path("annotated.mp4"),
+                     help="Output video path (default: annotated.mp4)")
+    exp.add_argument("--camera", choices=["left", "right"], default="left",
+                     help="Which camera's detections to show (default: left)")
+    exp.add_argument("--max-frames", type=int, default=0,
+                     help="Limit frames to process (0 = all)")
+
+    brw = sub.add_parser("browse", help="Interactive frame browser")
+    brw.add_argument("events", type=Path, help="Pipeline events JSONL file")
+    brw.add_argument("video", type=Path, help="Source video (left or right)")
+    brw.add_argument("--camera", choices=["left", "right"], default="left",
+                     help="Which camera's detections to show (default: left)")
+
+    args = parser.parse_args()
+
+    if args.mode == "export":
+        return export_mode(args.events, args.video, args.output,
+                           args.camera, args.max_frames)
+    elif args.mode == "browse":
+        return browse_mode(args.events, args.video, args.camera)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -77,6 +77,7 @@ def load_events(path):
         "detection_filter": [],
         "world_state": None,
         "pan_decision": None,
+        "panner_debug": None,
         "pose_presented": None,
         "frame_complete": None,
         "timestamp_ms": 0.0,
@@ -101,6 +102,8 @@ def load_events(path):
                 frames[idx]["detection_filter"].append(ev)
             elif kind == "world_state":
                 frames[idx]["world_state"] = ev
+            elif kind == "panner_debug":
+                frames[idx]["panner_debug"] = ev
             elif kind == "pan_decision":
                 frames[idx]["pan_decision"] = ev
             elif kind == "pose_presented":
@@ -202,6 +205,23 @@ def draw_shared_overlay(img, frame_idx, frame_data, total_frames, fps):
     cx = (w - tw) // 2
     cv2.putText(img, info, (cx, 28), FONT, 0.5, (255, 255, 255), 2, cv2.LINE_AA)
     cv2.putText(img, info, (cx, 28), FONT, 0.5, (0, 200, 200), 1, cv2.LINE_AA)
+
+    # Panner debug (second line from top)
+    pd = frame_data.get("panner_debug")
+    if pd:
+        ball_near = "NEAR" if pd.get("ball_near_cluster") else "far"
+        eff_w = pd.get("effective_ball_weight", 0)
+        bp = pd.get("ball_presence", 0)
+        spread = pd.get("cluster_spread", 0)
+        fov_t = pd.get("fov_target", 0)
+        n_p = pd.get("n_players", 0)
+        debug_text = (f"cluster: {n_p}p spread={spread:.2f}  "
+                      f"ball: {ball_near} presence={bp:.2f} weight={eff_w:.2f}  "
+                      f"fov_target={fov_t:.0f}")
+        cv2.putText(img, debug_text, (10, 48), FONT, 0.4,
+                    (255, 255, 255), 2, cv2.LINE_AA)
+        cv2.putText(img, debug_text, (10, 48), FONT, 0.4,
+                    (255, 150, 50), 1, cv2.LINE_AA)
 
     # Pan decision (bottom left)
     pose = frame_data.get("pose_presented")

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -266,7 +266,7 @@ def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
         draw_filter_removed(right, frame_data["detection_filter"], "right", panel_h, panel_w)
         draw_roi(right, roi_right, panel_h, panel_w)
         draw_camera_label(right, "R", panel_h, panel_w)
-        combined = np.hstack([left, right])
+        combined = np.vstack([left, right])
     else:
         combined = left
 
@@ -301,9 +301,9 @@ def export_mode(events_path, left_path, right_path, output_path, max_frames, cal
             cap_r = None
 
     fps = cap_l.get(cv2.CAP_PROP_FPS) or 30.0
-    panel_w, panel_h = 960, 540
-    out_w = panel_w * 2 if cap_r else panel_w
-    out_h = panel_h
+    panel_w, panel_h = 1920, 540
+    out_w = panel_w
+    out_h = panel_h * 2 if cap_r else panel_h
 
     fourcc = cv2.VideoWriter_fourcc(*"mp4v")
     out = cv2.VideoWriter(str(output_path), fourcc, fps, (out_w, out_h))
@@ -369,8 +369,8 @@ def browse_mode(events_path, left_path, right_path, cal_path):
 
     win = "Reco Detection Browser"
     cv2.namedWindow(win, cv2.WINDOW_NORMAL)
-    out_w = panel_w * 2 if cap_r else panel_w
-    cv2.resizeWindow(win, out_w, panel_h)
+    out_h = panel_h * 2 if cap_r else panel_h
+    cv2.resizeWindow(win, panel_w, out_h)
 
     current = 0
     needs_redraw = True


### PR DESCRIPTION
## Summary

Bug fixes from community reports, quality API overhaul, and detection debugging tools.

### Bug fixes
- **Rig tilt/roll save corruption**: Degrees stored in radians field, multiplying by ~57x each save/load cycle. Reported by two community users via telemetry.
- **start_time hang on GPU zero-copy**: Skip loop deadlocked the decode pool. Added `FrameSource::skip_frames()` that releases slots during skip.
- **ORT log flooding**: Graph optimizer info spam filtered to warn in GUI and CLI.
- **NVENC preset/maxrate scaling**: Quality override now bumps NVENC preset (p3/p4/p5) and bitrate ceiling to match the quality level.

### Quality API
- Replace `--crf` with `--quality-value` (0-100, higher = better)
- CRF-style encoders: `crf = 40.0 - (quality / 100.0) * 28.0`
- VideoToolbox: passes through directly as `global_quality`
- Verified on Linux NVENC (monotonic 3.8-31.6 Mbps) and Mac VideoToolbox (3.6-297 Mbps)

### Detection visualization
- Python script (`scripts/visualize_detections.py`) with export and browse modes
- Dual-camera vstack, ROI polygon overlay, sync offset alignment
- Detection interval handling (fresh vs coasting frames)
- PannerDebug event showing cluster/ball/FOV decision state per frame

### Telemetry
- New `source_info` event with video FPS, resolution, decoder backend, sync offset
- `export_error` now includes codec
- Helps debug the "could not export" reports where we had no context

## Test plan
- [x] Quality API: tested 5 levels on Linux NVENC + Mac VideoToolbox
- [x] start_time: 5.3K GoPro with --start-time 5.0 completes (was hanging)
- [x] Clippy + tests clean
- [x] GUI: sync offset slider, telemetry source_info (needs manual test)
- [x] Rig tilt save/load round-trip in GUI