### PR TITLE
Quiet default logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,36 @@ cargo build --release -p reco-cli
     --model yolo.engine --tracking field
 ```
 
+## Logging
+
+Reco uses `RUST_LOG` for its own CLI/library logs. If `RUST_LOG` is unset,
+the CLI defaults to `info`; set it explicitly when you want more or less
+output.
+
+```bash
+# Show debug messages from Reco and dependencies
+RUST_LOG=debug ./target/release/reco stitch left.mp4 right.mp4 -c match.json -o out.mp4
+
+# Set 'info' level debug for default, 'debug' only for certain crates
+RUST_LOG='info,reco_io=debug,reco_autocam=debug' \
+    ./target/release/reco stitch ...
+
+# Quieter normal run
+RUST_LOG=warn ./target/release/reco stitch left.mp4 right.mp4 -c match.json -o out.mp4
+```
+
+Raw FFmpeg and libva messages are controlled separately because they write
+outside Rust's logger. Reco keeps them quiet by default; opt in when debugging
+codec, hardware decode, or driver setup issues:
+
+```bash
+# Show FFmpeg's own diagnostics
+RECO_FFMPEG_LOG=debug ./target/release/reco stitch left.mp4 right.mp4 -c match.json -o out.mp4
+
+# Linux: show libva driver messages again
+LIBVA_MESSAGING_LEVEL=2 ./target/release/reco stitch left.mp4 right.mp4 -c match.json -o out.mp4
+```
+
 ## Architecture
 
 Nine Rust crates. Strict dependency direction keeps the engine reusable as a library.

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -57,6 +57,18 @@ fn init_tracing() {
         .try_init();
 }
 
+#[cfg(target_os = "linux")]
+fn quiet_libva_info_by_default() {
+    if std::env::var_os("LIBVA_MESSAGING_LEVEL").is_none() {
+        // SAFETY: This runs at CLI process startup, before we install the
+        // Ctrl-C handler or start decode/encode worker threads. Callers can
+        // still opt back into libva info logs by setting the env var.
+        unsafe {
+            std::env::set_var("LIBVA_MESSAGING_LEVEL", "1");
+        }
+    }
+}
+
 /// Install a panic hook that captures the panic context (location,
 /// payload) as a structured `tracing::error!` event before the default
 /// hook runs. When a user reports a bug post-deployment with a log
@@ -704,6 +716,9 @@ fn parse_wxh(s: &str) -> Result<(u32, u32), String> {
 }
 
 fn main() -> anyhow::Result<()> {
+    #[cfg(target_os = "linux")]
+    quiet_libva_info_by_default();
+
     // When profiling, tracing-subscriber is owned by the chrome layer
     // (one global subscriber per process). Otherwise, install our fmt
     // subscriber + log bridge for normal structured output.

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -129,7 +129,7 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
                 args.lookahead
             );
         } else {
-            log::info!(
+            log::debug!(
                 "Lookahead {:.1}s ignored: no AI tracking (needs --model, non-sweep); \
                  a plain stitch needs none",
                 args.lookahead

--- a/crates/reco-core/src/gpu/mod.rs
+++ b/crates/reco-core/src/gpu/mod.rs
@@ -153,7 +153,7 @@ impl GpuContext {
     /// drivers on some AMD iGPUs crash during instance creation).
     pub async fn with_surface(surface: Option<&wgpu::Surface<'_>>) -> Result<Self, GpuError> {
         let backends = Self::select_backends();
-        log::info!("wgpu backends: {:?}", backends);
+        log::debug!("wgpu backends: {:?}", backends);
 
         let desc = wgpu::InstanceDescriptor {
             backends,
@@ -206,9 +206,9 @@ impl GpuContext {
             features |= wgpu::Features::TEXTURE_FORMAT_P010;
         }
 
-        log::info!("Requesting device with features: {:?}", features);
+        log::debug!("Requesting device with features: {:?}", features);
         let (device, queue) = Self::request_device_with_fallback(&adapter, features).await?;
-        log::info!("Device created successfully");
+        log::debug!("Device created successfully");
 
         Ok(Self {
             device,
@@ -343,9 +343,9 @@ impl GpuContext {
             features |= wgpu::Features::TEXTURE_FORMAT_NV12;
         }
 
-        log::info!("Requesting device with features: {:?}", features);
+        log::debug!("Requesting device with features: {:?}", features);
         let (device, queue) = Self::request_device_with_fallback(&adapter, features).await?;
-        log::info!("Device created successfully");
+        log::debug!("Device created successfully");
 
         let ctx = Self {
             device,

--- a/crates/reco-core/src/gpu/nv12_converter.rs
+++ b/crates/reco-core/src/gpu/nv12_converter.rs
@@ -215,7 +215,7 @@ impl Nv12Converter {
         let dispatch_x = (width / 4).div_ceil(16);
         let dispatch_y = height.div_ceil(4);
 
-        log::info!(
+        log::debug!(
             "NV12 converter: {}x{} → {} bytes ({:.1} MB), dispatch ({}, {}, 1)",
             width,
             height,

--- a/crates/reco-core/src/gpu/rgba_readback.rs
+++ b/crates/reco-core/src/gpu/rgba_readback.rs
@@ -111,7 +111,7 @@ impl RgbaReadback {
 
         let (map_tx, map_rx) = std::sync::mpsc::sync_channel(1);
 
-        log::info!(
+        log::debug!(
             "RgbaReadback: {width}x{height} → {staging_size} bytes staging \
              ({} MB, row padding {padded_bytes_per_row}/{bytes_per_row})",
             staging_size / 1_048_576,

--- a/crates/reco-core/src/projection/coverage.rs
+++ b/crates/reco-core/src/projection/coverage.rs
@@ -270,7 +270,7 @@ impl CoverageBoundary {
             }
         }
 
-        log::info!(
+        log::debug!(
             "CoverageBoundary: pitch [{:.3}, {:.3}] ({:.1} deg), min pitch range {:.1} deg",
             global_pitch_min,
             global_pitch_max,

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -137,7 +137,7 @@ impl StitchPipeline {
             &scene,
         );
 
-        log::info!(
+        log::debug!(
             "Pipeline initialized: {}x{} output, GPU: {}",
             viewport.width,
             viewport.height,

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -258,7 +258,7 @@ impl FfmpegFileSource {
             .spawn(move || {
                 let mut dec = match ffmpeg::decoder::VideoDecoder::open_input(&input) {
                     Ok(d) => {
-                        log::info!(
+                        log::debug!(
                             "{label} decoder: {} ({}x{})",
                             d.backend(),
                             d.width(),
@@ -350,7 +350,7 @@ impl FfmpegFileSource {
                             return;
                         }
                     }
-                    log::info!("Sync offset: skipped {sync_offset} right frames");
+                    log::debug!("Sync offset: skipped {sync_offset} right frames");
                 } else if sync_offset < 0 {
                     // Left started first — skip N left frames.
                     let skip = sync_offset.unsigned_abs();
@@ -359,7 +359,7 @@ impl FfmpegFileSource {
                             return;
                         }
                     }
-                    log::info!("Sync offset: skipped {skip} left frames");
+                    log::debug!("Sync offset: skipped {skip} left frames");
                 }
 
                 while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
@@ -452,7 +452,7 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
         }
 
         let secs = frame as f64 / self.info.fps;
-        log::info!("Seeking to frame {frame} ({secs:.1}s)");
+        log::debug!("Seeking to frame {frame} ({secs:.1}s)");
         // Drop old receiver - disconnects current decode threads which
         // exit on the next send() failure. Spawns fresh decoders that
         // seek to the target keyframe and skip to the exact PTS.

--- a/crates/reco-io/src/ffmpeg/decoder.rs
+++ b/crates/reco-io/src/ffmpeg/decoder.rs
@@ -377,7 +377,7 @@ impl VideoDecoder {
                     Pixel::YUV420P10LE | Pixel::YUV420P10BE | Pixel::P010LE | Pixel::P010BE
                 );
                 if is_10 {
-                    log::info!(
+                    log::debug!(
                         "Source is 10-bit ({pixel:?}), GPU textures will use R16Unorm/Rg16Unorm"
                     );
                 }
@@ -391,7 +391,7 @@ impl VideoDecoder {
             let yuvj = matches!(format, Pixel::YUVJ420P | Pixel::YUVJ422P | Pixel::YUVJ444P);
             let range_jpeg = raw_codecpar.color_range == ffi::AVColorRange::AVCOL_RANGE_JPEG;
             if yuvj || range_jpeg {
-                log::info!(
+                log::debug!(
                     "Source is full-range YUV (format={format:?}, color_range={:?})",
                     raw_codecpar.color_range
                 );
@@ -1091,18 +1091,13 @@ fn attach_shared_hw_device(
 
 /// Platform-preferred hwaccel candidates.
 fn hwaccel_candidates() -> Vec<(ffi::AVHWDeviceType, DecodeBackend)> {
-    vec![
+    let mut candidates = vec![
         #[cfg(target_os = "windows")]
         (
             ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_D3D11VA,
             DecodeBackend::D3d11va,
         ),
-        #[cfg(not(target_os = "macos"))]
-        (
-            ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_CUDA,
-            DecodeBackend::Cuda,
-        ),
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(target_os = "linux")]
         (
             ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VAAPI,
             DecodeBackend::Vaapi,
@@ -1112,7 +1107,22 @@ fn hwaccel_candidates() -> Vec<(ffi::AVHWDeviceType, DecodeBackend)> {
             ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_VIDEOTOOLBOX,
             DecodeBackend::VideoToolbox,
         ),
-    ]
+    ];
+
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    if reco_core::interop::cuda::is_cuda_available() {
+        let cuda = (
+            ffi::AVHWDeviceType::AV_HWDEVICE_TYPE_CUDA,
+            DecodeBackend::Cuda,
+        );
+
+        #[cfg(target_os = "windows")]
+        candidates.insert(1, cuda);
+        #[cfg(target_os = "linux")]
+        candidates.insert(0, cuda);
+    }
+
+    candidates
 }
 
 /// Try to enable hardware-accelerated decoding on the codec context.
@@ -1161,7 +1171,7 @@ fn try_hwaccel(
         return (backend, device_ref);
     }
 
-    log::info!("No hardware decoder available - using software decode");
+    log::debug!("No hardware decoder available - using software decode");
     (DecodeBackend::Software, ptr::null_mut())
 }
 

--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -252,6 +252,69 @@ pub fn available_h264_encoders() -> Vec<EncoderInfo> {
     available_encoders(VideoCodec::H264)
 }
 
+fn auto_candidate_allowed(name: &str) -> bool {
+    if name.ends_with("_nvenc") && !cuda_runtime_available() {
+        return false;
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    if name.ends_with("_qsv") {
+        return false;
+    }
+
+    #[cfg(target_os = "linux")]
+    if name.ends_with("_qsv")
+        && let Some(vaapi_name) = vaapi_peer_encoder(name)
+        && encoder::find_by_name(vaapi_name).is_some()
+    {
+        return false;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    if name.ends_with("_videotoolbox") {
+        return false;
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    if name.ends_with("_amf") || name.ends_with("_mf") {
+        return false;
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    if name.ends_with("_vaapi") || name.ends_with("_v4l2m2m") {
+        return false;
+    }
+
+    #[cfg(not(target_os = "android"))]
+    if name.ends_with("_mediacodec") {
+        return false;
+    }
+
+    true
+}
+
+#[cfg(target_os = "linux")]
+fn vaapi_peer_encoder(name: &str) -> Option<&'static str> {
+    match name {
+        "h264_qsv" => Some("h264_vaapi"),
+        "hevc_qsv" => Some("hevc_vaapi"),
+        "av1_qsv" => Some("av1_vaapi"),
+        _ => None,
+    }
+}
+
+fn cuda_runtime_available() -> bool {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        reco_core::interop::cuda::is_cuda_available()
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        false
+    }
+}
+
 /// Encoder quality preset.
 #[derive(Debug, Clone, Copy, Default)]
 pub enum Quality {
@@ -511,6 +574,8 @@ impl VideoEncoder {
 
         let all_candidates = config.codec.candidates();
 
+        let forced_encoder = config.encoder_name.is_some();
+
         // Build candidate list
         let candidates: Vec<(&str, bool, Pixel)> = if let Some(ref name) = config.encoder_name {
             // When a specific encoder is forced, look it up in all codec tables
@@ -531,6 +596,7 @@ impl VideoEncoder {
             all_candidates
                 .iter()
                 .filter(|c| encoder::find_by_name(c.name).is_some())
+                .filter(|c| auto_candidate_allowed(c.name))
                 .map(|c| (c.name, c.is_hardware, c.pixel_format))
                 .collect()
         };
@@ -668,7 +734,11 @@ impl VideoEncoder {
                     });
                 }
                 Err(e) => {
-                    log::warn!("Encoder {name} failed to open: {e}, trying next...");
+                    if forced_encoder {
+                        log::warn!("Encoder {name} failed to open: {e}");
+                    } else {
+                        log::debug!("Encoder {name} failed to open: {e}, trying next...");
+                    }
                     last_err = Some(e);
                 }
             }

--- a/crates/reco-io/src/ffmpeg/mod.rs
+++ b/crates/reco-io/src/ffmpeg/mod.rs
@@ -16,6 +16,34 @@ static FFMPEG_INIT: Once = Once::new();
 /// Initialize FFmpeg (safe to call multiple times, only runs once).
 pub fn init() {
     FFMPEG_INIT.call_once(|| {
+        configure_external_logging();
         ffmpeg_next::init().expect("FFmpeg initialization failed");
     });
+}
+
+fn configure_external_logging() {
+    let ffmpeg_level = std::env::var("RECO_FFMPEG_LOG")
+        .ok()
+        .as_deref()
+        .map(ffmpeg_log_level)
+        .unwrap_or(ffmpeg_next::sys::AV_LOG_FATAL);
+
+    unsafe {
+        ffmpeg_next::sys::av_log_set_level(ffmpeg_level);
+    }
+}
+
+fn ffmpeg_log_level(level: &str) -> i32 {
+    match level.to_ascii_lowercase().as_str() {
+        "quiet" => ffmpeg_next::sys::AV_LOG_QUIET,
+        "panic" => ffmpeg_next::sys::AV_LOG_PANIC,
+        "fatal" => ffmpeg_next::sys::AV_LOG_FATAL,
+        "error" => ffmpeg_next::sys::AV_LOG_ERROR,
+        "warn" | "warning" => ffmpeg_next::sys::AV_LOG_WARNING,
+        "info" => ffmpeg_next::sys::AV_LOG_INFO,
+        "verbose" => ffmpeg_next::sys::AV_LOG_VERBOSE,
+        "debug" => ffmpeg_next::sys::AV_LOG_DEBUG,
+        "trace" => ffmpeg_next::sys::AV_LOG_TRACE,
+        _ => ffmpeg_next::sys::AV_LOG_FATAL,
+    }
 }

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -186,7 +186,7 @@ impl SmartFileSource {
         let use_zero_copy = !hwaccel_disabled && backend_capable && gpu_capable;
 
         if !use_zero_copy && !hwaccel_disabled {
-            log::info!(
+            log::debug!(
                 "Zero-copy disabled: decode_backend={decode_backend} (capable={backend_capable}), \
                  gpu_zero_copy={gpu_capable}. Using CPU upload path."
             );
@@ -701,12 +701,12 @@ impl FrameSource for SmartFileSource {
                         }
                     }
                 }
-                log::info!("GPU zero-copy: skipped {count} frames for start_time");
+                log::debug!("GPU zero-copy: skipped {count} frames for start_time");
                 Ok(count)
             }
             SourceMode::Cpu(source) => {
                 source.seek(count)?;
-                log::info!("CPU seek: jumped to frame {count}");
+                log::debug!("CPU seek: jumped to frame {count}");
                 Ok(count)
             }
             #[cfg(target_os = "macos")]

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -553,7 +553,7 @@ impl StitchJob {
         let gpu = reco_core::gpu::GpuContext::new_blocking()?;
         let gpu_name = gpu.gpu_name().to_string();
 
-        log::info!("StitchJob::run: force_cpu_decode={}", self.force_cpu_decode);
+        log::debug!("StitchJob::run: force_cpu_decode={}", self.force_cpu_decode);
         let mut source = if self.force_cpu_decode {
             log::info!("Force CPU decode: zero-copy disabled by --no-zero-copy");
             crate::SmartFileSource::open_cpu_only(&self.left, &self.right, effective_sync)?


### PR DESCRIPTION
## Description

Fixes #346 

### Summary
Quiet the default CLI logging path so normal stitch runs show the useful high-level story without repeated FFmpeg, libva, CUDA, QSV, and setup-detail noise. Debug details are still available via RUST_LOG, and raw FFmpeg/libva diagnostics have explicit opt-in environment knobs.

I'm happy to discuss/change log level changes if you disagree with them!

### Changes

- Set FFmpeg’s raw log level to fatal by default, with RECO_FFMPEG_LOG for opt-in diagnostics.
- Set Linux LIBVA_MESSAGING_LEVEL=1 at CLI startup unless the user already configured it.
- Demoted repeated setup/internal messages from info to debug, including decoder probe details, full-range YUV detection, sync skip confirmations, wgpu feature dumps, readback/converter allocation details, coverage math, and zero-copy fallback details.
- Avoid noisy automatic encoder probes:
- - skip NVENC auto-candidates when CUDA is unavailable
- - on Linux, skip QSV auto-candidates when the matching VA-API encoder exists
- - filter platform-specific encoders out of auto-selection where they do not apply
- Preserve explicit user intent: forced encoders like --encoder h264_qsv or --encoder h264_nvenc are still attempted and still warn on failure.
- Document log controls in the README, including RUST_LOG, RECO_FFMPEG_LOG, and LIBVA_MESSAGING_LEVEL.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense
