### PR TITLE
fix: show export failure reason in the status bar (#360)

### DIFF
--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -304,11 +304,10 @@ impl StitchSession {
                         let max_secs = max_n as f64 / fps;
                         let req_secs = n as f64 / fps;
                         return Err(SessionError::Config(format!(
-                            "--lookahead {req_secs:.1}s needs ~{:.1} GB VRAM for the frame pool \
-                             ({pool_size} slots @ {w}x{h}) but only ~{:.1} GB is free. The pool \
-                             stores decoded source-resolution frames, so reduce --lookahead to \
-                             <= {max_secs:.1}s, use lower-resolution source footage, or free GPU \
-                             memory, then retry. (Output resolution does not affect this pool.)",
+                            "not enough VRAM for a {req_secs:.1}s lookahead: reduce the lookahead \
+                             to <= {max_secs:.1}s, use lower-resolution source footage, or free \
+                             GPU memory. The frame pool needs ~{:.1} GB ({pool_size} slots @ \
+                             {w}x{h}) but only ~{:.1} GB is free.",
                             required as f64 / 1e9,
                             free as f64 / 1e9,
                         )));

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -335,7 +335,6 @@ pub fn run_export(
                 info.fps as f32,
                 source.is_gpu_resident(),
             );
-            let is_failure = !matches!(&result, Ok(true));
             let banner: String = match result {
                 Ok(true) => "AI tracking: active".into(),
                 Ok(false) => {
@@ -348,10 +347,11 @@ pub fn run_export(
             let weak = status_weak.clone();
             let _ = slint::invoke_from_event_loop(move || {
                 if let Some(app) = weak.upgrade() {
-                    if is_failure {
-                        app.set_export_status_text(banner.clone().into());
-                    }
-                    app.set_status_text(banner.into());
+                    // Banner goes to the export status only, never the main
+                    // status bar. This async set can land after the export
+                    // completion handler and would otherwise clobber the final
+                    // outcome (e.g. the VRAM error) shown there.
+                    app.set_export_status_text(banner.into());
                 }
             });
         });

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3515,7 +3515,6 @@ fn main() -> anyhow::Result<()> {
                         }
                         ExportOutcome::Failed(err) => {
                             app.set_export_status_text("".into());
-                            app.set_status_text("Export failed".into());
                             let (title, body) = match &err {
                                 reco_io::stitch_job::StitchError::EmptyOutput { .. } => (
                                     "Export produced no video",
@@ -3529,11 +3528,19 @@ fn main() -> anyhow::Result<()> {
                                     "Calibration error",
                                     e.clone(),
                                 ),
+                                reco_io::stitch_job::StitchError::Session(
+                                    reco_core::session::types::SessionError::Config(detail),
+                                ) => ("Export failed", detail.clone()),
                                 other => (
                                     "Export failed",
                                     format!("{other}"),
                                 ),
                             };
+                            // Build the detailed status now (body is moved into
+                            // the toast below) and apply it AFTER sync_to_ui,
+                            // whose status-bar fallback would otherwise replace
+                            // it with the generic toast title.
+                            let status = format!("Export failed - {body}");
                             let msg = format!("{err}");
                             if let Some(ref t) = s.telemetry {
                                 let codec = app.get_export_codec().to_string();
@@ -3541,6 +3548,7 @@ fn main() -> anyhow::Result<()> {
                             }
                             s.toasts.push(Severity::Error, title, body);
                             crate::toast::sync_to_ui(&s.toasts, &app);
+                            app.set_status_text(status.into());
                         }
                     }
                 }

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -1480,6 +1480,11 @@ export component RecoApp inherits Window {
                     color: #666;
                     font-size: 11px;
                     vertical-alignment: center;
+                    // Status bar is the primary error channel (toasts are
+                    // broken), so long failure messages must stay readable:
+                    // wrap onto extra lines instead of clipping the tail.
+                    wrap: word-wrap;
+                    horizontal-stretch: 1;
                 }
 
                 if root.export-in-progress: Text {
@@ -1505,8 +1510,6 @@ export component RecoApp inherits Window {
                     text: "Show in folder";
                     clicked => { root.show-in-folder(root.last-output-path); }
                 }
-
-                if !root.export-in-progress: Rectangle { horizontal-stretch: 1; }
 
                 if !root.export-in-progress && root.telem-fps-avg > 0: Text {
                     text: round(root.telem-fps-avg) + " / " + round(root.telem-fps-recent) + " fps";


### PR DESCRIPTION
## Description

Export failures were shown only via the toast overlay, which does not render reliably, so the status bar showed a generic "Export failed". The failure detail now goes to the status bar, and the lookahead VRAM-budget error gets a dedicated, action-first message ("not enough VRAM for a Ns lookahead: reduce the lookahead to <= Ms ..."). Part of #360.

## Checklist

- [x] Self-reviewed and follows project style
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] No schema or API change
