### PR TITLE
Keep pipeline decision lines at info (follow-up to #347)

### DIFF
--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -137,7 +137,7 @@ impl StitchPipeline {
             &scene,
         );
 
-        log::debug!(
+        log::info!(
             "Pipeline initialized: {}x{} output, GPU: {}",
             viewport.width,
             viewport.height,

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -258,7 +258,7 @@ impl FfmpegFileSource {
             .spawn(move || {
                 let mut dec = match ffmpeg::decoder::VideoDecoder::open_input(&input) {
                     Ok(d) => {
-                        log::debug!(
+                        log::info!(
                             "{label} decoder: {} ({}x{})",
                             d.backend(),
                             d.width(),

--- a/crates/reco-io/src/ffmpeg/decoder.rs
+++ b/crates/reco-io/src/ffmpeg/decoder.rs
@@ -1196,7 +1196,7 @@ fn try_hwaccel(
         return (backend, device_ref);
     }
 
-    log::debug!("No hardware decoder available - using software decode");
+    log::info!("No hardware decoder available - using software decode");
     (DecodeBackend::Software, ptr::null_mut())
 }
 

--- a/crates/reco-io/src/ffmpeg/mod.rs
+++ b/crates/reco-io/src/ffmpeg/mod.rs
@@ -22,11 +22,15 @@ pub fn init() {
 }
 
 fn configure_external_logging() {
+    // Default to ERROR (not FATAL): real FFmpeg encode/decode errors stay
+    // visible for diagnostics, while the chatty WARNING/INFO output (codec
+    // probes, "zero duration" stream notes, driver banners) is suppressed.
+    // Override with RECO_FFMPEG_LOG (e.g. `warning`, `info`, `debug`).
     let ffmpeg_level = std::env::var("RECO_FFMPEG_LOG")
         .ok()
         .as_deref()
         .map(ffmpeg_log_level)
-        .unwrap_or(ffmpeg_next::sys::AV_LOG_FATAL);
+        .unwrap_or(ffmpeg_next::sys::AV_LOG_ERROR);
 
     unsafe {
         ffmpeg_next::sys::av_log_set_level(ffmpeg_level);
@@ -44,6 +48,6 @@ fn ffmpeg_log_level(level: &str) -> i32 {
         "verbose" => ffmpeg_next::sys::AV_LOG_VERBOSE,
         "debug" => ffmpeg_next::sys::AV_LOG_DEBUG,
         "trace" => ffmpeg_next::sys::AV_LOG_TRACE,
-        _ => ffmpeg_next::sys::AV_LOG_FATAL,
+        _ => ffmpeg_next::sys::AV_LOG_ERROR,
     }
 }

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -186,7 +186,7 @@ impl SmartFileSource {
         let use_zero_copy = !hwaccel_disabled && backend_capable && gpu_capable;
 
         if !use_zero_copy && !hwaccel_disabled {
-            log::debug!(
+            log::info!(
                 "Zero-copy disabled: decode_backend={decode_backend} (capable={backend_capable}), \
                  gpu_zero_copy={gpu_capable}. Using CPU upload path."
             );


### PR DESCRIPTION
## Description

Follow-up to #347. That PR correctly quieted internal mechanics, but also demoted a few lines that report *decisions the pipeline makes*. The project's logging principle is that every behavior branch states what was chosen and why, so these four belong at `info`, not `debug`:

- per-eye decoder backend (`adapters.rs`) - aligns the CPU decode path with the zero-copy path, which already logs the decoder at `info`
- pipeline output resolution + GPU (`pipeline.rs`)
- zero-copy disabled, with the reason (`smart_source.rs`)
- hardware-vs-software decode fallback (`decoder.rs`)

Mechanics #347 moved to `debug` (device/feature dumps, dispatch and staging sizes) stay at `debug`.

Also defaults FFmpeg `av_log` to `ERROR` instead of `FATAL` so genuine codec errors stay visible (relevant to surfacing export failures); `RECO_FFMPEG_LOG` still overrides. The encoder/decoder probe-skips added in #347 mean `ERROR` does not reintroduce the CUDA/QSV probe noise on machines lacking those backends.

Net: `info` is the decision story end to end, `debug` is how it was carried out, `RUST_LOG` reopens everything.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense