### PR TITLE
fix: persist lens correction and seam blend in calibration

### DIFF
--- a/crates/reco-autocam/src/panners/field.rs
+++ b/crates/reco-autocam/src/panners/field.rs
@@ -1172,6 +1172,8 @@ mod tests {
             rig_roll: 0.0,
             sync_offset: 0,
             field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
         }
     }
 

--- a/crates/reco-autocam/src/panners/sweep.rs
+++ b/crates/reco-autocam/src/panners/sweep.rs
@@ -129,6 +129,8 @@ mod tests {
             rig_roll: 0.0,
             sync_offset: 0,
             field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
         }
     }
 

--- a/crates/reco-calibrate/src/lib.rs
+++ b/crates/reco-calibrate/src/lib.rs
@@ -477,8 +477,10 @@ pub fn calibrate_with(
         layout: best_layout,
         rig_tilt: 0.0, // set by CalibrationPipeline after calibrate()
         rig_roll: 0.0,
-        sync_offset: 0,  // set by CalibrationPipeline after calibrate()
-        field_roi: None, // set manually or by a future field detection pipeline
+        sync_offset: 0,              // set by CalibrationPipeline after calibrate()
+        field_roi: None,             // set manually or by a future field detection pipeline
+        lens_correction_amount: 1.0, // full correction; user-tunable in the GUI
+        blend_width: 0.05,           // renderer default; user-tunable in the GUI
     };
 
     Ok(CalibrationResult {

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -294,6 +294,36 @@ pub struct MatchCalibration {
     /// from stands, scoreboards, and other non-field areas.
     #[serde(default)]
     pub field_roi: Option<FieldRoi>,
+
+    /// Lens distortion-correction strength applied in the renderer.
+    ///
+    /// `1.0` = full correction (the modelled lens profile is applied),
+    /// `0.0` = correction off (raw fisheye). Persisted so the GUI restores
+    /// the user's choice on reload. Defaults to `1.0` for older
+    /// calibrations that predate this field, matching prior behaviour.
+    #[serde(default = "default_lens_correction_amount")]
+    pub lens_correction_amount: f32,
+
+    /// Seam blend width as a fraction of the panorama overlap.
+    ///
+    /// Controls how wide the feathered transition between the two cameras
+    /// is. Persisted so a hand-tuned seam survives save/reload. Defaults to
+    /// `0.05` for older calibrations that predate this field, matching the
+    /// previous hard-coded renderer default.
+    #[serde(default = "default_blend_width")]
+    pub blend_width: f32,
+}
+
+/// Backward-compatible default for [`MatchCalibration::lens_correction_amount`]
+/// when loading a calibration written before the field existed.
+fn default_lens_correction_amount() -> f32 {
+    1.0
+}
+
+/// Backward-compatible default for [`MatchCalibration::blend_width`] when
+/// loading a calibration written before the field existed.
+fn default_blend_width() -> f32 {
+    0.05
 }
 
 /// Maximum calibration file size (1 MB) to prevent loading unreasonably large files.
@@ -370,6 +400,22 @@ impl MatchCalibration {
             return Err(CalibrationError::NonFiniteFloat {
                 field: "rig_roll".to_string(),
                 value: self.rig_roll.to_string(),
+            });
+        }
+        // blend_width and lens_correction_amount feed the GPU shader; a
+        // NaN/inf slipping in from a hand-edited JSON would corrupt the
+        // render. Range is clamped at the GUI setters and re-validated by
+        // the viewport, so a finiteness gate here matches rig_tilt/roll.
+        if !self.blend_width.is_finite() {
+            return Err(CalibrationError::NonFiniteFloat {
+                field: "blend_width".to_string(),
+                value: self.blend_width.to_string(),
+            });
+        }
+        if !self.lens_correction_amount.is_finite() {
+            return Err(CalibrationError::NonFiniteFloat {
+                field: "lens_correction_amount".to_string(),
+                value: self.lens_correction_amount.to_string(),
             });
         }
         // B-10: reject pathological sync_offset (e.g. i64::MIN) that would
@@ -678,6 +724,8 @@ mod tests {
             rig_roll: 0.0,
             sync_offset: 0,
             field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
         }
     }
 
@@ -811,6 +859,17 @@ mod tests {
     }
 
     #[test]
+    fn validate_nan_blend_width_fails() {
+        let mut cal = valid_cal();
+        cal.blend_width = f32::NAN;
+        let err = cal.validate().unwrap_err();
+        assert!(
+            matches!(err, CalibrationError::NonFiniteFloat { ref field, .. } if field == "blend_width"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
     fn roundtrip_serialization() {
         let cal = MatchCalibration {
             left: CameraParams {
@@ -842,8 +901,12 @@ mod tests {
                 z_rz: 0.0,
             },
             rig_tilt: 0.3,
-            rig_roll: 0.0,
+            rig_roll: -0.12,
             sync_offset: 67,
+            // Deliberately non-default (correction off, wide seam) so a
+            // dropped field would change the round-tripped value.
+            lens_correction_amount: 0.0,
+            blend_width: 0.123,
         };
 
         let json = serde_json::to_string(&cal).unwrap();
@@ -851,6 +914,26 @@ mod tests {
 
         assert_eq!(parsed.left.width, cal.left.width);
         assert!((parsed.layout.intersect - cal.layout.intersect).abs() < f64::EPSILON);
+        assert!((parsed.rig_tilt - cal.rig_tilt).abs() < f64::EPSILON);
+        assert!((parsed.rig_roll - cal.rig_roll).abs() < f64::EPSILON);
+        assert_eq!(parsed.sync_offset, cal.sync_offset);
+        assert!((parsed.lens_correction_amount - cal.lens_correction_amount).abs() < f32::EPSILON);
+        assert!((parsed.blend_width - cal.blend_width).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn old_calibration_json_without_new_fields_uses_safe_defaults() {
+        // A calibration written before lens_correction_amount/blend_width
+        // existed must load with the prior behaviour: full correction (1.0)
+        // and the 0.05 seam, not 0.0/0.0.
+        let mut value = serde_json::to_value(valid_cal()).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("lens_correction_amount");
+        obj.remove("blend_width");
+
+        let parsed: MatchCalibration = serde_json::from_value(value).unwrap();
+        assert!((parsed.lens_correction_amount - 1.0).abs() < f32::EPSILON);
+        assert!((parsed.blend_width - 0.05).abs() < f32::EPSILON);
     }
 
     #[test]

--- a/crates/reco-core/src/detect/panner.rs
+++ b/crates/reco-core/src/detect/panner.rs
@@ -266,6 +266,8 @@ mod tests {
             rig_roll: 0.0,
             sync_offset: 0,
             field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
         }
     }
 

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -757,6 +757,8 @@ mod tests {
             rig_roll: 0.0,
             sync_offset: 0,
             field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
         }
     }
 

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -53,6 +53,8 @@ fn test_calibration() -> MatchCalibration {
         rig_roll: 0.0,
         sync_offset: 0,
         field_roi: None,
+        lens_correction_amount: 1.0,
+        blend_width: 0.05,
     }
 }
 

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -488,7 +488,20 @@ impl AppState {
         let (Some(cal), Some(path)) = (&self.calibration, &self.calibration_path) else {
             return Err("No calibration or path to save".into());
         };
-        let json = serde_json::to_string_pretty(cal).map_err(|e| format!("serialize: {e}"))?;
+        // `self.calibration` already tracks layout, rig tilt/roll and sync.
+        // The per-camera lens intrinsics, seam blend, and lens-correction
+        // strength live on the live renderer/AppState (kept off the struct so
+        // slider ticks stay cheap), so fold them in before writing - otherwise
+        // hand-tuned lens and seam values are silently lost on reload.
+        let mut out = cal.clone();
+        out.lens_correction_amount = self.lens_correction_amount;
+        if let Some(bridge) = self.bridge.as_ref() {
+            let pipeline = bridge.renderer().pipeline();
+            out.left = pipeline.calibration().left.clone();
+            out.right = pipeline.calibration().right.clone();
+            out.blend_width = pipeline.viewport().blend_width;
+        }
+        let json = serde_json::to_string_pretty(&out).map_err(|e| format!("serialize: {e}"))?;
         std::fs::write(path, json).map_err(|e| format!("write {}: {e}", path.display()))?;
         log::info!("Saved calibration to {}", path.display());
         Ok(())
@@ -2501,8 +2514,14 @@ fn main() -> anyhow::Result<()> {
     });
 
     let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
     app.on_changed_blend_width(move |w| {
         state_ref.borrow_mut().set_blend_width(w);
+        // Seam blend is persisted with the calibration, so a change is
+        // unsaved work - surface the Save Calibration button.
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
     });
 
     let state_ref = Rc::clone(&state);
@@ -2618,7 +2637,11 @@ fn main() -> anyhow::Result<()> {
                 let mut s = state_ref.borrow_mut();
                 if let Some(app) = app_weak.upgrade() {
                     app.set_status_text("Calibration saved".into());
+                    // Clear BOTH dirty flags: the Save button is shown on
+                    // `cal-dirty || lens-dirty`, so leaving lens-dirty set
+                    // kept the button visible after a successful save.
                     app.set_cal_dirty(false);
+                    app.set_lens_dirty(false);
                     s.toasts.push(Severity::Info, "Calibration saved", "");
                     crate::toast::sync_to_ui(&s.toasts, &app);
                 }
@@ -2984,6 +3007,8 @@ fn main() -> anyhow::Result<()> {
         s.preview_dirty = true;
         if let Some(app) = app_weak.upgrade() {
             app.set_lens_correction_amount(clamped);
+            // Lens correction is persisted with the calibration.
+            app.set_cal_dirty(true);
         }
     });
 
@@ -3720,6 +3745,13 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 .bridge
                 .as_ref()
                 .map(|b| b.renderer().pipeline().viewport().blend_width);
+            // Lens-correction strength came in via the loaded calibration and
+            // the renderer was seeded with it at bridge creation; mirror it
+            // into AppState so a later save re-persists the right value.
+            let lens_correction = s.calibration.as_ref().map(|c| c.lens_correction_amount);
+            if let Some(lc) = lens_correction {
+                s.lens_correction_amount = lc;
+            }
 
             if let Some(app) = app_weak.upgrade() {
                 app.set_files_loaded(true);
@@ -3749,6 +3781,9 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 }
                 if let Some(bw) = blend_width {
                     app.set_blend_width(bw);
+                }
+                if let Some(lc) = lens_correction {
+                    app.set_lens_correction_amount(lc);
                 }
                 if let Some(cal) = s.calibration.as_ref() {
                     app.set_sync_offset(cal.sync_offset as i32);
@@ -3919,10 +3954,23 @@ fn handle_calibration_result(
                         .bridge
                         .as_ref()
                         .map(|b| b.renderer().pipeline().viewport().rig_tilt);
+                    // rig_roll was previously omitted here (only the manual
+                    // load restored it), so an auto-calibrated roll left the
+                    // slider at 0 while the preview was corrected - touching
+                    // it then snapped roll back to 0 and broke the cal.
+                    let rig_roll_rad = state
+                        .bridge
+                        .as_ref()
+                        .map(|b| b.renderer().pipeline().viewport().rig_roll);
                     let blend_width = state
                         .bridge
                         .as_ref()
                         .map(|b| b.renderer().pipeline().viewport().blend_width);
+                    let lens_correction =
+                        state.calibration.as_ref().map(|c| c.lens_correction_amount);
+                    if let Some(lc) = lens_correction {
+                        state.lens_correction_amount = lc;
+                    }
 
                     // Auto-save calibration next to the left video so
                     // it appears in Recent and can be reloaded.
@@ -3988,8 +4036,14 @@ fn handle_calibration_result(
                         if let Some(rt) = rig_tilt_rad {
                             app.set_rig_tilt(rt.to_degrees());
                         }
+                        if let Some(rr) = rig_roll_rad {
+                            app.set_rig_roll(rr.to_degrees());
+                        }
                         if let Some(bw) = blend_width {
                             app.set_blend_width(bw);
+                        }
+                        if let Some(lc) = lens_correction {
+                            app.set_lens_correction_amount(lc);
                         }
                         if let Some(cal) = state.calibration.as_ref() {
                             app.set_sync_offset(cal.sync_offset as i32);

--- a/crates/reco-gui/src/preview.rs
+++ b/crates/reco-gui/src/preview.rs
@@ -73,11 +73,16 @@ impl PreviewBridge {
             gpu.backend_name(),
         );
 
+        // Lens-correction strength is consumed by the pipeline, not the
+        // viewport; capture it before `calibration` is moved into the
+        // renderer below.
+        let lens_correction_amount = calibration.lens_correction_amount;
+
         let viewport = ViewportConfig {
             width: viewport_width,
             height: viewport_height,
             fov_degrees: 75.0,
-            blend_width: 0.05,
+            blend_width: calibration.blend_width,
             rig_tilt: calibration.rig_tilt as f32,
             rig_roll: calibration.rig_roll as f32,
             ..ViewportConfig::default()
@@ -87,7 +92,7 @@ impl PreviewBridge {
         // the safe common denominator across backends (Vulkan/Metal/DX12).
         let texture_format = wgpu::TextureFormat::Rgba8Unorm;
 
-        let renderer = StitchRenderer::new(
+        let mut renderer = StitchRenderer::new(
             calibration,
             gpu,
             viewport,
@@ -96,6 +101,11 @@ impl PreviewBridge {
             texture_format,
             reco_core::render::renderer::InputFormat::Yuv420p,
         )?;
+        // Honour a persisted lens-correction strength (e.g. correction
+        // saved off) instead of the pipeline's full-correction default.
+        renderer
+            .pipeline_mut()
+            .set_lens_correction_amount(lens_correction_amount);
 
         Ok(Self {
             renderer,


### PR DESCRIPTION
## Description

`save_calibration()` serialized only the `MatchCalibration` struct, but the values the user edits in the GUI live elsewhere: lens-correction strength on AppState, and seam blend + per-camera lens intrinsics on the live renderer. So those edits were silently lost on reload. Reported by woojoung via the in-app bug tool (v0.5.2): "Lens correction and Seam blend values are not applied when saving JSON" (and an earlier "Auto Calibration Failed" / cannot keep a different left/right lens, the same persistence root cause).

Changes:
- Add `lens_correction_amount` + `blend_width` to `MatchCalibration` with backward-compatible default fns (1.0 / 0.05), matching the struct's existing `rig_tilt`/`sync_offset` serde-default pattern so existing calibration files keep loading.
- `save_calibration` folds the live renderer/AppState values into the written JSON.
- `PreviewBridge::new` seeds the renderer from the loaded calibration (seam blend was hard-coded to 0.05; lens correction was never restored).
- Restore both on the manual and auto-calibrate load paths.
- Restore `rig_roll` on the auto-calibrate path (it was omitted, so a calibrated roll showed 0 on the slider and snapped to 0 when the slider was touched).
- Dirty-flag fixes: editing seam blend or lens correction now shows the Save button; a successful save clears `lens_dirty` so the button disappears.
- Finiteness guard for the two new GPU-facing fields in `validate()`.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (workspace tests green; the single local failure, `reco-io` `matroska_reader_sees_partial_writes` under the non-default `stacked-output` feature, fails identically on clean `main` on this machine - an environment/ffmpeg-dependent concurrent-read test, unrelated to this change)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense (round-trip now asserts all persisted fields with non-default values; back-compat default test; `blend_width` finiteness test)

## Screenshots

UI-behavior fix - needs a manual save/reload round-trip test before merge (adjust lens correction + seam blend + a per-camera lens value, Save, reload, confirm they persist). Rendered output cannot be captured from CI/agent.
