### PR TITLE
chore: bump crates to 0.5.3-beta.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "reco-autocam"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "log",
  "reco-core",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "reco-calibrate"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "approx",
  "argmin",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "reco-cli"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "reco-control"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "log",
  "reco-core",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "reco-core"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "approx",
  "ash",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "reco-detect"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "block2 0.6.2",
  "bytemuck",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "reco-gui"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "reco-io"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "directories",
  "ffmpeg-next",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "reco-obs"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 dependencies = [
  "bindgen",
  "cc",

--- a/crates/reco-autocam/Cargo.toml
+++ b/crates/reco-autocam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-autocam"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-calibrate/Cargo.toml
+++ b/crates/reco-calibrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-calibrate"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-cli/Cargo.toml
+++ b/crates/reco-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-cli"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 description = "CLI tool for Reco panoramic video stitching"

--- a/crates/reco-control/Cargo.toml
+++ b/crates/reco-control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-control"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-core/Cargo.toml
+++ b/crates/reco-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-core"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 description = "GPU-accelerated panoramic video stitching engine"

--- a/crates/reco-detect/Cargo.toml
+++ b/crates/reco-detect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-detect"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-gui"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-io/Cargo.toml
+++ b/crates/reco-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-io"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 description = "Pluggable frame I/O backends for Reco (FFmpeg, GStreamer, ...)"

--- a/crates/reco-obs/Cargo.toml
+++ b/crates/reco-obs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-obs"
-version = "0.5.3-beta.1"
+version = "0.5.3-beta.2"
 edition.workspace = true
 rust-version.workspace = true
 description = "OBS Studio source plugin for Reco panoramic video stitching"


### PR DESCRIPTION
Version bump for the **0.5.3-beta.2** pre-release.

Since beta.1 this adds, on top of main: quieter default logging (#347) + the decision-story refinement (#372), and the export lookahead VRAM risk slider with a VRAM-safe default (#374) - which unblocks high-resolution footage (e.g. GoPro 5.3K) on modest GPUs that previously hit a hard export failure on the lookahead pool.

Bumps all 9 crates `0.5.3-beta.1` -> `0.5.3-beta.2` and refreshes `Cargo.lock`. Tag `v0.5.3-beta.2` after merge to trigger the release build.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense