### PR TITLE
fix(reco-io): share one D3D11 device across concat decoders (#345)

### DIFF
--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -89,17 +89,40 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
     #[cfg_attr(not(feature = "autocam"), allow(unused_variables))]
     let field_roi = cal.field_roi.clone();
 
-    let mut job = reco_io::StitchJob::with_calibration(args.left, args.right, cal, args.output)
-        .codec(parse_codec(args.codec))
-        .quality(parse_quality(args.quality))
-        .resolution(args.width, args.height)
-        .blend_width(args.blend)
-        .on_progress(move |p: &reco_core::session::types::FrameProgress| {
-            // Use the session's own elapsed clock so the reported
-            // rate excludes one-time GPU / encoder / ORT init and
-            // reflects only the decode → stitch → encode loop.
-            progress.report_with_elapsed(p.frames_completed, p.elapsed);
-        });
+    // Accept `a.mp4;b.mp4;c.mp4` to chain segments via the concat demuxer
+    // (mirrors the GUI's multi-segment selection). A single path stays Single.
+    let to_input = |s: &str| -> reco_io::stitch_job::InputPath {
+        let parts: Vec<std::path::PathBuf> = s
+            .split(';')
+            .filter(|p| !p.is_empty())
+            .map(std::path::PathBuf::from)
+            .collect();
+        if parts.len() > 1 {
+            log::info!(
+                "CLI input: {} segments, chaining via concat demuxer",
+                parts.len()
+            );
+            reco_io::stitch_job::InputPath::Chained(parts)
+        } else {
+            reco_io::stitch_job::InputPath::Single(std::path::PathBuf::from(s))
+        }
+    };
+    let mut job = reco_io::StitchJob::with_calibration(
+        to_input(args.left),
+        to_input(args.right),
+        cal,
+        args.output,
+    )
+    .codec(parse_codec(args.codec))
+    .quality(parse_quality(args.quality))
+    .resolution(args.width, args.height)
+    .blend_width(args.blend)
+    .on_progress(move |p: &reco_core::session::types::FrameProgress| {
+        // Use the session's own elapsed clock so the reported
+        // rate excludes one-time GPU / encoder / ORT init and
+        // reflects only the decode → stitch → encode loop.
+        progress.report_with_elapsed(p.frames_completed, p.elapsed);
+    });
 
     if let Some(t) = args.start_time {
         job = job.start_time(t);

--- a/crates/reco-core/src/interop/d3d11.rs
+++ b/crates/reco-core/src/interop/d3d11.rs
@@ -28,8 +28,8 @@ use thiserror::Error;
 use windows::Win32::Foundation::{CloseHandle, GENERIC_ALL, HANDLE, S_OK};
 use windows::Win32::Graphics::Direct3D11::{
     D3D11_QUERY, D3D11_QUERY_DESC, D3D11_RESOURCE_MISC_SHARED, D3D11_RESOURCE_MISC_SHARED_NTHANDLE,
-    D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, ID3D11DeviceContext, ID3D11Multithread, ID3D11Query,
-    ID3D11Texture2D,
+    D3D11_TEXTURE2D_DESC, D3D11_USAGE_DEFAULT, ID3D11Device, ID3D11DeviceContext,
+    ID3D11Multithread, ID3D11Query, ID3D11Texture2D,
 };
 use windows::Win32::Graphics::Direct3D12::ID3D12Resource;
 use windows::Win32::Graphics::Dxgi::Common::{
@@ -74,6 +74,10 @@ impl From<D3d11InteropError> for crate::session::types::SessionError {
 /// Created on the first `stage_frame` call using the device obtained from
 /// the source texture, so all D3D11 operations stay on a single device.
 struct StagingState {
+    /// FFmpeg's D3D11 device that owns the decode pool and the staging
+    /// textures. `stage_frame` rejects source frames from any other device:
+    /// a cross-device `CopySubresourceRegion` faults the GPU.
+    device: ID3D11Device,
     context: ID3D11DeviceContext,
     staging: Vec<ID3D11Texture2D>,
     _wgpu_textures: Vec<wgpu::Texture>,
@@ -164,7 +168,8 @@ impl D3d11StagingPool {
         // immediate contexts are single-threaded by default; this adds an
         // internal critical section that serializes access.
         let multithread: ID3D11Multithread = device.cast()?;
-        unsafe { multithread.SetMultithreadProtected(true) };
+        // Returns the previous state; we don't need it.
+        let _ = unsafe { multithread.SetMultithreadProtected(true) };
 
         let context = unsafe { device.GetImmediateContext()? };
 
@@ -340,6 +345,7 @@ impl D3d11StagingPool {
         };
 
         self.state = Some(StagingState {
+            device,
             context,
             staging: staging_textures,
             _wgpu_textures: wgpu_textures,
@@ -387,6 +393,20 @@ impl D3d11StagingPool {
 
             self.ensure_initialized(&src)?;
             let state = self.state.as_ref().unwrap();
+
+            // The staging textures live on the device captured at init. A
+            // CopySubresourceRegion from a texture on a different device faults
+            // the GPU (DEVICE_REMOVED on desktop NVIDIA, driver hang on
+            // laptops). Reject it with a clear error - the stereo decoders
+            // sharing one hw device is an invariant of this path.
+            let src_device = src.GetDevice()?;
+            if Interface::as_raw(&src_device) != Interface::as_raw(&state.device) {
+                return Err(D3d11InteropError::StagingCopy(
+                    "source frame is on a different D3D11 device than the staging pool; \
+                     the stereo decoders must share one hw device"
+                        .into(),
+                ));
+            }
 
             let src_subresource = array_slice as u32;
 

--- a/crates/reco-io/src/ffmpeg/decoder.rs
+++ b/crates/reco-io/src/ffmpeg/decoder.rs
@@ -272,13 +272,20 @@ impl VideoDecoder {
         shared: &SharedHwDevice,
     ) -> Result<Self, DecodeError> {
         crate::init();
-        let ictx = match input_path {
-            crate::stitch_job::InputPath::Single(p) => input(p)?,
-            crate::stitch_job::InputPath::Chained(_) => {
-                return Self::open_input(input_path);
+        match input_path {
+            crate::stitch_job::InputPath::Single(p) => {
+                let ictx = input(p)?;
+                Self::from_input_context_with_shared(ictx, shared)
             }
-        };
-        Self::from_input_context_with_shared(ictx, shared)
+            // Chained must also attach the shared device. Otherwise each
+            // concat decoder creates its own D3D11 device, and the staging
+            // pool's CopySubresourceRegion copies one side's frame into the
+            // other device's texture -> cross-device fault (DEVICE_REMOVED on
+            // desktop NVIDIA, driver hang on laptops). See open_chained_impl.
+            crate::stitch_job::InputPath::Chained(paths) => {
+                Self::open_chained_impl(paths, Some(shared))
+            }
+        }
     }
 
     fn from_input_context(ictx: ffmpeg::format::context::Input) -> Result<Self, DecodeError> {
@@ -443,13 +450,31 @@ impl VideoDecoder {
     /// Timestamps are rebased, hardware acceleration works across
     /// segment boundaries, and seeking spans the full duration.
     pub fn open_chained(paths: &[std::path::PathBuf]) -> Result<Self, DecodeError> {
+        Self::open_chained_impl(paths, None)
+    }
+
+    /// Chained open that optionally attaches a pre-created shared hw device.
+    ///
+    /// A stereo pair's two concat decoders must land on the SAME D3D11
+    /// device: the zero-copy staging pool copies both sides into textures on
+    /// a single device via `CopySubresourceRegion`, which faults across
+    /// devices. Single-file open already threads the shared device through;
+    /// concat must do the same or it regresses to per-decoder devices.
+    fn open_chained_impl(
+        paths: &[std::path::PathBuf],
+        shared: Option<&SharedHwDevice>,
+    ) -> Result<Self, DecodeError> {
         use std::io::Write;
 
-        if paths.len() <= 1 {
-            return Self::open(paths.first().map(|p| p.as_path()).unwrap_or(Path::new("")));
-        }
-
         crate::init();
+
+        if paths.len() <= 1 {
+            let p = paths.first().map(|p| p.as_path()).unwrap_or(Path::new(""));
+            return match shared {
+                Some(s) => Self::from_input_context_with_shared(input(p)?, s),
+                None => Self::open(p),
+            };
+        }
 
         let mut manifest = tempfile::Builder::new()
             .prefix("reco_concat_")
@@ -490,7 +515,7 @@ impl VideoDecoder {
             _ => return Err(DecodeError::Ffmpeg("expected input context".into())),
         };
 
-        let mut dec = Self::from_input_context(ictx)?;
+        let mut dec = Self::from_input_context_inner(ictx, shared)?;
         dec._manifest = Some(manifest);
         Ok(dec)
     }


### PR DESCRIPTION
## Description

Fixes #345 — export hangs at "opening encoder and decoders" when importing multiple chunks (a single L+R pair always worked, on every version).

Root cause: a stereo pair's concat (`Chained`) decoders each created their own D3D11VA device. The zero-copy staging pool then copied one side's frame into a staging texture on the *other* device — a cross-device `CopySubresourceRegion`, which faults the GPU (`DXGI_ERROR_DEVICE_REMOVED`, 0x887a0005, on desktop NVIDIA; driver hang on laptops). Single files share one device via `SharedHwDevice`, so they never hit it; the `Chained` path silently bypassed that sharing.

Changes:
- `open_input_with_shared_device` now threads the shared hw device through the `Chained` path (`open_chained_impl`), exactly like `Single` already did — both decoders land on one D3D11 device.
- `d3d11` staging rejects a cross-device source frame with a clear error instead of issuing a GPU-faulting copy (defense-in-depth, so a mismatch can never silently remove the device again).
- `reco-cli stitch` accepts `a.mp4;b.mp4` to chain segments via the concat demuxer (mirrors the GUI's multi-segment selection; also the headless repro vehicle).

Verified on an NVIDIA GTX 1080 Ti: single and 2-segment concat both stitch to completion; the prior `DEVICE_REMOVED` is gone, and per-frame device logging confirmed left and right now share one device.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (changed-crate tests green locally; full suite via CI)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [ ] I added or updated tests where it made sense (N/A: the failure is in the Windows D3D11VA GPU path, not exercisable in Linux CI; validated on hardware)
