### PR TITLE
chore: simplify PR template, add CLA Assistant

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,14 @@
 ## Description
 
-<!-- Brief description of the changes -->
-
-## Type of Change
-
-- [ ] 🐛 Bug fix
-- [ ] ✨ New feature
-- [ ] 💥 Breaking change
-- [ ] 📖 Documentation update
-- [ ] 🧹 Code cleanup / refactor
+<!-- What does this change do, and why? -->
 
 ## Checklist
 
-- [ ] Code follows project style guidelines
-- [ ] Self-reviewed my own code
-- [ ] Tests pass locally (`cargo test`)
-- [ ] Lint/format checks pass (`cargo clippy --all-targets -- -D warnings && cargo fmt --all -- --check`)
+- [ ] I self-reviewed this change and it follows the project style guidelines
+- [ ] `cargo test --all` passes
+- [ ] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
+- [ ] I added or updated tests where it made sense
 
-## Screenshots (if applicable)
+## Screenshots
 
-<!-- Add screenshots for UI changes -->
+<!-- Required for UI changes, otherwise delete this section -->

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Signatures are committed to a dedicated branch so main stays clean.
+          path-to-signatures: signatures/version1/cla.json
+          branch: cla-signatures
+          # The agreement contributors are signing.
+          path-to-document: https://github.com/reco-project/video-stitcher/blob/main/CONTRIBUTING.md#contributor-license-agreement
+          # Bots (dependabot, etc.) never need to sign.
+          allowlist: '*[bot]'
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution. Before this can be merged, please
+            read our [Contributor License Agreement](https://github.com/reco-project/video-stitcher/blob/main/CONTRIBUTING.md#contributor-license-agreement)
+            and sign it by posting the comment below. It grants the maintainer
+            the right to relicense your contribution, including under a commercial
+            license for dual-licensing.
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'


### PR DESCRIPTION
## Description

Simplifies the PR template and adds CLA enforcement.

- PR template: dropped emojis and the Type-of-change section, condensed the checklist, removed the manual CLA checkbox (the bot owns that now).
- Added CLA Assistant Lite (v2.6.1) at `.github/workflows/cla.yml`. It records per-contributor signatures to the `cla-signatures` branch and gates merges with a status check. Bots are allowlisted.

The signature store branch (`cla-signatures`) and Actions write permission are already set up. The bot activates once this lands on `main` (pull_request_target reads the workflow from the default branch), so it cannot trigger on this PR itself.