### PR TITLE
refactor: rename telemetry 'encode' metric to 'submit'

### DIFF
--- a/crates/reco-core/src/detect/pipeline_event.rs
+++ b/crates/reco-core/src/detect/pipeline_event.rs
@@ -116,7 +116,7 @@ pub struct FrameTimingMicros {
     pub upload_us: Option<u32>,
     pub stitch_us: Option<u32>,
     pub readback_us: Option<u32>,
-    pub encode_us: Option<u32>,
+    pub submit_us: Option<u32>,
     pub detection_us: Option<u32>,
     pub total_us: u32,
 }
@@ -129,7 +129,7 @@ impl From<&crate::telemetry::FrameTiming> for FrameTimingMicros {
             upload_us: to_us(t.upload),
             stitch_us: to_us(t.stitch),
             readback_us: to_us(t.readback),
-            encode_us: to_us(t.encode),
+            submit_us: to_us(t.submit),
             detection_us: to_us(t.detection),
             total_us: t.total.map_or(0, |d| d.as_micros() as u32),
         }
@@ -344,7 +344,7 @@ mod tests {
                     upload_us: None,
                     stitch_us: Some(500),
                     readback_us: None,
-                    encode_us: Some(2000),
+                    submit_us: Some(2000),
                     detection_us: None,
                     total_us: 5000,
                 },

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -283,7 +283,7 @@ impl StitchSession {
         let stitch_time = render_time
             .saturating_sub(upload_time)
             .saturating_sub(self.last_readback_time)
-            .saturating_sub(self.last_encode_time);
+            .saturating_sub(self.last_submit_time);
         self.telemetry.record_frame(crate::telemetry::FrameTiming {
             decode: Some(decode_time),
             upload: Some(upload_time),
@@ -294,7 +294,7 @@ impl StitchSession {
             },
             stitch: Some(stitch_time),
             readback: Some(self.last_readback_time),
-            encode: Some(self.last_encode_time),
+            submit: Some(self.last_submit_time),
             total: Some(frame_t0.elapsed()),
             ..Default::default()
         });
@@ -658,7 +658,7 @@ impl StitchSession {
                 enc.submit(data, self.frame_count as i64)?;
             }
         }
