### PR TITLE
refactor(reco-io): extract VAAPI hw upload into hw_upload.rs

### DIFF
--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -10,16 +10,10 @@ use ffmpeg::format::Pixel;
 use ffmpeg::software::scaling::{context::Context as ScalingContext, flag::Flags as ScalingFlags};
 use ffmpeg::util::frame::video::Video as VideoFrame;
 use ffmpeg::{Rational, codec, encoder, format};
-use std::{path::Path, ptr};
+use std::path::Path;
 use thiserror::Error;
 
-fn staging_pixel_format(encoder_pixel_format: Pixel) -> Pixel {
-    if encoder_pixel_format == Pixel::VAAPI {
-        Pixel::NV12
-    } else {
-        encoder_pixel_format
-    }
-}
+use super::hw_upload::{HardwareUpload, staging_pixel_format};
 
 /// Errors from the video encoder.
 #[derive(Debug, Error)]
@@ -396,11 +390,6 @@ pub struct EncoderConfig {
     pub stream_url: Option<String>,
 }
 
-struct HardwareUpload {
-    frame: VideoFrame,
-    frames_ref: *mut ffmpeg::sys::AVBufferRef,
-}
-
 type OpenedVideoEncoder = (
     ffmpeg::encoder::video::Encoder,
     ScalingContext,
@@ -409,80 +398,6 @@ type OpenedVideoEncoder = (
     Rational,
     Option<HardwareUpload>,
 );
-
-impl HardwareUpload {
-    fn new_vaapi(width: u32, height: u32) -> Result<Self, EncodeError> {
-        unsafe {
-            let mut device_ref = ptr::null_mut();
-            let ret = ffmpeg::sys::av_hwdevice_ctx_create(
-                &mut device_ref,
-                ffmpeg::sys::AVHWDeviceType::AV_HWDEVICE_TYPE_VAAPI,
-                ptr::null(),
-                ptr::null_mut(),
-                0,
-            );
-            if ret < 0 {
-                return Err(ffmpeg::Error::from(ret).into());
-            }
-
-            let mut frames_ref = ffmpeg::sys::av_hwframe_ctx_alloc(device_ref);
-            if frames_ref.is_null() {
-                ffmpeg::sys::av_buffer_unref(&mut device_ref);
-                return Err(ffmpeg::Error::Unknown.into());
-            }
-            ffmpeg::sys::av_buffer_unref(&mut device_ref);
-
-            let frames_ctx = (*frames_ref).data as *mut ffmpeg::sys::AVHWFramesContext;
-            if frames_ctx.is_null() {
-                ffmpeg::sys::av_buffer_unref(&mut frames_ref);
-                return Err(ffmpeg::Error::Unknown.into());
-            }
-
-            (*frames_ctx).format = Pixel::VAAPI.into();
-            (*frames_ctx).sw_format = Pixel::NV12.into();
-            (*frames_ctx).width = width as i32;
-            (*frames_ctx).height = height as i32;
-            (*frames_ctx).initial_pool_size = 8;
-
-            let ret = ffmpeg::sys::av_hwframe_ctx_init(frames_ref);
-            if ret < 0 {
-                ffmpeg::sys::av_buffer_unref(&mut frames_ref);
-                return Err(ffmpeg::Error::from(ret).into());
-            }
-
-            Ok(Self {
-                frame: VideoFrame::empty(),
-                frames_ref,
-            })
-        }
-    }
-
-    fn upload(&mut self, source: &VideoFrame) -> Result<&VideoFrame, EncodeError> {
-        let frame = &mut self.frame;
-        unsafe {
-            ffmpeg::sys::av_frame_unref(frame.as_mut_ptr());
-            let ret = ffmpeg::sys::av_hwframe_get_buffer(self.frames_ref, frame.as_mut_ptr(), 0);
-            if ret < 0 {
-                return Err(ffmpeg::Error::from(ret).into());
-            }
-            let ret = ffmpeg::sys::av_hwframe_transfer_data(frame.as_mut_ptr(), source.as_ptr(), 0);
-            if ret < 0 {
-                return Err(ffmpeg::Error::from(ret).into());
-            }
-        }
-        frame.set_pts(source.pts());
-        Ok(frame)
-    }
-}
-
-impl Drop for HardwareUpload {
-    fn drop(&mut self) {
-        unsafe {
-            ffmpeg::sys::av_frame_unref(self.frame.as_mut_ptr());
-            ffmpeg::sys::av_buffer_unref(&mut self.frames_ref);
-        }
-    }
-}
 
 /// Video encoder that writes RGBA frames to an MP4 file.
 ///
@@ -791,13 +706,9 @@ impl VideoEncoder {
 
         let hardware_upload = if pixel_fmt == Pixel::VAAPI {
             let upload = HardwareUpload::new_vaapi(width, height)?;
-            unsafe {
-                let frames_ref = ffmpeg::sys::av_buffer_ref(upload.frames_ref);
-                if frames_ref.is_null() {
-                    return Err(ffmpeg::Error::Unknown.into());
-                }
-                (*enc.as_mut_ptr()).hw_frames_ctx = frames_ref;
-            }
+            // SAFETY: `enc` is a live, not-yet-opened encoder context.
+            let codec_ctx = unsafe { enc.as_mut_ptr() };
+            upload.attach_to_encoder(codec_ctx)?;
             Some(upload)
         } else {
             None

--- a/crates/reco-io/src/ffmpeg/hw_upload.rs
+++ b/crates/reco-io/src/ffmpeg/hw_upload.rs
@@ -1,0 +1,137 @@
+//! VAAPI hardware-frame upload for the FFmpeg encoder.
+//!
+//! `h264_vaapi` / `hevc_vaapi` / `av1_vaapi` only accept frames that live
+//! in VAAPI surfaces, not CPU pixel formats. This module owns the VAAPI
+//! hwdevice + hwframe context and uploads CPU NV12 staging frames to GPU
+//! surfaces via `av_hwframe_transfer_data`. All of the unsafe FFmpeg FFI
+//! for that path is isolated here so the encoder core stays readable.
+
+extern crate ffmpeg_next as ffmpeg;
+
+use ffmpeg::format::Pixel;
+use ffmpeg::util::frame::video::Video as VideoFrame;
+use std::ptr;
+
+use super::encoder::EncodeError;
+
+/// CPU staging pixel format for a given encoder input format.
+///
+/// VAAPI encoders declare `Pixel::VAAPI` (an opaque GPU surface), but the
+/// swscale target and the reusable CPU frame must be a real software
+/// format. Map VAAPI to its NV12 `sw_format`; every other format is its
+/// own staging format.
+pub(super) fn staging_pixel_format(encoder_pixel_format: Pixel) -> Pixel {
+    if encoder_pixel_format == Pixel::VAAPI {
+        Pixel::NV12
+    } else {
+        encoder_pixel_format
+    }
+}
+
+/// Owns a VAAPI hwframe context and uploads CPU NV12 frames to GPU surfaces.
+pub(super) struct HardwareUpload {
+    frame: VideoFrame,
+    frames_ref: *mut ffmpeg::sys::AVBufferRef,
+}
+
+impl HardwareUpload {
+    /// Create a VAAPI device + NV12-backed hwframe pool for `width`x`height`.
+    ///
+    /// Returns an error if VAAPI is unavailable, which lets the encoder
+    /// fallback chain move on to the next candidate.
+    pub(super) fn new_vaapi(width: u32, height: u32) -> Result<Self, EncodeError> {
+        unsafe {
+            let mut device_ref = ptr::null_mut();
+            let ret = ffmpeg::sys::av_hwdevice_ctx_create(
+                &mut device_ref,
+                ffmpeg::sys::AVHWDeviceType::AV_HWDEVICE_TYPE_VAAPI,
+                ptr::null(),
+                ptr::null_mut(),
+                0,
+            );
+            if ret < 0 {
+                return Err(ffmpeg::Error::from(ret).into());
+            }
+
+            let mut frames_ref = ffmpeg::sys::av_hwframe_ctx_alloc(device_ref);
+            if frames_ref.is_null() {
+                ffmpeg::sys::av_buffer_unref(&mut device_ref);
+                return Err(ffmpeg::Error::Unknown.into());
+            }
+            ffmpeg::sys::av_buffer_unref(&mut device_ref);
+
+            let frames_ctx = (*frames_ref).data as *mut ffmpeg::sys::AVHWFramesContext;
+            if frames_ctx.is_null() {
+                ffmpeg::sys::av_buffer_unref(&mut frames_ref);
+                return Err(ffmpeg::Error::Unknown.into());
+            }
+
+            (*frames_ctx).format = Pixel::VAAPI.into();
+            (*frames_ctx).sw_format = Pixel::NV12.into();
+            (*frames_ctx).width = width as i32;
+            (*frames_ctx).height = height as i32;
+            (*frames_ctx).initial_pool_size = 8;
+
+            let ret = ffmpeg::sys::av_hwframe_ctx_init(frames_ref);
+            if ret < 0 {
+                ffmpeg::sys::av_buffer_unref(&mut frames_ref);
+                return Err(ffmpeg::Error::from(ret).into());
+            }
+
+            Ok(Self {
+                frame: VideoFrame::empty(),
+                frames_ref,
+            })
+        }
+    }
+
+    /// Attach this hwframe context to the encoder before it is opened.
+    ///
+    /// VAAPI encoders need `hw_frames_ctx` set before `open` so they know
+    /// their input lives in the surface pool. Takes a fresh ref on the
+    /// buffer: the encoder releases it on free, `Drop` releases ours.
+    ///
+    /// `codec_ctx` must be a live, not-yet-opened `AVCodecContext`.
+    pub(super) fn attach_to_encoder(
+        &self,
+        codec_ctx: *mut ffmpeg::sys::AVCodecContext,
+    ) -> Result<(), EncodeError> {
+        unsafe {
+            let frames_ref = ffmpeg::sys::av_buffer_ref(self.frames_ref);
+            if frames_ref.is_null() {
+                return Err(ffmpeg::Error::Unknown.into());
+            }
+            (*codec_ctx).hw_frames_ctx = frames_ref;
+        }
+        Ok(())
+    }
+
+    /// Upload a CPU NV12 `source` frame to a VAAPI surface and return it.
+    ///
+    /// The returned frame is owned by `self` and reused on the next call.
+    pub(super) fn upload(&mut self, source: &VideoFrame) -> Result<&VideoFrame, EncodeError> {
+        let frame = &mut self.frame;
+        unsafe {
+            ffmpeg::sys::av_frame_unref(frame.as_mut_ptr());
+            let ret = ffmpeg::sys::av_hwframe_get_buffer(self.frames_ref, frame.as_mut_ptr(), 0);
+            if ret < 0 {
+                return Err(ffmpeg::Error::from(ret).into());
+            }
+            let ret = ffmpeg::sys::av_hwframe_transfer_data(frame.as_mut_ptr(), source.as_ptr(), 0);
+            if ret < 0 {
+                return Err(ffmpeg::Error::from(ret).into());
+            }
+        }
+        frame.set_pts(source.pts());
+        Ok(frame)
+    }
+}
+
+impl Drop for HardwareUpload {
+    fn drop(&mut self) {
+        unsafe {
+            ffmpeg::sys::av_frame_unref(self.frame.as_mut_ptr());
+            ffmpeg::sys::av_buffer_unref(&mut self.frames_ref);
+        }
+    }
+}

--- a/crates/reco-io/src/ffmpeg/mod.rs
+++ b/crates/reco-io/src/ffmpeg/mod.rs
@@ -7,6 +7,7 @@
 pub mod calibration_io;
 pub mod decoder;
 pub mod encoder;
+mod hw_upload;
 
 use std::sync::Once;
 


### PR DESCRIPTION
## Description

Follow-up to #324. Moves the VAAPI hardware-upload code out of the 1700+ line `encoder.rs` into a dedicated `crates/reco-io/src/ffmpeg/hw_upload.rs`, so all of the VAAPI hwframe `unsafe` FFI lives in one auditable file.

- `HardwareUpload` (struct + `new_vaapi` / `upload` / `Drop`) and `staging_pixel_format` move to `hw_upload.rs` (`pub(super)`).
- New `HardwareUpload::attach_to_encoder` encapsulates the `av_buffer_ref` + `hw_frames_ctx` assignment, so `encoder.rs` no longer touches the raw `frames_ref` pointer directly.
- `encoder.rs` shrinks ~88 lines and only uses `HardwareUpload` through safe-looking methods.

No behaviour change - pure move + encapsulation. Mirrors how `decoder.rs` clusters its hwframe FFI.

Verified: `cargo build --features ffmpeg`, `cargo clippy --features ffmpeg --all-targets -- -D warnings`, `cargo fmt --check`, `cargo test --features ffmpeg` all pass.