### PR TITLE
chore: bump to 0.5.3-beta.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,7 +5385,7 @@ dependencies = [
 
 [[package]]
 name = "reco-autocam"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "log",
  "reco-core",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "reco-calibrate"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "approx",
  "argmin",
@@ -5426,7 +5426,7 @@ dependencies = [
 
 [[package]]
 name = "reco-cli"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -5449,7 +5449,7 @@ dependencies = [
 
 [[package]]
 name = "reco-control"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "log",
  "reco-core",
@@ -5462,7 +5462,7 @@ dependencies = [
 
 [[package]]
 name = "reco-core"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "approx",
  "ash",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "reco-detect"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "block2 0.6.2",
  "bytemuck",
@@ -5514,7 +5514,7 @@ dependencies = [
 
 [[package]]
 name = "reco-gui"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "reco-io"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "directories",
  "ffmpeg-next",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "reco-obs"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/reco-autocam/Cargo.toml
+++ b/crates/reco-autocam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-autocam"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-calibrate/Cargo.toml
+++ b/crates/reco-calibrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-calibrate"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-cli/Cargo.toml
+++ b/crates/reco-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-cli"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "CLI tool for Reco panoramic video stitching"

--- a/crates/reco-control/Cargo.toml
+++ b/crates/reco-control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-control"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-core/Cargo.toml
+++ b/crates/reco-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-core"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "GPU-accelerated panoramic video stitching engine"

--- a/crates/reco-detect/Cargo.toml
+++ b/crates/reco-detect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-detect"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-gui"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-io/Cargo.toml
+++ b/crates/reco-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-io"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "Pluggable frame I/O backends for Reco (FFmpeg, GStreamer, ...)"

--- a/crates/reco-obs/Cargo.toml
+++ b/crates/reco-obs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-obs"
-version = "0.5.2"
+version = "0.5.3-beta.1"
 edition.workspace = true
 rust-version.workspace = true
 description = "OBS Studio source plugin for Reco panoramic video stitching"


### PR DESCRIPTION
## Description

Version bump for the **0.5.3-beta.1** pre-release. Crate-only change (9 `[package]` versions + Cargo.lock); inter-crate deps are path-only, so nothing else moves.

Merge alongside #356 (concat / D3D11VA export-hang fix — the reason for this beta) and #355 (docs cleanup). Once all three are in main, tag `v0.5.3-beta.1` to trigger `release.yml`, which builds the Windows/Linux/macOS GUI+CLI bundles and creates a **draft pre-release** to review and publish.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (no code change; `cargo check --workspace` clean after the bump)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass (version-only change)
- [ ] I added or updated tests where it made sense (N/A: version bump)
