### PR TITLE
fix: surface lens-profile fallback so failed auto-cal is diagnosable

### DIFF
--- a/crates/reco-calibrate/src/lens_database.rs
+++ b/crates/reco-calibrate/src/lens_database.rs
@@ -328,8 +328,12 @@ impl LensDatabase {
     ) -> Option<(CameraParams, LensProfileInfo)> {
         for p in &self.profiles {
             if p.width == width && p.height == height {
-                log::info!(
-                    "lens auto-detect: resolution-only match {}x{} from {} ({})",
+                log::warn!(
+                    "lens auto-detect: no camera match for {}x{}; falling back to a \
+                     GENERIC resolution-only profile from {} ({}). Its distortion model \
+                     may not match your lens, which can make calibration inaccurate or \
+                     fail. If results look wrong, supply a lens profile or tune the Lens \
+                     sliders manually.",
                     width,
                     height,
                     p.brand,

--- a/crates/reco-calibrate/src/pipeline.rs
+++ b/crates/reco-calibrate/src/pipeline.rs
@@ -187,7 +187,9 @@ impl CalibrationPipeline {
         )
         .ok_or_else(|| {
             CalibrateError::InvalidConfig(format!(
-                "no lens profile found for left camera ({}x{})",
+                "no lens profile matched the left camera at {}x{}: the video carries no \
+                 usable camera telemetry and no database profile shares this resolution. \
+                 Load a lens profile or record at a supported resolution.",
                 self.left_info.width, self.left_info.height
             ))
         })?;

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3915,6 +3915,13 @@ fn handle_calibration_result(
             }
             let left_profile = output.left_lens_profile.clone();
             let right_profile = output.right_lens_profile.clone();
+            // Either camera resolving to a Fallback profile means no real
+            // camera match was found - the user must know, because it is the
+            // most common reason calibration looks wrong or fails outright.
+            let used_fallback = [left_profile.as_ref(), right_profile.as_ref()]
+                .into_iter()
+                .flatten()
+                .any(|p| matches!(p.source, ProfileSource::Fallback));
             match state.init_with_calibration(output.calibration) {
                 Ok(true) => {
                     let fps = state.playback.fps();
@@ -4068,6 +4075,23 @@ fn handle_calibration_result(
                                     "{:.0}% confidence ({total_matches} matches). \
                                      Try recording with more camera overlap.",
                                     confidence * 100.0
+                                ),
+                            );
+                            crate::toast::sync_to_ui(&state.toasts, &app);
+                        }
+                        if used_fallback {
+                            log::warn!(
+                                "calibration used a GENERIC fallback lens profile (no \
+                                 camera match at {in_w}x{in_h}); stitch quality may be \
+                                 poor and the optimizer can fail to converge"
+                            );
+                            state.toasts.push(
+                                Severity::Warn,
+                                "Using a generic lens profile",
+                                format!(
+                                    "No lens profile matched your camera at {in_w}x{in_h}, \
+                                     so a generic one was used. If the stitch looks wrong, \
+                                     load a lens profile or adjust the Lens sliders."
                                 ),
                             );
                             crate::toast::sync_to_ui(&state.toasts, &app);


### PR DESCRIPTION
## Description

When no telemetry or database profile matches a camera, `detect_profile` silently falls back to a generic resolution-only profile whose distortion model often does not fit the real lens. That is the common cause of "Auto Calibration Failed" with no user-facing signal (reported by woojoung, v0.5.0).

Transparency change, no schema/API change:
- `lens_database.rs`: the fallback log is escalated from `info` to a story-telling `warn` that names the risk and the remedy.
- `main.rs`: a non-blocking `Warn` toast when auto-calibrate resolves either camera to a `Fallback` profile (mirrors the existing low-confidence toast).
- `pipeline.rs`: the "no lens profile" error now explains the cause (no telemetry, no resolution match) and the fix (load a profile / supported resolution); it already surfaces in the GUI failure toast.

Deliberately out of scope: the pre-calibration profile-picker UI, and carrying fallback context through the optimizer-failure error path (noted follow-up).

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (no new tests; change is logging + a GUI toast + an error string)
- [x] clippy + fmt verified locally on the changed crates (`reco-calibrate` lib, `reco-gui`); CI runs the full `--all-targets` suite on this branch
- [ ] Tests where it made sense (N/A; needs a live GUI check that the toast/warn appear)

## Screenshots

Needs a live check: run auto-calibrate on a clip with no matching lens profile (or stripped telemetry) and confirm the "Using a generic lens profile" toast and the `warn` log appear.
