### PR TITLE
docs: AGENTS.md as canonical agent guide + de-stale CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,76 @@
+# Reco Video Stitcher
+
+Open-source GPU-accelerated panoramic sports camera software.
+
+## Project status
+
+Active release work lives in GitHub issues, PRs, and milestones, not in this
+file - check there for the current focus. For the latest stable version and
+changelog, see the [GitHub Releases page](https://github.com/reco-project/video-stitcher/releases).
+Per-crate consumer pain is logged in each crate's `FRICTION.md`
+(e.g. `crates/reco-gui/FRICTION.md`, `crates/reco-obs/FRICTION.md`).
+
+**Rule: document friction, don't work around it.** A reco-core API gap that a
+consumer would otherwise hack around gets a `FRICTION.md` entry, not a
+consumer-side workaround.
+
+## Architecture (Rust + wgpu)
+
+- `crates/reco-core/` — GPU stitching engine (library crate, no I/O deps)
+- `crates/reco-cli/` — CLI binary (`reco stitch`, `reco info`, `reco calibrate`, `reco preview`)
+- `crates/reco-io/` — Pluggable I/O backends (FFmpeg decode/encode, GStreamer, libcamera)
+- `crates/reco-detect/` — AI detection backends (ORT CPU/GPU, TensorRT, NCNN, CoreML/Metal)
+- `crates/reco-autocam/` — AI camera control (directors, trajectory smoothing, ROI filtering)
+- `crates/reco-calibrate/` — Stereo camera calibration (AKAZE features, optimization)
+- `crates/reco-gui/` — Slint GUI consumer (wgpu zero-copy preview)
+- `crates/reco-obs/` — OBS Studio source plugin (async-frame ingestion + BGRA + interactive pan/zoom)
+
+## Key commands
+
+```bash
+cargo build                   # Build all crates
+cargo test --all              # Run all tests
+cargo clippy --all-targets -- -D warnings   # Lint
+cargo fmt --all -- --check    # Format check
+cargo fmt --all               # Auto-format
+cargo doc --no-deps --open    # Generate and open docs
+cargo run -p reco-cli -- info # Show GPU info
+cargo run -p reco-cli -- stitch left.mp4 right.mp4 -c match.json -o out.mp4
+cargo run -p reco-cli -- preview left.mp4 right.mp4 -c match.json
+cargo run --release -p reco-cli --features profiling -- stitch left.mp4 right.mp4 -c match.json -o out.mp4 --max-frames 300  # Profile 300 frames → reco-trace.json (open in ui.perfetto.dev)
+```
+
+## Build & contributing
+
+- Build prerequisites (Rust version, FFmpeg development libraries, clang,
+  pkg-config) and the feature-flag matrix: see [README.md](README.md).
+- Contribution conventions (branch naming, PR template, CLA): see
+  [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Code standards
+
+- `rustfmt` formatting (config in `rustfmt.toml`)
+- `clippy` linting with `-D warnings` (zero warnings policy)
+- Doc comments (`///`) on all public items
+- Module-level docs (`//!`) explaining purpose
+- Tests in each module (`#[cfg(test)] mod tests`)
+- All PRs must pass: `cargo fmt --check && cargo clippy && cargo test`
+- Clippy must also pass with `--features profiling`
+- Keep commit messages and PR descriptions concise and technical (what
+  changed + why), especially when written by an AI agent - no filler, no
+  marketing tone
+- `profiling` feature: opt-in `tracing` + `tracing-chrome` instrumentation (zero-cost when off)
+
+## Context
+- Public open-source project (AGPL-3.0) with a growing community and forum
+- Users include football clubs, amateur sports teams — prioritize UX clarity
+- Open alternative to proprietary sports camera solutions
+- Targets: desktop (Win/macOS/Linux), NVIDIA Jetson, cloud, mobile
+
+## When writing code
+- Production-grade: handle errors, validate inputs at API boundaries
+- Cross-platform (Windows/macOS/Linux) — avoid platform-specific assumptions
+- Performance matters: this processes video frames in real time
+- Modular: reco-core must be usable as a standalone Rust crate
+- Explicit over implicit: no hidden defaults, no magic
+- Verify changes actually run - exercise the binary or tests, not just `cargo check`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,68 +1,8 @@
-# Reco Video Stitcher
+@AGENTS.md
 
-Open-source GPU-accelerated panoramic sports camera software.
-
-## Current phase (read first)
-
-**Focus: v0.5.0 public release (GUI + AI tracking for community testers).**
-PR #288 on `feat/v0.5.0-release`. Tracking issue #289.
-Phases 1-9 shipped. GUI architecture revision in progress.
-Remaining: ROI visualization, recording perf fix, packaging
-(Phase 11), first-run experience (Phase 12), manual testing (Phase 13).
-Full plan at `~/.claude/plans/i-need-advanced-telemetry-breezy-eagle.md`.
-
-Active FRICTION: 16 in `crates/reco-obs/FRICTION.md`, 11 active
-in `crates/reco-gui/FRICTION.md` (N16-N18 added 2026-04-28).
-User's rule: **document friction,
-don't work around**; reco-core API gaps get a FRICTION entry, not a
-consumer-side hack.
-
-## v2 Architecture (Rust + wgpu)
-
-- `crates/reco-core/` — GPU stitching engine (library crate, no I/O deps)
-- `crates/reco-cli/` — CLI binary (`reco stitch`, `reco info`, `reco calibrate`, `reco preview`)
-- `crates/reco-io/` — Pluggable I/O backends (FFmpeg decode/encode, GStreamer, libcamera)
-- `crates/reco-detect/` — AI detection backends (ORT CPU/GPU, TensorRT, NCNN, CoreML/Metal)
-- `crates/reco-autocam/` — AI camera control (directors, trajectory smoothing, ROI filtering)
-- `crates/reco-calibrate/` — Stereo camera calibration (AKAZE features, optimization)
-- `crates/reco-gui/` — Slint GUI consumer (wgpu 28 zero-copy preview)
-- `crates/reco-obs/` — OBS Studio source plugin (async-frame ingestion + BGRA + interactive pan/zoom)
-
-## Key commands
-
-```bash
-cargo build                   # Build all crates
-cargo test --all              # Run all tests
-cargo clippy --all-targets -- -D warnings   # Lint
-cargo fmt --all -- --check    # Format check
-cargo fmt --all               # Auto-format
-cargo doc --no-deps --open    # Generate and open docs
-cargo run -p reco-cli -- info # Show GPU info
-cargo run -p reco-cli -- stitch left.mp4 right.mp4 -c match.json -o out.mp4
-cargo run -p reco-cli -- preview left.mp4 right.mp4 -c match.json
-cargo run --release -p reco-cli --features profiling -- stitch left.mp4 right.mp4 -c match.json -o out.mp4 --max-frames 300  # Profile 300 frames → reco-trace.json (open in ui.perfetto.dev)
-```
-
-## Code standards
-
-- `rustfmt` formatting (config in `rustfmt.toml`)
-- `clippy` linting with `-D warnings` (zero warnings policy)
-- Doc comments (`///`) on all public items
-- Module-level docs (`//!`) explaining purpose
-- Tests in each module (`#[cfg(test)] mod tests`)
-- All PRs must pass: `cargo fmt --check && cargo clippy && cargo test`
-- Clippy must also pass with `--features profiling`
-- `profiling` feature: opt-in `tracing` + `tracing-chrome` instrumentation (zero-cost when off)
-
-## Context
-- Public open-source project (AGPL-3.0) with a growing community and forum
-- Users include football clubs, amateur sports teams — prioritize UX clarity
-- Open alternative to proprietary sports camera solutions
-- v2 targets: desktop (Win/macOS/Linux), NVIDIA Jetson, cloud, mobile
-
-## When writing code
-- Production-grade: handle errors, validate inputs at API boundaries
-- Cross-platform (Windows/macOS/Linux) — avoid platform-specific assumptions
-- Performance matters: this processes video frames in real time
-- Modular: reco-core must be usable as a standalone Rust crate
-- Explicit over implicit: no hidden defaults, no magic
+<!--
+Canonical agent guidance for ALL AI coding tools lives in AGENTS.md.
+Claude Code only auto-loads CLAUDE.md, so this file imports AGENTS.md (above)
+via the @-import; Codex / Cursor / Aider read AGENTS.md directly.
+Edit AGENTS.md, not this file.
+-->

--- a/crates/reco-gui/FRICTION.md
+++ b/crates/reco-gui/FRICTION.md
@@ -52,3 +52,14 @@ without reading raw JSON.
 
 **Impact**: Low. Likely a Slint bug. Workaround: move critical sliders
 outside the ScrollView.
+
+### N19. FOV reaches the renderer via a cached push, not a render param
+
+**Impact**: Medium. `render_yuv` takes yaw/pitch as live per-frame
+parameters, but FOV only through a separate cached `pipeline.set_fov`.
+A pose change applied outside the smoothing tick (e.g. re-enabling
+constrained look, which clamps `current_fov` directly) updates yaw/pitch
+live but leaves the cached FOV stale, so the view ignores the clamp while
+the slider shows it. The consumer has to remember to push FOV after any
+out-of-tick clamp. FOV should be a `render_yuv` parameter like yaw/pitch
+(or the renderer should own the full pose state).


### PR DESCRIPTION
## Description

Generalize the agent guidance and make it cross-agent (docs-only, no code changes).

- AGENTS.md is now the canonical guide (read by Codex/Cursor/Aider); CLAUDE.md is a one-line `@AGENTS.md` import, portable on Windows unlike a symlink.
- De-stale: drop the phase/PR-pinned "Current phase" block and `v2` naming; point to GitHub releases/issues/milestones for live status.
- Add rules: concise commit/PR text (especially for AI agents) and verify-changes-run (not just `cargo check`); link README (build prereqs) and CONTRIBUTING.
- reco-gui FRICTION N19: FOV reaches the renderer via a cached push, not a render param (refs #343).

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (docs-only, no code changed)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass (docs-only)
- [ ] I added or updated tests where it made sense (N/A, docs-only)
