### PR TITLE
fix: release preview GPU pipeline during export to free VRAM (#360)

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3281,6 +3281,11 @@ fn main() -> anyhow::Result<()> {
         s.playback.pause();
         app.set_playing(false);
 
+        // Release the preview pipeline so its VRAM is free for the export;
+        // rebuilt on completion. run_export uses its own source.
+        log::info!("Releasing preview GPU pipeline to free VRAM for export");
+        s.reset_pipeline();
+
         app.set_export_error_text("".into());
         app.set_export_in_progress(true);
         app.set_export_progress(0.0);
@@ -3484,6 +3489,17 @@ fn main() -> anyhow::Result<()> {
                 s.export_rx = None;
                 if let Some(h) = s.export_thread.take() {
                     let _ = h.join();
+                }
+                // Rebuild the preview from the in-memory calibration, on any
+                // outcome.
+                if let Some(cal) = s.calibration.clone() {
+                    match s.init_with_calibration(cal) {
+                        Ok(_) => {
+                            s.preview_dirty = true;
+                            log::info!("Rebuilt live preview after export");
+                        }
+                        Err(e) => log::warn!("Failed to rebuild preview after export: {e}"),
+                    }
                 }
                 if let Some(app) = app_weak.upgrade() {
                     app.set_export_in_progress(false);

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -1065,6 +1065,21 @@ export component RecoApp inherits Window {
                         height: 100%;
                     }
 
+                    // Preview is released during export to free VRAM; show
+                    // that it is intentionally paused, not frozen/broken.
+                    if root.files-loaded && root.export-in-progress: Rectangle {
+                        width: 100%;
+                        height: 100%;
+                        background: #000000bb;
+                        Text {
+                            text: "Preview paused during export";
+                            color: #dddddd;
+                            font-size: 14px;
+                            horizontal-alignment: center;
+                            vertical-alignment: center;
+                        }
+                    }
+
                     // ROI vertex overlay (visible in lens preview mode).
                     // Absolute-positioned dots at each polygon vertex.
                     for idx in root.roi-points-x.length: Rectangle {


### PR DESCRIPTION
## Description

The real fix for #360 (pairs with #366, the engine-side auto-clamp safety net).

The GUI kept the live preview's GPU pipeline resident throughout export. `run_export` opens its own self-contained source and never touches the preview, so the pinned preview just starved VRAM - on 8 GB cards it left too little for the AI lookahead pool, failing tracked exports at 0 frames.

`on_start_export` now releases the preview pipeline (`reset_pipeline`) before spawning the export, and the export-completion handler rebuilds it from the **in-memory** calibration (preserving unsaved lens/blend edits) on every outcome (ok / cancelled / failed).

## Verification (headless, RTX 5070)

Measured a stitch pipeline's GPU VRAM at 3840x2880 - the issue's exact resolution, same DJI Osmo Action 4 footage: **peak 2828 MiB (~2.76 GB)**, matching the issue's reported **2.70 GB** preview footprint. Releasing that before export frees exactly the VRAM the lookahead pool (1.66-4.71 GB) was starved of on the 8 GB card that had only 1.57 GB free.

## Checklist

- [x] I self-reviewed this change
- [x] clippy `-p reco-gui -D warnings` and fmt clean
- [x] No schema/API change
- [ ] GUI runtime confirm (preview returns after export): logic compile-verified + code-reviewed; the VRAM mechanism + magnitude are verified headless above. A graphical run (Linux desktop or Surface) confirms the suspend/resume UX.

## Notes

Suspend = `reset_pipeline` (drops bridge + playback, keeps calibration/files); resume = `init_with_calibration` with the in-memory cal so unsaved edits survive. The preview view (pan/zoom/playhead) resets to default after export - acceptable; can preserve later if wanted.
