### PR TITLE
fix: keep appended video segments in FIFO order

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1486,7 +1486,6 @@ fn main() -> anyhow::Result<()> {
                         reco_io::stitch_job::InputPath::Chained(ps) => ps.clone(),
                     };
                     all.extend(paths);
-                    all.sort();
                     log::info!("Left: appended to {} total segments", all.len());
                     reco_io::stitch_job::InputPath::Chained(all)
                 }
@@ -1560,7 +1559,6 @@ fn main() -> anyhow::Result<()> {
                         reco_io::stitch_job::InputPath::Chained(ps) => ps.clone(),
                     };
                     all.extend(paths);
-                    all.sort();
                     log::info!("Right: appended to {} total segments", all.len());
                     reco_io::stitch_job::InputPath::Chained(all)
                 }


### PR DESCRIPTION
## Description

Appending video segments re-sorted the entire segment list lexically (`all.sort()`), so a newly appended clip could jump ahead of earlier ones instead of going to the end. Drop the re-sort on append so segments stay in insertion (FIFO) order; the initial multi-select is still name-sorted within the pick.

## Checklist

- [x] Self-reviewed and follows project style
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] No schema or API change
