### PR TITLE
ci: gitleaks binary for fork PRs; allowlist maintainer in CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -30,8 +30,8 @@ jobs:
           branch: cla-signatures
           # The agreement contributors are signing.
           path-to-document: https://github.com/reco-project/video-stitcher/blob/main/CONTRIBUTING.md#contributor-license-agreement
-          # Bots (dependabot, etc.) never need to sign.
-          allowlist: '*[bot]'
+          # The maintainer (CLA grantee) and bots never need to sign.
+          allowlist: 'mohamedtahaguelzim,*[bot]'
           custom-notsigned-prcomment: >-
             Thank you for your contribution. Before this can be merged, please
             read our [Contributor License Agreement](https://github.com/reco-project/video-stitcher/blob/main/CONTRIBUTING.md#contributor-license-agreement)

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -311,9 +311,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      # Run the gitleaks CLI directly instead of gitleaks-action. The action
+      # requires a license key for org repos, and that secret is unavailable
+      # to pull_request runs from forks, so it failed on every community PR.
+      # The binary is free for everyone and needs no secret, so it scans fork
+      # and internal PRs identically.
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" gitleaks
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Scan working tree for secrets
+        run: gitleaks dir . --redact --verbose


### PR DESCRIPTION
## Description

Two CI fixes.

**Secret Scanning works on fork PRs.** `gitleaks-action` requires a license secret, and GitHub withholds secrets from `pull_request` runs triggered by forks, so the job failed on every external contribution. This swaps the action for the free gitleaks CLI (v8.30.1), which needs no secret and scans fork and internal PRs identically. The `GITLEAKS_LICENSE` repo secret is now unused and can be deleted.

**CLA bot no longer nags the maintainer.** Added `mohamedtahaguelzim` to the allowlist so the CLA grantee isn't asked to sign their own agreement.