### PR TITLE
feat(reco-core): encode-worker cost + backpressure in telemetry snapshot

### DIFF
--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -378,8 +378,19 @@ impl StitchSession {
     }
 
     /// Snapshot of the session's telemetry collector.
+    ///
+    /// Merges the async encode thread's overlapped encode cost and
+    /// backpressure into the snapshot (the collector only sees the
+    /// per-frame submit cost).
     pub fn telemetry_snapshot(&self) -> crate::telemetry::TelemetrySnapshot {
-        self.telemetry.snapshot()
+        let mut snap = self.telemetry.snapshot();
+        if let Some(enc) = &self.encoder {
+            let (_frames, avg_encode_ms, bp_stalls, bp_ms) = enc.stats();
+            snap.avg_encode_worker_ms = avg_encode_ms;
+            snap.backpressure_stalls = bp_stalls;
+            snap.backpressure_ms = bp_ms;
+        }
+        snap
     }
 
     /// Mutable reference to the telemetry collector.

--- a/crates/reco-core/src/telemetry.rs
+++ b/crates/reco-core/src/telemetry.rs
@@ -252,6 +252,11 @@ impl TelemetryCollector {
             avg_stitch_ms: avg_stitch,
             avg_readback_ms: avg_readback,
             avg_submit_ms: avg_submit,
+            // Populated by the session from the async encode thread; the
+            // collector itself has no view of the overlapped encode cost.
+            avg_encode_worker_ms: 0.0,
+            backpressure_stalls: 0,
+            backpressure_ms: 0.0,
             avg_detection_ms: avg_detection,
             avg_total_ms: avg_total,
             p99_total_ms: p99_total,
@@ -331,6 +336,13 @@ pub struct TelemetrySnapshot {
     pub avg_stitch_ms: f32,
     pub avg_readback_ms: f32,
     pub avg_submit_ms: f32,
+    /// Real overlapped encode cost on the async encode thread (per frame).
+    /// Zero if no async encoder is attached.
+    pub avg_encode_worker_ms: f32,
+    /// Times `submit` blocked on a full encode channel (encoder = bottleneck).
+    pub backpressure_stalls: u64,
+    /// Total time spent blocked on encode backpressure (ms).
+    pub backpressure_ms: f32,
     pub avg_detection_ms: f32,
     pub avg_total_ms: f32,
     pub p99_total_ms: f32,
@@ -392,6 +404,13 @@ impl std::fmt::Display for SessionSummary {
         writeln!(f, "  Stitch:    {:.1} ms", s.avg_stitch_ms)?;
         writeln!(f, "  Readback:  {:.1} ms", s.avg_readback_ms)?;
         writeln!(f, "  Submit:    {:.1} ms", s.avg_submit_ms)?;
+        if s.avg_encode_worker_ms > 0.0 || s.backpressure_stalls > 0 {
+            writeln!(
+                f,
+                "  Encode:    {:.1} ms (overlapped); backpressure {} stalls / {:.1} ms",
+                s.avg_encode_worker_ms, s.backpressure_stalls, s.backpressure_ms
+            )?;
+        }
         if s.avg_detection_ms > 0.0 {
             writeln!(f, "  Detection: {:.1} ms", s.avg_detection_ms)?;
         }


### PR DESCRIPTION
Slice 3 of #335 (final). `telemetry_snapshot()` merges the async encode thread's real overlapped encode time + backpressure into the snapshot. Summary now reads:

```
Submit:  0.2 ms
Encode:  1.2 ms (overlapped); backpressure 15 stalls / 3.3 ms
```

Verified on h264_nvenc footage. Closes #335.