### PR TITLE
Surface lookahead VRAM risk on the export slider

### DIFF
--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -31,6 +31,9 @@ mod frame_processing;
 mod run_loop;
 /// VRAM texture pool for GPU-resident frame buffering.
 pub(crate) mod vram_pool;
+/// Lookahead VRAM fit estimate, for the export UI risk slider and the
+/// pre-flight budget check.
+pub use vram_pool::{LookaheadFit, lookahead_fit};
 /// Configuration wiring (set/clear/attach methods).
 mod wiring;
 

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -298,9 +298,9 @@ impl StitchSession {
                     );
                     if required > budget {
                         let fps = source.info().fps.max(1.0);
-                        let max_slots = budget / per_slot.max(1);
-                        // pool_size = n + (n/2).max(1) + 2 ~= 1.5n + 2; invert for n.
-                        let max_n = max_slots.saturating_sub(2) * 2 / 3;
+                        // Shared with the export-panel risk slider so the
+                        // suggested ceiling here matches the slider's red zone.
+                        let max_n = super::vram_pool::max_lookahead_frames(per_slot, budget);
                         let max_secs = max_n as f64 / fps;
                         let req_secs = n as f64 / fps;
                         return Err(SessionError::Config(format!(

--- a/crates/reco-core/src/session/vram_pool.rs
+++ b/crates/reco-core/src/session/vram_pool.rs
@@ -242,3 +242,106 @@ pub fn estimate_vram(width: u32, height: u32, n_slots: usize, bytes_per_sample: 
     let per_frame = (y_bytes + uv_bytes) * 2; // 2 cameras
     per_frame * n_slots
 }
+
+/// Number of stereo pool slots required for `n` lookahead frames.
+///
+/// Mirrors the buffered-loop sizing (lookahead window + post-smoothing tail +
+/// slack). Keep in sync with `run_loop`'s `pool_size` and the D3D11 staging
+/// pool so the slider, the pre-flight check, and the actual allocation agree.
+pub fn lookahead_pool_slots(n: usize) -> usize {
+    let post_smooth_half = (n / 2).max(1);
+    n + post_smooth_half + 4
+}
+
+/// Largest lookahead frame count whose pool fits within `budget_bytes`.
+///
+/// Inverts [`lookahead_pool_slots`] against the per-slot cost from
+/// [`estimate_vram`]. Returns 0 when not even a minimal pool fits.
+pub fn max_lookahead_frames(per_slot_bytes: usize, budget_bytes: usize) -> usize {
+    let max_slots = budget_bytes / per_slot_bytes.max(1);
+    // lookahead_pool_slots(n) ~= 1.5*n + 4 for n >= 2; invert for n.
+    max_slots.saturating_sub(4) * 2 / 3
+}
+
+/// Lookahead VRAM fit thresholds, in seconds, for a source resolution and
+/// VRAM budget.
+///
+/// `safe_secs` is a comfortable ceiling (green zone upper bound); `max_secs`
+/// is the hard ceiling that still fits `budget_bytes` (red zone lower bound);
+/// the band between is "tight" (yellow). The lookahead pool stores
+/// source-resolution frames (they are re-rendered into the export), so the
+/// cost scales with source `width`x`height`, not output resolution.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LookaheadFit {
+    /// Comfortable ceiling with headroom (green zone upper bound), seconds.
+    pub safe_secs: f64,
+    /// Hard ceiling that still fits the budget (red zone lower bound), seconds.
+    pub max_secs: f64,
+}
+
+/// Headroom fraction for the comfortable (`safe`/green) ceiling.
+const LOOKAHEAD_SAFE_FRACTION: f64 = 0.75;
+
+/// Compute lookahead fit thresholds for a source resolution and VRAM budget.
+pub fn lookahead_fit(
+    width: u32,
+    height: u32,
+    bytes_per_sample: usize,
+    budget_bytes: usize,
+    fps: f64,
+) -> LookaheadFit {
+    let per_slot = estimate_vram(width, height, 1, bytes_per_sample);
+    let fps = fps.max(1.0);
+    let max_frames = max_lookahead_frames(per_slot, budget_bytes);
+    let safe_frames = max_lookahead_frames(
+        per_slot,
+        (budget_bytes as f64 * LOOKAHEAD_SAFE_FRACTION) as usize,
+    );
+    LookaheadFit {
+        safe_secs: safe_frames as f64 / fps,
+        max_secs: max_frames as f64 / fps,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pool_slots_match_buffered_sizing() {
+        assert_eq!(lookahead_pool_slots(0), 1 + 4); // post_smooth_half clamps to 1
+        assert_eq!(lookahead_pool_slots(10), 10 + 5 + 4);
+        assert_eq!(lookahead_pool_slots(44), 44 + 22 + 4);
+    }
+
+    #[test]
+    fn max_frames_zero_when_budget_too_small() {
+        let per_slot = estimate_vram(5312, 4648, 1, 1); // ~74 MB
+        assert_eq!(max_lookahead_frames(per_slot, 0), 0);
+        assert_eq!(max_lookahead_frames(per_slot, per_slot), 0); // < 4 slots
+    }
+
+    #[test]
+    fn max_frames_monotonic_in_budget() {
+        let per_slot = estimate_vram(1920, 1080, 1, 1);
+        let small = max_lookahead_frames(per_slot, 500_000_000);
+        let big = max_lookahead_frames(per_slot, 4_000_000_000);
+        assert!(big > small);
+    }
+
+    #[test]
+    fn fit_safe_below_max() {
+        // chefboyrd86's case: 5.3K (5312x4648), ~1.7 GB budget, 30 fps.
+        let fit = lookahead_fit(5312, 4648, 1, 1_700_000_000, 30.0);
+        assert!(fit.safe_secs <= fit.max_secs);
+        // His 1.5s default does NOT fit on this budget -> lands in the red zone.
+        assert!(fit.max_secs < 1.5);
+    }
+
+    #[test]
+    fn fit_high_budget_allows_default() {
+        // Plenty of VRAM: 1080p source, 8 GB budget -> default 1.5s is safe.
+        let fit = lookahead_fit(1920, 1080, 1, 8_000_000_000, 30.0);
+        assert!(fit.safe_secs >= 1.5);
+    }
+}

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -4014,6 +4014,26 @@ fn run_autoload(
     }
 }
 
+/// VRAM budget (bytes) available to the lookahead pool at export time.
+///
+/// The preview pipeline is released during export, so we estimate from total
+/// VRAM minus a reserve for decode/stitch/encode/AI rather than the
+/// preview-occupied "free" figure (which is also unreliable on some Windows
+/// GPUs). A test build can override the budget via `RECO_VRAM_BUDGET_GB` to
+/// exercise the risk zones on a large GPU.
+fn budget_for_lookahead(total_vram: u64) -> usize {
+    #[cfg(feature = "automation")]
+    if let Ok(gb) = std::env::var("RECO_VRAM_BUDGET_GB")
+        && let Ok(v) = gb.parse::<f64>()
+    {
+        return (v * 1e9) as usize;
+    }
+    // Fraction of total VRAM assumed usable for the pool once the preview is
+    // freed and decode/stitch/encode/AI have taken their share.
+    const SLIDER_VRAM_FRACTION: f64 = 0.70;
+    (total_vram as f64 * SLIDER_VRAM_FRACTION) as usize
+}
+
 fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<RecoApp>) {
     let mut s = state.borrow_mut();
     if let Some(app) = app_weak.upgrade() {
@@ -4073,6 +4093,33 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
 
             if let Some(app) = app_weak.upgrade() {
                 app.set_files_loaded(true);
+                // Lookahead VRAM risk thresholds for the export slider. The
+                // pool stores source-resolution frames (re-rendered into the
+                // export), so the ceiling scales with source resolution, not
+                // output. Budget = total VRAM minus a reserve for
+                // decode/stitch/encode/AI; the preview is freed during export,
+                // so it is not counted here.
+                match s
+                    .bridge
+                    .as_ref()
+                    .and_then(|b| b.renderer().gpu().available_vram())
+                {
+                    Some((_free, total)) if total > 0 && in_w > 0 && in_h > 0 => {
+                        let budget = budget_for_lookahead(total);
+                        let fit = reco_core::session::lookahead_fit(in_w, in_h, 1, budget, fps);
+                        app.set_lookahead_green_max(fit.safe_secs as f32);
+                        app.set_lookahead_red_min(fit.max_secs as f32);
+                        app.set_lookahead_risk_active(true);
+                        log::info!(
+                            "Lookahead VRAM fit: safe<={:.1}s tight<={:.1}s @ {in_w}x{in_h}, \
+                             budget {:.1} GB",
+                            fit.safe_secs,
+                            fit.max_secs,
+                            budget as f64 / 1e9,
+                        );
+                    }
+                    _ => app.set_lookahead_risk_active(false),
+                }
                 app.set_has_roi(
                     s.calibration
                         .as_ref()

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -4117,6 +4117,21 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                             fit.max_secs,
                             budget as f64 / 1e9,
                         );
+                        // VRAM-aware default: if the current lookahead would
+                        // not fit (red zone = guaranteed export failure), seed
+                        // it to the comfortable value instead. This only
+                        // rescues an unusable value; a lookahead that already
+                        // fits is left as the user set it, so a deliberate
+                        // in-budget choice is never overridden.
+                        if app.get_export_lookahead_secs() as f64 > fit.max_secs {
+                            let safe = fit.safe_secs as f32;
+                            app.set_export_lookahead_secs(safe);
+                            log::info!(
+                                "Lookahead lowered to {safe:.1}s to fit VRAM \
+                                 (chosen value exceeded the {:.1}s ceiling)",
+                                fit.max_secs,
+                            );
+                        }
                     }
                     _ => app.set_lookahead_risk_active(false),
                 }

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -48,6 +48,123 @@ component LabeledSlider inherits VerticalLayout {
     }
 }
 
+/// Lookahead slider with VRAM risk colouring. Green/yellow/red zones show
+/// where the chosen lookahead stops fitting GPU memory for the loaded source
+/// resolution, so the user sees the risk and stays in control instead of
+/// meeting a silent clamp or a post-hoc export failure. Thresholds (in the
+/// same units as `value`) come from the engine's VRAM fit estimate; when
+/// they are unknown the track falls back to a neutral colour.
+component VramRiskSlider inherits VerticalLayout {
+    in property <string> label;
+    in property <float> minimum: 0;
+    in property <float> maximum: 1;
+    in-out property <float> value;
+    in property <string> suffix: "";
+    in property <float> green-max;
+    in property <float> red-min;
+    in property <bool> risk-active: false;
+    callback changed(float);
+
+    spacing: 3px;
+
+    function apply-x(mx: length, w: length) {
+        root.value = clamp(
+            root.minimum + (mx / w) * (root.maximum - root.minimum),
+            root.minimum, root.maximum);
+        root.changed(root.value);
+    }
+
+    HorizontalLayout {
+        spacing: 6px;
+        Text {
+            text: root.label;
+            color: #bbb;
+            font-size: 11px;
+            vertical-alignment: center;
+            horizontal-stretch: 1;
+        }
+        Text {
+            text: !root.risk-active ? ""
+                : root.value <= root.green-max ? "safe"
+                : root.value <= root.red-min ? "tight" : "may fail";
+            color: !root.risk-active ? #888
+                : root.value <= root.green-max ? #5cd65c
+                : root.value <= root.red-min ? #e6c14d : #e35c5c;
+            font-size: 11px;
+            vertical-alignment: center;
+        }
+        Text {
+            text: round(root.value * 10) / 10 + root.suffix;
+            color: #888;
+            font-size: 11px;
+            vertical-alignment: center;
+        }
+    }
+
+    track := Rectangle {
+        height: 16px;
+        border-radius: 8px;
+        clip: true;
+        background: #2b2b2b;
+        property <float> gfrac: clamp(root.green-max / max(root.maximum, 0.0001), 0.0, 1.0);
+        property <float> rfrac: clamp(root.red-min / max(root.maximum, 0.0001), 0.0, 1.0);
+
+        if root.risk-active: Rectangle {
+            x: 0;
+            y: 0;
+            height: track.height;
+            width: track.width * track.gfrac;
+            background: #2e7d32;
+        }
+        if root.risk-active: Rectangle {
+            x: track.width * track.gfrac;
+            y: 0;
+            height: track.height;
+            width: max(0px, track.width * (track.rfrac - track.gfrac));
+            background: #b8932a;
+        }
+        if root.risk-active: Rectangle {
+            x: track.width * track.rfrac;
+            y: 0;
+            height: track.height;
+            width: max(0px, track.width * (1.0 - track.rfrac));
+            background: #b13b2e;
+        }
+
+        handle := Rectangle {
+            width: 14px;
+            height: 14px;
+            border-radius: 7px;
+            background: #ffffff;
+            border-width: 2px;
+            border-color: #222;
+            y: (track.height - self.height) / 2;
+            x: clamp((root.value - root.minimum) / max(root.maximum - root.minimum, 0.0001), 0.0, 1.0)
+                * (track.width - self.width);
+        }
+
+        TouchArea {
+            mouse-cursor: pointer;
+            moved => {
+                if (self.pressed) {
+                    root.apply-x(self.mouse-x, track.width);
+                }
+            }
+            pointer-event(e) => {
+                if (e.kind == PointerEventKind.down) {
+                    root.apply-x(self.mouse-x, track.width);
+                }
+            }
+        }
+    }
+
+    if root.risk-active: Text {
+        text: "fits ≈ " + (round(root.red-min * 10) / 10) + "s here (VRAM)";
+        color: #777;
+        font-size: 10px;
+    }
+}
+
 /// Collapsible section header with clear hover feedback.
 component SectionHeader inherits Rectangle {
     in property <string> title;
@@ -426,6 +543,12 @@ export component RecoApp inherits Window {
     // dead-zone assumes it is active to absorb its latency.
     in-out property <string> export-panner-preset: "broadcast";
     in-out property <float> export-lookahead-secs: 1.5;
+    // Lookahead VRAM risk thresholds (seconds) for the export slider, set from
+    // the engine's fit estimate once footage + GPU are known. green-max =
+    // comfortable ceiling, red-min = hard ceiling that still fits VRAM.
+    in-out property <float> lookahead-green-max: 0;
+    in-out property <float> lookahead-red-min: 0;
+    in-out property <bool> lookahead-risk-active: false;
     in-out property <string> export-framing: "action";
     in-out property <bool> export-lock-pitch: false;
     in-out property <string> export-cluster-mode: "density";
@@ -2478,14 +2601,18 @@ export component RecoApp inherits Window {
                         }
 
                         // Lookahead is the dominant smoothness lever; give it
-                        // a full-width slider. 0 disables the buffer.
-                        LabeledSlider {
+                        // a full-width slider. 0 disables the buffer. The VRAM
+                        // risk colouring warns when the chosen value won't fit
+                        // GPU memory for the loaded source resolution.
+                        VramRiskSlider {
                             label: "Lookahead (smoothness)";
                             minimum: 0.0;
                             maximum: 2.5;
                             value <=> root.export-lookahead-secs;
                             suffix: "s";
-                            decimals: 1;
+                            green-max: root.lookahead-green-max;
+                            red-min: root.lookahead-red-min;
+                            risk-active: root.lookahead-risk-active;
                         }
 
                         panner-advanced := SectionHeader {


### PR DESCRIPTION
## Description

The lookahead frame pool stores **source-resolution** frames (they are re-rendered into the export), so high-resolution footage (e.g. GoPro 5.3K) on a modest GPU exceeds VRAM and the export pre-flight hard-fails. Community users hit this with nothing but a failed export to go on - the source-res pool can't be downscaled, so the only real lever is the lookahead value itself.

This surfaces the limit on the export panel's Lookahead slider instead of hiding it. The track shows green/yellow/red zones for the loaded source resolution and the GPU's VRAM budget, with a `safe`/`tight`/`may fail` label and a "fits ≈ Xs here (VRAM)" hint. The user sees the risk and stays in control - no silent clamp, no post-hoc surprise. Choosing a red value and exporting still fails with the existing pre-flight error, which now reuses the same fit math so its suggested ceiling matches the red zone.

### Changes
- **reco-core**: `lookahead_fit` / `max_lookahead_frames` / `lookahead_pool_slots` in `session::vram_pool`, shared by the slider and the run-loop pre-flight (with unit tests); re-exported as `reco_core::session::lookahead_fit`. The pre-flight now uses the shared helper.
- **reco-gui**: `VramRiskSlider` component; thresholds computed on load from total VRAM minus a reserve (the preview is released during export, so it is not counted). `RECO_VRAM_BUDGET_GB` overrides the budget on `automation` builds for headless testing.

Verified headlessly (Xvfb) on 5.3K footage with a forced 2 GB budget: the default 1.5s shows red "may fail" ("fits ≈ 0.8s"), dragging to 0.3s shows green "safe".

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense