### PR TITLE
fix: preview duration spans all concat segments (#361)

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -516,8 +516,11 @@ impl AppState {
 
     /// Check if all three files are selected and try to initialize.
     fn try_init(&mut self) -> Result<bool, String> {
+        // Open playback from the full InputPath (all concat segments) so the
+        // timeline duration spans every file, not just the first. left_path/
+        // right_path stay single (first segment) for lens/calibration.
         let (left, right, cal_path) =
-            match (&self.left_path, &self.right_path, &self.calibration_path) {
+            match (&self.left_input, &self.right_input, &self.calibration_path) {
                 (Some(l), Some(r), Some(c)) => (l.clone(), r.clone(), c.clone()),
                 _ => return Ok(false),
             };
@@ -546,9 +549,9 @@ impl AppState {
 
     /// Initialize preview from a calibration result (no file needed).
     fn init_with_calibration(&mut self, cal: MatchCalibration) -> Result<bool, String> {
-        let (left, right) = match (&self.left_path, &self.right_path) {
+        let (left, right) = match (&self.left_input, &self.right_input) {
             (Some(l), Some(r)) => (l.clone(), r.clone()),
-            _ => return Err("Both video paths required".into()),
+            _ => return Err("Both video inputs required".into()),
         };
 
         let sync_offset = cal.sync_offset;
@@ -833,7 +836,7 @@ impl AppState {
         if let Some(cal) = self.calibration.as_mut() {
             cal.sync_offset = offset;
         }
-        if let (Some(left), Some(right)) = (&self.left_path, &self.right_path) {
+        if let (Some(left), Some(right)) = (&self.left_input, &self.right_input) {
             let left = left.clone();
             let right = right.clone();
             if let Err(e) = self.playback.open(&left, &right, offset) {

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3746,6 +3746,10 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
     if let Some(app) = app_weak.upgrade() {
         sync_segments(&s, &app);
     }
+    // Capture the pre-init clip length so we can distinguish an input
+    // change (new load / appended segments) from a calibration-only
+    // reload further down.
+    let prev_total = s.playback.total_frames();
     match s.try_init() {
         Ok(true) => {
             let fps = s.playback.fps();
@@ -3805,6 +3809,21 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                 sync_frame_display(&app, s.playback.frame_index(), total, fps);
                 app.set_fps(fps as f32);
                 app.set_status_text(format!("Ready - {:.0} fps - {total} frames", fps).into());
+                // The export trim defaults to the whole clip. When the input
+                // length changes (new file, appended segments, or a shorter
+                // clip) a previously seeded trim end would stick to the old
+                // duration and silently truncate the export, so refresh it
+                // here. A manual trim survives a calibration-only reload,
+                // where the frame total is unchanged.
+                if prev_total != Some(total) && fps > 0.0 {
+                    let clip_secs = total as f32 / fps as f32;
+                    app.set_clip_duration_secs(clip_secs);
+                    app.set_export_start_secs(0.0);
+                    app.set_export_end_secs(clip_secs);
+                    log::info!(
+                        "Export trim reset to full clip ({clip_secs:.1}s, {total} frames) after input change"
+                    );
+                }
                 if let Some(img) = img {
                     app.set_preview_frame(img);
                 }

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -3,11 +3,11 @@
 //! Wraps an `FfmpegFileSource` with play/pause/step/seek state and
 //! frame timing. Delivers YUV frame data on demand, paced by FPS.
 
-use std::path::Path;
 use std::time::{Duration, Instant};
 
 use reco_core::source::{FrameSource, SourceError, SourceInfo, YuvData};
 use reco_io::adapters::FfmpegFileSource;
+use reco_io::stitch_job::InputPath;
 
 /// Playback state machine.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -65,13 +65,17 @@ impl Playback {
     }
 
     /// Open a stereo video source.
+    ///
+    /// Takes [`InputPath`] so multi-segment (concat) inputs span every file
+    /// in the timeline - total frames, seeking, and the duration range cover
+    /// the whole chain, not just the first segment.
     pub fn open(
         &mut self,
-        left_path: &Path,
-        right_path: &Path,
+        left: &InputPath,
+        right: &InputPath,
         sync_offset: i64,
     ) -> Result<(), SourceError> {
-        let source = FfmpegFileSource::open_with_offset(left_path, right_path, sync_offset)?;
+        let source = FfmpegFileSource::open_from_inputs(left, right, sync_offset)?;
         let info = source.info();
         let fps = info.fps;
         self.total_frames = source.total_frames();


### PR DESCRIPTION
## Description

Fixes #361. The GUI preview opened playback from only the **first** concat segment (`ps[0]`), so the timeline duration range covered just file #1 - seeking and trim couldn't reach later segments of a multi-file (auto-split GoPro/DJI) load. Export was already correct; it runs over the full `InputPath` via `open_from_inputs`.

`Playback::open` now takes `InputPath` and opens via `FfmpegFileSource::open_from_inputs`, so total frames, seeking, and the duration range span the whole chain. The three callers (`try_init`, `init_with_calibration`, `set_sync_offset`) pass the full `left_input`/`right_input` (already stored); `left_path`/`right_path` stay single (first segment) for lens/calibration, which is intentional.

## Checklist

- [x] I self-reviewed this change
- [x] clippy `-p reco-gui -D warnings` and fmt clean on the change
- [x] No schema change; reuses the existing `open_from_inputs` path that export already uses
- [x] Live check pending: load a multi-segment L/R set, confirm the timeline/duration spans all files and seeking reaches the last segment

## Screenshots

Behavior fix - verify on a Windows build with a real multi-segment load (e.g. several GoPro chapters per side): the duration range and seek bar should cover the full combined length, not just the first file.
