### PR TITLE
fix: consolidate duplicate calibration save buttons

### DIFF
--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -1313,18 +1313,15 @@ export component RecoApp inherits Window {
                             changed(v) => { root.changed-cal-x-ty(v); }
                         }
 
-                        HorizontalLayout {
-                            spacing: 8px;
-                            Button {
-                                text: "Save Cal & Lens";
-                                enabled: root.cal-dirty;
-                                clicked => { root.save-calibration(); }
-                            }
-                            Button {
-                                text: "Reset";
-                                enabled: root.cal-dirty;
-                                clicked => { root.reset-calibration(); }
-                            }
+                        // Saving lives in one place: the "Save Calibration"
+                        // button in the Files-panel Calibration card (enabled on
+                        // cal/lens dirty, saves the whole calibration incl. lens
+                        // + blend). This section keeps only the contextual
+                        // layout Reset so there is no duplicate save button.
+                        Button {
+                            text: "Reset";
+                            enabled: root.cal-dirty;
+                            clicked => { root.reset-calibration(); }
                         }
                     }
 


### PR DESCRIPTION
## Description

Two buttons invoked the **same** `save-calibration()` action:
- "Save Calibration" - primary, in the Files-panel Calibration card (enabled on `cal-dirty || lens-dirty`).
- "Save Cal & Lens" - buried in the collapsed Calibration section of the Controls panel (enabled on `cal-dirty` only, so it stayed **disabled** when only the lens sliders were edited).

Two names and inconsistent enable logic for one action - confusing, and the lens-tab one was effectively a bug. Drop the buried duplicate; keep the single "Save Calibration" (since #358 it persists the whole calibration: layout + rig + sync + per-camera lens + seam blend + lens correction) and the contextual layout "Reset".

Slint-only; no Rust/logic change (both buttons already called the same callback).

## Checklist

- [x] I self-reviewed this change
- [x] `cargo check -p reco-gui` passes (Slint compiles)
- [x] No logic change; both buttons already invoked `save-calibration()`
- [ ] Quick visual check pending

## Screenshots

Visual change: the duplicate save button in the Controls-panel Calibration section is gone; saving is the single "Save Calibration" in the Files-panel Calibration card.
