### PR TITLE
Base lookahead VRAM pre-flight on total VRAM, not the unreliable free figure

### DIFF
--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -33,7 +33,7 @@ mod run_loop;
 pub(crate) mod vram_pool;
 /// Lookahead VRAM fit estimate, for the export UI risk slider and the
 /// pre-flight budget check.
-pub use vram_pool::{LookaheadFit, lookahead_fit};
+pub use vram_pool::{LookaheadFit, lookahead_budget_bytes, lookahead_fit};
 /// Configuration wiring (set/clear/attach methods).
 mod wiring;
 

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -286,15 +286,19 @@ impl StitchSession {
             // VramPool::new plus graceful teardown for any slip-through.
             match self.core.pipeline().gpu().available_vram() {
                 Some((free, total)) => {
-                    const BUDGET_FRACTION: f64 = 0.80;
-                    let budget = (free as f64 * BUDGET_FRACTION) as usize;
+                    // Budget from total VRAM, not the driver's "free" figure:
+                    // the latter is unreliable (can read 0 on a multi-GB card
+                    // mid-session) and would block viable exports. Shared with
+                    // the export-panel risk slider so the two always agree.
+                    // Over-allocation is caught gracefully at pool creation.
+                    let budget = super::vram_pool::lookahead_budget_bytes(total);
                     log::info!(
-                        "VRAM budget: {:.2} GB free / {:.2} GB total; lookahead pool needs \
-                         {:.2} GB ({pool_size} slots @ {w}x{h}), keeping {:.0}% headroom",
-                        free as f64 / 1e9,
+                        "VRAM budget: {:.2} GB usable of {:.2} GB total ({:.2} GB reported free); \
+                         lookahead pool needs {:.2} GB ({pool_size} slots @ {w}x{h})",
+                        budget as f64 / 1e9,
                         total as f64 / 1e9,
+                        free as f64 / 1e9,
                         required as f64 / 1e9,
-                        (1.0 - BUDGET_FRACTION) * 100.0,
                     );
                     if required > budget {
                         let fps = source.info().fps.max(1.0);
@@ -307,9 +311,10 @@ impl StitchSession {
                             "not enough VRAM for a {req_secs:.1}s lookahead: reduce the lookahead \
                              to <= {max_secs:.1}s, use lower-resolution source footage, or free \
                              GPU memory. The frame pool needs ~{:.1} GB ({pool_size} slots @ \
-                             {w}x{h}) but only ~{:.1} GB is free.",
+                             {w}x{h}); usable budget is ~{:.1} GB of {:.1} GB total.",
                             required as f64 / 1e9,
-                            free as f64 / 1e9,
+                            budget as f64 / 1e9,
+                            total as f64 / 1e9,
                         )));
                     }
                 }

--- a/crates/reco-core/src/session/vram_pool.rs
+++ b/crates/reco-core/src/session/vram_pool.rs
@@ -282,6 +282,24 @@ pub struct LookaheadFit {
 /// Headroom fraction for the comfortable (`safe`/green) ceiling.
 const LOOKAHEAD_SAFE_FRACTION: f64 = 0.75;
 
+/// Fraction of total VRAM treated as usable for the lookahead pool.
+///
+/// The pool competes with decode surfaces, the stitch pipeline, the encoder,
+/// AI tensors, and the OS compositor, so part of total VRAM is reserved.
+const LOOKAHEAD_BUDGET_FRACTION: f64 = 0.70;
+
+/// VRAM budget (bytes) available to the lookahead pool, derived from *total*
+/// VRAM rather than the driver's "free" figure.
+///
+/// The free query is unreliable on some GPUs - it can report 0 bytes free on a
+/// multi-GB card mid-session, which would otherwise block a perfectly viable
+/// export. A total-based estimate is used instead, and over-allocation is
+/// caught gracefully at pool creation on every platform. Shared by the export
+/// pre-flight check and the GUI risk slider so the two always agree.
+pub fn lookahead_budget_bytes(total_vram: u64) -> usize {
+    (total_vram as f64 * LOOKAHEAD_BUDGET_FRACTION) as usize
+}
+
 /// Compute lookahead fit thresholds for a source resolution and VRAM budget.
 pub fn lookahead_fit(
     width: u32,
@@ -343,5 +361,17 @@ mod tests {
         // Plenty of VRAM: 1080p source, 8 GB budget -> default 1.5s is safe.
         let fit = lookahead_fit(1920, 1080, 1, 8_000_000_000, 30.0);
         assert!(fit.safe_secs >= 1.5);
+    }
+
+    #[test]
+    fn budget_is_total_based_and_reserves_headroom() {
+        // zzz's case: 5.52 GB total. A bogus free=0 must not zero the budget;
+        // the budget is derived from total and leaves a reserve.
+        let total = 5_520_000_000u64;
+        let budget = lookahead_budget_bytes(total);
+        assert!(budget > 0);
+        assert!(budget < total as usize); // reserves headroom
+        // The 2.49 GB pool from the forum report fits in the usable budget.
+        assert!(budget >= 2_490_000_000);
     }
 }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -4028,10 +4028,9 @@ fn budget_for_lookahead(total_vram: u64) -> usize {
     {
         return (v * 1e9) as usize;
     }
-    // Fraction of total VRAM assumed usable for the pool once the preview is
-    // freed and decode/stitch/encode/AI have taken their share.
-    const SLIDER_VRAM_FRACTION: f64 = 0.70;
-    (total_vram as f64 * SLIDER_VRAM_FRACTION) as usize
+    // Same budget the export pre-flight uses, so the slider's risk zones match
+    // exactly what the engine will accept.
+    reco_core::session::lookahead_budget_bytes(total_vram)
 }
 
 fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<RecoApp>) {


### PR DESCRIPTION
## Description

The export lookahead pre-flight gated on the driver's reported **free** VRAM (`free × 0.80`). On some GPUs that query is unreliable - it can report **0 bytes free on a multi-GB card** mid-session - so the pre-flight rejected a perfectly viable export, and the only workaround was restarting the app. It also disagreed with the new export-panel risk slider, which derives its zones from **total** VRAM: the slider could show "safe" while the engine refused to start.

This makes both use one shared budget derived from **total** VRAM (`lookahead_budget_bytes`, total minus a reserve). The slider and the pre-flight now always agree, and a bogus `free` reading can't block an export. If VRAM is genuinely insufficient, pool creation still fails gracefully (the `catch_unwind` guards on the Linux `VramPool` and the Windows D3D11 staging pool), so the optimistic budget can't crash - it degrades to the same clear error.

### Changes
- `session::vram_pool::lookahead_budget_bytes(total_vram)` - shared budget, re-exported as `reco_core::session::lookahead_budget_bytes`.
- run-loop pre-flight uses it (logs usable/total/reported-free for diagnostics) instead of `free × 0.80`.
- GUI `budget_for_lookahead` delegates to it, so the risk slider matches the engine exactly.

Reported on the forum: "VRAM budget: 0.00 GB free / 5.52 GB total ... closing and reopening the executable resolved it."

Verified with a real lookahead export (logs `VRAM budget: 8.64 GB usable of 12.34 GB total`, completes).

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense