### PR TITLE
feat(gui): drag-to-reorder video segments

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -848,6 +848,33 @@ impl AppState {
         }
     }
 
+    /// Re-open the playback source from the current chained inputs without
+    /// rebuilding the GPU pipeline. Used after a segment reorder: the
+    /// calibration and bridge are unchanged, only the decode order differs,
+    /// so the next render picks up the new order from the start.
+    fn reopen_source(&mut self) {
+        // Nothing consumes the source until a preview pipeline exists (e.g.
+        // before calibration), so skip the costly decoder open. try_init opens
+        // it in the current order once calibration is loaded.
+        if self.bridge.is_none() {
+            return;
+        }
+        let offset = self
+            .calibration
+            .as_ref()
+            .map(|c| c.sync_offset)
+            .unwrap_or(0);
+        if let (Some(left), Some(right)) = (&self.left_input, &self.right_input) {
+            let left = left.clone();
+            let right = right.clone();
+            if let Err(e) = self.playback.open(&left, &right, offset) {
+                log::error!("Failed to reopen playback after reorder: {e}");
+                return;
+            }
+            self.preview_dirty = true;
+        }
+    }
+
     fn set_rig_roll(&mut self, deg: f32) {
         if let Some(cal) = self.calibration.as_mut() {
             cal.rig_roll = (deg as f64).to_radians();
@@ -2134,6 +2161,88 @@ fn main() -> anyhow::Result<()> {
                 sync_segments(&s, &app);
             }
         }
+    });
+
+    // Drag-to-reorder within a side. The segments are the same cameras in a
+    // new temporal order, so the calibration still applies: reorder the
+    // chained paths and rebuild the preview. The frame total is unchanged,
+    // so the export trim is deliberately left as-is.
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_reorder_left_segment(move |from, to| {
+        let mut s = state_ref.borrow_mut();
+        let (from, to) = (from as usize, to as usize);
+        let new_first = match s.left_input {
+            Some(reco_io::stitch_job::InputPath::Chained(ref mut paths)) => {
+                if from < paths.len() && to < paths.len() && from != to {
+                    let p = paths.remove(from);
+                    paths.insert(to, p);
+                    Some(paths[0].clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let Some(first) = new_first else {
+            return;
+        };
+        log::info!("Left: reordered segment {from} -> {to}");
+        s.left_path = Some(first);
+        if let Some(app) = app_weak.upgrade() {
+            if let Some(reco_io::stitch_job::InputPath::Chained(ps)) = s.left_input.as_ref() {
+                app.set_left_path(
+                    format!("{} ({} segments)", display_name(&ps[0]), ps.len()).into(),
+                );
+            }
+            sync_segments(&s, &app);
+        }
+        drop(s);
+        // Re-open the preview source off the drop handler: the list reorders
+        // and repaints immediately, then the (slow) 4K concat re-probe runs on
+        // the next tick instead of freezing the UI on every drop.
+        let reopen = Rc::clone(&state_ref);
+        slint::Timer::single_shot(std::time::Duration::from_millis(40), move || {
+            reopen.borrow_mut().reopen_source();
+        });
+    });
+
+    let app_weak = app.as_weak();
+    let state_ref = Rc::clone(&state);
+    app.on_reorder_right_segment(move |from, to| {
+        let mut s = state_ref.borrow_mut();
+        let (from, to) = (from as usize, to as usize);
+        let new_first = match s.right_input {
+            Some(reco_io::stitch_job::InputPath::Chained(ref mut paths)) => {
+                if from < paths.len() && to < paths.len() && from != to {
+                    let p = paths.remove(from);
+                    paths.insert(to, p);
+                    Some(paths[0].clone())
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        let Some(first) = new_first else {
+            return;
+        };
+        log::info!("Right: reordered segment {from} -> {to}");
+        s.right_path = Some(first);
+        if let Some(app) = app_weak.upgrade() {
+            if let Some(reco_io::stitch_job::InputPath::Chained(ps)) = s.right_input.as_ref() {
+                app.set_right_path(
+                    format!("{} ({} segments)", display_name(&ps[0]), ps.len()).into(),
+                );
+            }
+            sync_segments(&s, &app);
+        }
+        drop(s);
+        // Re-open the preview source off the drop handler (see left handler).
+        let reopen = Rc::clone(&state_ref);
+        slint::Timer::single_shot(std::time::Duration::from_millis(40), move || {
+            reopen.borrow_mut().reopen_source();
+        });
     });
 
     // ── Preferences dialog callbacks ──

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -196,6 +196,128 @@ component ToastStack inherits Rectangle {
     }
 }
 
+// Per-side video segment list with drag-to-reorder (grip handle) and
+// per-row removal. Rows are a fixed height so pointer travel maps cleanly
+// to row offsets; the dragged row dims and the destination row is outlined
+// to preview where the segment will land.
+component SegmentList inherits Rectangle {
+    in property <[string]> segments;
+    in property <brush> card-bg;
+    callback remove(int);
+    callback reorder(int /* from */, int /* to */);
+
+    property <int> drag-from: -1; // row being dragged, or -1 when idle
+    property <int> drag-to: -1; // insertion gap [0..count] under the cursor
+    property <length> row-h: 26px;
+    property <length> row-gap: 4px;
+    property <length> rowstep: root.row-h + root.row-gap;
+    property <int> count: root.segments.length;
+
+    height: root.count > 0 ? root.count * root.rowstep - root.row-gap : 0px;
+
+    VerticalLayout {
+        spacing: root.row-gap;
+        for seg[idx] in root.segments: Rectangle {
+            height: root.row-h;
+            border-radius: 4px;
+            background: root.card-bg;
+            // The dragged row dims to a "ghost"; the drop position is shown
+            // by the insertion line below, not a per-row outline.
+            opacity: root.drag-from == idx ? 0.4 : 1.0;
+            HorizontalLayout {
+                padding-left: 2px;
+                padding-right: 4px;
+                spacing: 4px;
+                // Drag handle. Only active with 2+ segments to reorder.
+                Rectangle {
+                    width: 18px;
+                    Text {
+                        text: "⠿";
+                        color: grip.has-hover || root.drag-from == idx ? #8ae68a : #5a5a5a;
+                        font-size: 13px;
+                        horizontal-alignment: center;
+                        vertical-alignment: center;
+                    }
+                    grip := TouchArea {
+                        enabled: root.count > 1;
+                        mouse-cursor: grab;
+                        pointer-event(e) => {
+                            if (e.kind == PointerEventKind.down) {
+                                root.drag-from = idx;
+                                root.drag-to = idx;
+                            }
+                            if (e.kind == PointerEventKind.up) {
+                                // drag-to is an insertion gap [0..count]. Dropping
+                                // in either gap touching the source is a no-op;
+                                // otherwise map the gap to a row index, adjusting
+                                // for the source being removed first.
+                                if (root.drag-from != -1
+                                    && root.drag-to != root.drag-from
+                                    && root.drag-to != root.drag-from + 1) {
+                                    root.reorder(
+                                        root.drag-from,
+                                        root.drag-to > root.drag-from ? root.drag-to - 1 : root.drag-to);
+                                }
+                                root.drag-from = -1;
+                                root.drag-to = -1;
+                            }
+                            if (e.kind == PointerEventKind.cancel) {
+                                root.drag-from = -1;
+                                root.drag-to = -1;
+                            }
+                        }
+                        moved => {
+                            if (root.drag-from == idx) {
+                                // Nearest insertion gap to the cursor, in list
+                                // coordinates (the grabbed grip reports mouse-y
+                                // relative to its own row even past its bounds).
+                                root.drag-to = Math.max(0, Math.min(root.count,
+                                    Math.round((idx * root.rowstep + self.mouse-y) / root.rowstep)));
+                            }
+                        }
+                    }
+                }
+                Text {
+                    text: (idx + 1) + ". " + seg;
+                    color: #ccc;
+                    font-size: 10px;
+                    vertical-alignment: center;
+                    overflow: elide;
+                    horizontal-stretch: 1;
+                }
+                Rectangle {
+                    width: 18px;
+                    height: 18px;
+                    border-radius: 3px;
+                    background: rm.has-hover ? #3a2020 : transparent;
+                    Text { text: "×"; color: #888; font-size: 13px; horizontal-alignment: center; vertical-alignment: center; }
+                    rm := TouchArea { clicked => { root.remove(idx); } }
+                }
+            }
+        }
+    }
+
+    // Insertion line: during a drag, drawn in the gap where the segment will
+    // land - a thin accent bar with a dot on the leading edge. Hidden when the
+    // target gap touches the dragged row (those drops are no-ops).
+    if root.drag-from != -1 && root.drag-to != root.drag-from && root.drag-to != root.drag-from + 1: Rectangle {
+        x: 0;
+        y: max(0px, min(root.height - 2px, root.drag-to * root.rowstep - root.row-gap / 2));
+        width: root.width;
+        height: 2px;
+        background: #8ae68a;
+        border-radius: 1px;
+        Rectangle {
+            x: 0px;
+            y: -2px;
+            width: 6px;
+            height: 6px;
+            border-radius: 3px;
+            background: #8ae68a;
+        }
+    }
+}
+
 export component RecoApp inherits Window {
     title: "Reco Video Stitcher";
     preferred-width: 1280px;
@@ -542,6 +664,8 @@ export component RecoApp inherits Window {
     in-out property <[string]> right-segments: [];
     callback remove-left-segment(int);
     callback remove-right-segment(int);
+    callback reorder-left-segment(int /* from */, int /* to */);
+    callback reorder-right-segment(int /* from */, int /* to */);
     callback clear-left();
     callback clear-right();
     callback clear-calibration();
@@ -711,31 +835,11 @@ export component RecoApp inherits Window {
                             font-size: 11px;
                         }
 
-                        for seg[idx] in root.left-segments: Rectangle {
-                            height: 26px;
-                            border-radius: 4px;
-                            background: root.bg-card;
-                            HorizontalLayout {
-                                padding-left: 8px;
-                                padding-right: 4px;
-                                spacing: 4px;
-                                Text {
-                                    text: (idx + 1) + ". " + seg;
-                                    color: #ccc;
-                                    font-size: 10px;
-                                    vertical-alignment: center;
-                                    overflow: elide;
-                                    horizontal-stretch: 1;
-                                }
-                                Rectangle {
-                                    width: 18px;
-                                    height: 18px;
-                                    border-radius: 3px;
-                                    background: seg-rm.has-hover ? #3a2020 : transparent;
-                                    Text { text: "×"; color: #888; font-size: 13px; horizontal-alignment: center; vertical-alignment: center; }
-                                    seg-rm := TouchArea { clicked => { root.remove-left-segment(idx); } }
-                                }
-                            }
+                        SegmentList {
+                            segments: root.left-segments;
+                            card-bg: root.bg-card;
+                            remove(i) => { root.remove-left-segment(i); }
+                            reorder(f, t) => { root.reorder-left-segment(f, t); }
                         }
 
                         Rectangle { height: 1px; background: root.border-subtle; }
@@ -754,31 +858,11 @@ export component RecoApp inherits Window {
                             font-size: 11px;
                         }
 
-                        for seg[idx] in root.right-segments: Rectangle {
-                            height: 26px;
-                            border-radius: 4px;
-                            background: root.bg-card;
-                            HorizontalLayout {
-                                padding-left: 8px;
-                                padding-right: 4px;
-                                spacing: 4px;
-                                Text {
-                                    text: (idx + 1) + ". " + seg;
-                                    color: #ccc;
-                                    font-size: 10px;
-                                    vertical-alignment: center;
-                                    overflow: elide;
-                                    horizontal-stretch: 1;
-                                }
-                                Rectangle {
-                                    width: 18px;
-                                    height: 18px;
-                                    border-radius: 3px;
-                                    background: seg-rm2.has-hover ? #3a2020 : transparent;
-                                    Text { text: "×"; color: #888; font-size: 13px; horizontal-alignment: center; vertical-alignment: center; }
-                                    seg-rm2 := TouchArea { clicked => { root.remove-right-segment(idx); } }
-                                }
-                            }
+                        SegmentList {
+                            segments: root.right-segments;
+                            card-bg: root.bg-card;
+                            remove(i) => { root.remove-right-segment(i); }
+                            reorder(f, t) => { root.reorder-right-segment(f, t); }
                         }
 
                         if root.has-both-videos || root.calibration-path != "": Rectangle { height: 1px; background: root.border-subtle; }


### PR DESCRIPTION
Multi-file inputs can now be reordered by dragging a row's grip handle, instead of removing and re-adding segments to fix their order.

The per-side segment list is extracted into a shared `SegmentList` component (drag handle, drop-target highlight, remove). Reordering re-opens the preview source in the new order without rebuilding the GPU pipeline; calibration and the export trim are unchanged (same segments, new temporal order).