-        self.last_encode_time = encode_t0.elapsed();
+        self.last_submit_time = encode_t0.elapsed();
 
         self.frame_count += 1;
         Ok(())

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -119,7 +119,7 @@ pub struct StitchSession {
     /// Used by `process_frame_any` to split "stitch" into
     /// render / readback / encode for accurate telemetry.
     pub(crate) last_readback_time: std::time::Duration,
-    pub(crate) last_encode_time: std::time::Duration,
+    pub(crate) last_submit_time: std::time::Duration,
     // ── GPU-resident source state (populated by configure_from_source) ──
     /// Bind groups for GPU-resident shared textures.
     /// Created lazily from the source's textures at the start of run().
@@ -266,7 +266,7 @@ impl StitchSession {
             event_sink: None,
             telemetry: crate::telemetry::TelemetryCollector::new(),
             last_readback_time: std::time::Duration::ZERO,
-            last_encode_time: std::time::Duration::ZERO,
+            last_submit_time: std::time::Duration::ZERO,
             #[cfg(target_os = "linux")]
             gpu_bind_groups: None,
             #[cfg(target_os = "linux")]

--- a/crates/reco-core/src/telemetry.rs
+++ b/crates/reco-core/src/telemetry.rs
@@ -15,7 +15,11 @@ pub struct FrameTiming {
     pub upload: Option<Duration>,
     pub stitch: Option<Duration>,
     pub readback: Option<Duration>,
-    pub encode: Option<Duration>,
+    /// Synchronous submit cost on the pipeline thread: NV12 memcpy into the
+    /// async encode buffer + channel enqueue (+ backpressure wait if the
+    /// encoder is the bottleneck). NOT the encode compute, which runs
+    /// overlapped on the encode thread (see `AsyncEncodeThread`).
+    pub submit: Option<Duration>,
     pub detection: Option<Duration>,
     pub tracking: Option<Duration>,
     pub total: Option<Duration>,
@@ -29,7 +33,7 @@ pub enum PipelineStage {
     Upload,
     Stitch,
     Readback,
-    Encode,
+    Submit,
     Detection,
     Tracking,
 }
@@ -41,7 +45,7 @@ impl std::fmt::Display for PipelineStage {
             Self::Upload => write!(f, "upload"),
             Self::Stitch => write!(f, "stitch"),
             Self::Readback => write!(f, "readback"),
-            Self::Encode => write!(f, "encode"),
+            Self::Submit => write!(f, "submit"),
             Self::Detection => write!(f, "detection"),
             Self::Tracking => write!(f, "tracking"),
         }
@@ -199,7 +203,7 @@ impl TelemetryCollector {
         let avg_upload = avg(|t| t.upload);
         let avg_stitch = avg(|t| t.stitch);
         let avg_readback = avg(|t| t.readback);
-        let avg_encode = avg(|t| t.encode);
+        let avg_submit = avg(|t| t.submit);
         let avg_detection = avg(|t| t.detection);
         let avg_total = avg(|t| t.total);
 
@@ -234,7 +238,7 @@ impl TelemetryCollector {
             avg_upload,
             avg_stitch,
             avg_readback,
-            avg_encode,
+            avg_submit,
             avg_detection,
         );
 
@@ -247,7 +251,7 @@ impl TelemetryCollector {
             avg_upload_ms: avg_upload,
             avg_stitch_ms: avg_stitch,
             avg_readback_ms: avg_readback,
-            avg_encode_ms: avg_encode,
+            avg_submit_ms: avg_submit,
             avg_detection_ms: avg_detection,
             avg_total_ms: avg_total,
             p99_total_ms: p99_total,
@@ -287,7 +291,7 @@ impl TelemetryCollector {
         upload: f32,
         stitch: f32,
         readback: f32,
-        encode: f32,
+        submit: f32,
         detection: f32,
     ) -> Option<PipelineStage> {
         // Upload (staging copies) is a sub-step of decode for zero-copy paths.
@@ -297,7 +301,7 @@ impl TelemetryCollector {
             (PipelineStage::Decode, decode + upload),
             (PipelineStage::Stitch, stitch),
             (PipelineStage::Readback, readback),
-            (PipelineStage::Encode, encode),
+            (PipelineStage::Submit, submit),
             (PipelineStage::Detection, detection),
         ];
         stages
@@ -326,7 +330,7 @@ pub struct TelemetrySnapshot {
     pub avg_upload_ms: f32,
     pub avg_stitch_ms: f32,
     pub avg_readback_ms: f32,
-    pub avg_encode_ms: f32,
+    pub avg_submit_ms: f32,
     pub avg_detection_ms: f32,
     pub avg_total_ms: f32,
     pub p99_total_ms: f32,
@@ -387,7 +391,7 @@ impl std::fmt::Display for SessionSummary {
         }
         writeln!(f, "  Stitch:    {:.1} ms", s.avg_stitch_ms)?;
         writeln!(f, "  Readback:  {:.1} ms", s.avg_readback_ms)?;
-        writeln!(f, "  Encode:    {:.1} ms", s.avg_encode_ms)?;
+        writeln!(f, "  Submit:    {:.1} ms", s.avg_submit_ms)?;
         if s.avg_detection_ms > 0.0 {
             writeln!(f, "  Detection: {:.1} ms", s.avg_detection_ms)?;
         }
@@ -425,7 +429,7 @@ mod tests {
             tc.record_frame(FrameTiming {
                 decode: Some(Duration::from_millis(2)),
                 stitch: Some(Duration::from_millis(1)),
-                encode: Some(Duration::from_millis(3)),
+                submit: Some(Duration::from_millis(3)),
                 total: Some(Duration::from_millis(8)),
                 ..Default::default()
             });
@@ -433,8 +437,8 @@ mod tests {
         let snap = tc.snapshot();
         assert_eq!(snap.frames_processed, 100);
         assert!((snap.avg_decode_ms - 2.0).abs() < 0.1);
-        assert!((snap.avg_encode_ms - 3.0).abs() < 0.1);
-        assert!(snap.bottleneck == Some(PipelineStage::Encode));
+        assert!((snap.avg_submit_ms - 3.0).abs() < 0.1);
+        assert!(snap.bottleneck == Some(PipelineStage::Submit));
     }
 
     #[test]
@@ -442,13 +446,13 @@ mod tests {
         let mut tc = TelemetryCollector::new();
         tc.record_frame(FrameTiming {
             decode: Some(Duration::from_millis(10)),
-            encode: Some(Duration::from_millis(20)),
+            submit: Some(Duration::from_millis(20)),
             readback: Some(Duration::from_millis(5)),
             total: Some(Duration::from_millis(35)),
             ..Default::default()
         });
         let snap = tc.snapshot();
-        assert_eq!(snap.bottleneck, Some(PipelineStage::Encode));
+        assert_eq!(snap.bottleneck, Some(PipelineStage::Submit));
     }
 
     #[test]

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -83,7 +83,7 @@ impl reco_core::telemetry::TelemetrySink for ExportTelemetrySink {
                 app.set_telem_decode_ms(snap.avg_decode_ms);
                 app.set_telem_stitch_ms(snap.avg_stitch_ms);
                 app.set_telem_readback_ms(snap.avg_readback_ms);
-                app.set_telem_encode_ms(snap.avg_encode_ms);
+                app.set_telem_submit_ms(snap.avg_submit_ms);
                 app.set_telem_total_ms(snap.avg_total_ms);
                 app.set_telem_p99_ms(snap.p99_total_ms);
                 app.set_telem_detection_ms(snap.avg_detection_ms);

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -390,7 +390,7 @@ export component RecoApp inherits Window {
     in-out property <float> telem-decode-ms: 0.0;
     in-out property <float> telem-stitch-ms: 0.0;
     in-out property <float> telem-readback-ms: 0.0;
-    in-out property <float> telem-encode-ms: 0.0;
+    in-out property <float> telem-submit-ms: 0.0;
     in-out property <float> telem-total-ms: 0.0;
     in-out property <float> telem-p99-ms: 0.0;
     in-out property <float> telem-detection-ms: 0.0;
@@ -1347,7 +1347,7 @@ export component RecoApp inherits Window {
                         Text { text: "  Decode:   " + round(root.telem-decode-ms * 10) / 10 + " ms"; color: #888; font-size: 10px; }
                         Text { text: "  Stitch:   " + round(root.telem-stitch-ms * 10) / 10 + " ms"; color: #888; font-size: 10px; }
                         Text { text: "  Readback: " + round(root.telem-readback-ms * 10) / 10 + " ms"; color: #888; font-size: 10px; }
-                        Text { text: "  Encode:   " + round(root.telem-encode-ms * 10) / 10 + " ms"; color: #888; font-size: 10px; }
+                        Text { text: "  Submit:   " + round(root.telem-submit-ms * 10) / 10 + " ms"; color: #888; font-size: 10px; }
                         if root.telem-bottleneck != "": Text { text: "Bottleneck: " + root.telem-bottleneck; color: #e8a060; font-size: 11px; font-weight: 600; }
                         if root.telem-gpu-name != "": Text { text: root.telem-gpu-name; color: #666; font-size: 10px; }
                         if root.telem-frames-dropped > 0: Text { text: "Dropped: " + root.telem-frames-dropped; color: #f88; font-size: 11px; }


### PR DESCRIPTION
Slice 2 of #335. The per-frame "encode" timing only measures submit (NV12 memcpy + channel enqueue + backpressure), not encode compute. Renamed to "submit" across `FrameTiming`, `PipelineStage`, the snapshot/Display, JSONL (`encode_us`->`submit_us`), and the GUI panel. Real encode cost is on the encode thread (#340 logs it).