### PR TITLE
fix(reco-core): reclaim D3D11VA staging VRAM across exports

### DIFF
--- a/crates/reco-cli/Cargo.toml
+++ b/crates/reco-cli/Cargo.toml
@@ -12,6 +12,13 @@ repository = "https://github.com/reco-project/video-stitcher"
 name = "reco"
 path = "src/main.rs"
 
+# Cross-export VRAM leak repro. Uses reco-autocam to drive the lookahead pool,
+# so it only builds when the `autocam` feature is on (skipped under
+# --no-default-features).
+[[example]]
+name = "vram_leak_repro"
+required-features = ["autocam"]
+
 [features]
 # Default gives autocam + ort (CPU) detection, matching
 # pre-refactor behavior. Jetson / custom builds opt out via

--- a/crates/reco-cli/examples/vram_leak_repro.rs
+++ b/crates/reco-cli/examples/vram_leak_repro.rs
@@ -1,0 +1,103 @@
+//! Repro harness for the cross-export VRAM leak.
+//!
+//! The GUI runs multiple exports per session; users on 8 GB GPUs report the
+//! second export starting VRAM-starved because the first export's GPU
+//! resources are not reclaimed. This runs [`StitchJob::run`] N times in ONE
+//! process and prints GPU free/used VRAM (via `nvidia-smi`) before and after
+//! each run, so a leak shows up as free VRAM that never recovers.
+//!
+//! Usage: `vram_leak_repro <left> <right> <cal.json> [runs=2] [max_frames=120]`
+
+use std::process::Command;
+use std::sync::atomic::AtomicBool;
+
+fn vram() -> String {
+    Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=memory.free,memory.used",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| format!("free/used MB = {}", s.trim()))
+        .unwrap_or_else(|| "nvidia-smi unavailable".into())
+}
+
+fn main() {
+    // Surface reco's `log::*` output (decode path, pool type, teardown) so the
+    // leak source is visible. Bridges `log` -> tracing like the real CLI does.
+    let _ = tracing_log::LogTracer::init();
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
+        )
+        .try_init();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 4 {
+        eprintln!(
+            "usage: {} <left> <right> <cal.json> [runs=2] [max_frames=120]",
+            args[0]
+        );
+        std::process::exit(2);
+    }
+    let left = args[1].clone();
+    let right = args[2].clone();
+    let cal = args[3].clone();
+    let runs: usize = args.get(4).and_then(|s| s.parse().ok()).unwrap_or(2);
+    let max_frames: u64 = args.get(5).and_then(|s| s.parse().ok()).unwrap_or(120);
+    // Optional: enable AI tracking + lookahead (allocates the lookahead pool,
+    // the resource the bug report blames for the ~3.9 GB cross-export leak).
+    let model = args.get(6).cloned();
+    let lookahead: f64 = args.get(7).and_then(|s| s.parse().ok()).unwrap_or(1.0);
+
+    let interrupted = AtomicBool::new(false);
+    println!(
+        "baseline   {}   (mode: {})",
+        vram(),
+        if model.is_some() {
+            "AI+lookahead"
+        } else {
+            "plain"
+        }
+    );
+
+    for run in 1..=runs {
+        println!("[run {run}] before: {}", vram());
+        let out = format!("vram_repro_run{run}.mp4");
+        let mut job = reco_io::StitchJob::new(left.as_str(), right.as_str(), cal.as_str(), &out)
+            .resolution(1920, 1080)
+            .max_frames(max_frames);
+
+        if let Some(ref model_path) = model {
+            let model_path = model_path.clone();
+            job = job.lookahead(lookahead);
+            job = job.on_session(move |session, source| {
+                let cfg = reco_autocam::AutocamConfig::new(&model_path)
+                    .with_tracking_mode(reco_autocam::TrackingMode::Field)
+                    // High interval: detection accuracy is irrelevant to the
+                    // leak test, and fewer detections = much faster runs.
+                    .with_detection_interval(30);
+                let fps = source.info().fps as f32;
+                let gpu = source.is_gpu_resident();
+                match reco_autocam::setup_autocam(session, &cfg, fps, gpu) {
+                    Ok(active) => println!("    autocam active={active}"),
+                    Err(e) => println!("    autocam setup failed: {e}"),
+                }
+            });
+        }
+
+        match job.run(&interrupted) {
+            Ok(r) => println!("[run {run}] OK: {} frames written", r.frames_processed),
+            Err(e) => println!("[run {run}] FAILED: {e}"),
+        }
+        println!("[run {run}] after:  {}", vram());
+    }
+    println!("final          {}", vram());
+    // If VRAM recovers after a delay, the leak is late thread/device teardown
+    // (decode threads exiting after run() returns); if it stays, it's a true leak.
+    std::thread::sleep(std::time::Duration::from_secs(6));
+    println!("final (+6s)    {}", vram());
+}

--- a/crates/reco-core/src/interop/cuda.rs
+++ b/crates/reco-core/src/interop/cuda.rs
@@ -980,7 +980,30 @@ pub struct CudaImportedNv12 {
 impl Drop for CudaImportedNv12 {
     fn drop(&mut self) {
         if let Ok(cuda) = cuda() {
+            // The staging pool drops on the session thread, not the decode
+            // thread that established the CUDA context, so a context may not be
+            // current here. Without one, the cleanup calls below fail and the
+            // import - which pins the D3D11 staging texture's VRAM - is never
+            // released (a permanent per-export leak on NVIDIA). Mirror
+            // `CudaKernel::drop` and ensure a context first.
+            if let Err(e) = cuda_ensure_context() {
+                log::warn!("CudaImportedNv12 drop: no CUDA context, leaking import: {e}");
+                return;
+            }
             unsafe {
+                // The mapped buffers from cuExternalMemoryGetMappedBuffer must
+                // be freed with cuMemFree *before* the external memory object is
+                // destroyed (CUDA driver API contract). Skipping this leaves the
+                // mappings live, so cuDestroyExternalMemory cannot release CUDA's
+                // reference to the shared texture and its VRAM never returns.
+                let y_rc = (cuda.cu_mem_free_v2)(self.y_ptr);
+                if y_rc != CUDA_SUCCESS {
+                    log::warn!("cuMemFree(Y 0x{:x}) failed: {y_rc}", self.y_ptr);
+                }
+                let uv_rc = (cuda.cu_mem_free_v2)(self.uv_ptr);
+                if uv_rc != CUDA_SUCCESS {
+                    log::warn!("cuMemFree(UV 0x{:x}) failed: {uv_rc}", self.uv_ptr);
+                }
                 let rc = (cuda.cu_destroy_external_memory)(self.ext_mem);
                 if rc != CUDA_SUCCESS {
                     log::warn!("cuDestroyExternalMemory failed: {rc}");

--- a/crates/reco-core/src/interop/d3d11.rs
+++ b/crates/reco-core/src/interop/d3d11.rs
@@ -275,22 +275,32 @@ impl D3d11StagingPool {
             };
 
             // Import into CUDA for AI detection (NVIDIA only, non-fatal).
-            let nv12_pitch = self.width as usize;
-            let cuda_import = crate::interop::cuda::cuda_import_d3d11_nv12(
-                handle.0,
-                self.width,
-                self.height,
-                nv12_pitch,
-            );
-            match &cuda_import {
-                Ok(m) => log::debug!(
-                    "CUDA imported staging slot {i}: Y=0x{:x} UV=0x{:x}",
-                    m.y_ptr,
-                    m.uv_ptr
-                ),
-                Err(e) => log::debug!("CUDA import for slot {i} skipped: {e}"),
-            }
-            cuda_imports.push(cuda_import.ok());
+            // Only when a CUDA-resident detector will actually read these
+            // pointers. Importing otherwise is pure waste: ~1 ms/slot of setup
+            // and an external-memory object per slot that must be torn down
+            // again on pool drop (the storage below is discarded when
+            // `enable_cuda` is false).
+            let cuda_import = if self.enable_cuda {
+                let nv12_pitch = self.width as usize;
+                let imported = crate::interop::cuda::cuda_import_d3d11_nv12(
+                    handle.0,
+                    self.width,
+                    self.height,
+                    nv12_pitch,
+                );
+                match &imported {
+                    Ok(m) => log::debug!(
+                        "CUDA imported staging slot {i}: Y=0x{:x} UV=0x{:x}",
+                        m.y_ptr,
+                        m.uv_ptr
+                    ),
+                    Err(e) => log::debug!("CUDA import for slot {i} skipped: {e}"),
+                }
+                imported.ok()
+            } else {
+                None
+            };
+            cuda_imports.push(cuda_import);
 
             unsafe {
                 let _ = CloseHandle(handle);
@@ -333,14 +343,16 @@ impl D3d11StagingPool {
             self.pixel_format
         );
 
-        let cuda_nv12 = if self.enable_cuda && cuda_imports.iter().all(|c| c.is_some()) {
+        let cuda_nv12 = if !self.enable_cuda {
+            // No CUDA-resident detector requested it; imports were skipped above.
+            log::info!("CUDA detection not requested; D3D11VA staging stays DX12-only");
+            None
+        } else if cuda_imports.iter().all(|c| c.is_some()) {
             let v: Vec<_> = cuda_imports.into_iter().map(|c| c.unwrap()).collect();
             log::info!("CUDA detection enabled on D3D11VA staging textures");
             Some(v)
         } else {
-            log::info!(
-                "CUDA detection not available on D3D11VA staging (non-NVIDIA or CUDA not found)"
-            );
+            log::info!("CUDA detection requested but import failed (non-NVIDIA or CUDA not found)");
             None
         };
 

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -127,6 +127,12 @@ struct AutoExportSpec {
     output: PathBuf,
     model: Option<PathBuf>,
     lookahead_secs: f32,
+    /// Total number of exports to run back-to-back in one session, from
+    /// `RECO_AUTOEXPORT_REPEAT` (default 1). Used to surface cross-export GPU
+    /// resource leaks: VRAM is logged between runs, so a leak shows up as a
+    /// figure that never returns to baseline. The output path gets a `_N`
+    /// suffix per run so runs don't clobber each other.
+    repeats: u32,
 }
 
 #[cfg(feature = "automation")]
@@ -167,6 +173,11 @@ impl AutoloadSpec {
                     .ok()
                     .and_then(|v| v.parse().ok())
                     .unwrap_or(0.0),
+                repeats: std::env::var("RECO_AUTOEXPORT_REPEAT")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .filter(|&n| n > 0)
+                    .unwrap_or(1),
             });
         Some(Self {
             left,
@@ -199,6 +210,21 @@ struct AppState {
     /// Headless preload/auto-export hook (RECO_AUTOLOAD); `None` in normal use.
     #[cfg(feature = "automation")]
     autoload: Option<AutoloadSpec>,
+    /// Repeat-export driver state (RECO_AUTOEXPORT_REPEAT). When `mode` is set,
+    /// the export-completion handler re-triggers another export until `done`
+    /// reaches `total`, then quits the event loop. Inert otherwise.
+    #[cfg(feature = "automation")]
+    auto_export_mode: bool,
+    /// Total exports to run back-to-back this session.
+    #[cfg(feature = "automation")]
+    auto_export_total: u32,
+    /// Exports completed so far (the next run is `done + 1`).
+    #[cfg(feature = "automation")]
+    auto_export_done: u32,
+    /// Base output path for repeat exports; each run appends `_N` before the
+    /// extension so successive runs do not overwrite each other.
+    #[cfg(feature = "automation")]
+    auto_export_base: Option<PathBuf>,
     /// Unified pose state machine (target + current + smoothing +
     /// coverage clamping). Replaces the earlier hand-rolled
     /// `yaw/pitch/target_*` fields; all input events (drag, wheel,
@@ -444,6 +470,14 @@ impl AppState {
             shared_gpu: None,
             #[cfg(feature = "automation")]
             autoload: AutoloadSpec::from_env(),
+            #[cfg(feature = "automation")]
+            auto_export_mode: false,
+            #[cfg(feature = "automation")]
+            auto_export_total: 0,
+            #[cfg(feature = "automation")]
+            auto_export_done: 0,
+            #[cfg(feature = "automation")]
+            auto_export_base: None,
             pose: PoseControl::new(PoseControlConfig {
                 drag_deg_per_pixel: DRAG_DEG_PER_PIXEL,
                 smoothing: POSE_SMOOTHING,
@@ -3723,10 +3757,69 @@ fn main() -> anyhow::Result<()> {
                                 format!("{frames} frames to {}", path.display()),
                             );
                             crate::toast::sync_to_ui(&s.toasts, &app);
+
+                            // Repeat-export driver: measure VRAM now that the
+                            // preview has been rebuilt (the steady state between
+                            // runs), then either trigger the next export or quit.
+                            // A leak shows up as `used` that never returns to the
+                            // baseline logged at startup. Deferred via single_shot
+                            // so the next start_export runs after this borrow of
+                            // `s` is released (start_export borrows it too).
+                            #[cfg(feature = "automation")]
+                            if s.auto_export_mode {
+                                s.auto_export_done += 1;
+                                let done = s.auto_export_done;
+                                let total = s.auto_export_total;
+                                let vram = autoexport_vram();
+                                if done < total {
+                                    log::info!(
+                                        "RECO_AUTOEXPORT: run {done}/{total} complete, {vram}; starting next"
+                                    );
+                                    let base = s.auto_export_base.clone();
+                                    let app_w = app_weak.clone();
+                                    slint::Timer::single_shot(
+                                        std::time::Duration::from_millis(800),
+                                        move || {
+                                            if let Some(app) = app_w.upgrade() {
+                                                if let Some(base) = base {
+                                                    let out = autoexport_run_path(&base, done + 1);
+                                                    app.set_export_output_path(
+                                                        out.display().to_string().into(),
+                                                    );
+                                                }
+                                                app.invoke_start_export();
+                                            }
+                                        },
+                                    );
+                                } else {
+                                    log::info!(
+                                        "RECO_AUTOEXPORT: all {total} runs complete, final {vram}; quitting"
+                                    );
+                                    slint::Timer::single_shot(
+                                        std::time::Duration::from_millis(1500),
+                                        || {
+                                            let _ = slint::quit_event_loop();
+                                        },
+                                    );
+                                }
+                            }
                         }
                         ExportOutcome::Cancelled => {
                             app.set_export_status_text("".into());
                             app.set_status_text("Export cancelled".into());
+                            #[cfg(feature = "automation")]
+                            if s.auto_export_mode {
+                                log::warn!(
+                                    "RECO_AUTOEXPORT: run cancelled, {}; quitting",
+                                    autoexport_vram()
+                                );
+                                slint::Timer::single_shot(
+                                    std::time::Duration::from_millis(1000),
+                                    || {
+                                        let _ = slint::quit_event_loop();
+                                    },
+                                );
+                            }
                         }
                         ExportOutcome::Failed(err) => {
                             app.set_export_status_text("".into());
@@ -3764,6 +3857,19 @@ fn main() -> anyhow::Result<()> {
                             s.toasts.push(Severity::Error, title, body);
                             crate::toast::sync_to_ui(&s.toasts, &app);
                             app.set_status_text(status.into());
+                            #[cfg(feature = "automation")]
+                            if s.auto_export_mode {
+                                log::warn!(
+                                    "RECO_AUTOEXPORT: run failed ({msg}), {}; quitting",
+                                    autoexport_vram()
+                                );
+                                slint::Timer::single_shot(
+                                    std::time::Duration::from_millis(1000),
+                                    || {
+                                        let _ = slint::quit_event_loop();
+                                    },
+                                );
+                            }
                         }
                     }
                 }
@@ -3960,6 +4066,35 @@ fn vsync_render_tick(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<RecoA
     false
 }
 
+/// GPU free/used VRAM (MB) via `nvidia-smi`, for repeat-export leak logging.
+/// Returns a short descriptive string; never fails the run.
+#[cfg(feature = "automation")]
+fn autoexport_vram() -> String {
+    std::process::Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=memory.free,memory.used",
+            "--format=csv,noheader,nounits",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| format!("free/used MB = {}", s.trim()))
+        .unwrap_or_else(|| "nvidia-smi unavailable".into())
+}
+
+/// Output path for repeat-export run `n`: `base_n.ext` (1-based), so successive
+/// runs in one session do not overwrite each other.
+#[cfg(feature = "automation")]
+fn autoexport_run_path(base: &std::path::Path, n: u32) -> PathBuf {
+    let stem = base
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("export");
+    let ext = base.extension().and_then(|e| e.to_str()).unwrap_or("mp4");
+    let name = format!("{stem}_{n}.{ext}");
+    base.with_file_name(name)
+}
+
 /// Execute an [`AutoloadSpec`]: set inputs + calibration, build the preview,
 /// and optionally start an export. Dev/test hook (RECO_AUTOLOAD) only.
 #[cfg(feature = "automation")]
@@ -3998,7 +4133,19 @@ fn run_autoload(
     if let Some(exp) = spec.export
         && let Some(app) = app_weak.upgrade()
     {
-        app.set_export_output_path(exp.output.display().to_string().into());
+        // Repeat-export driver: run `exp.repeats` exports back-to-back in this
+        // one session so a cross-export GPU leak shows up as VRAM that never
+        // returns to baseline. The completion handler re-triggers the next run
+        // and quits when done. `remaining` counts runs AFTER this first one.
+        {
+            let mut s = state.borrow_mut();
+            s.auto_export_mode = true;
+            s.auto_export_total = exp.repeats;
+            s.auto_export_done = 0;
+            s.auto_export_base = Some(exp.output.clone());
+        }
+        let first_out = autoexport_run_path(&exp.output, 1);
+        app.set_export_output_path(first_out.display().to_string().into());
         if let Some(model) = &exp.model {
             app.set_export_autocam_enabled(true);
             app.set_export_model_path(model.display().to_string().into());
@@ -4006,8 +4153,10 @@ fn run_autoload(
             app.set_export_lookahead_secs(exp.lookahead_secs);
         }
         log::info!(
-            "RECO_AUTOEXPORT: starting export -> {} (lookahead {}s)",
-            exp.output.display(),
+            "RECO_AUTOEXPORT: baseline {}; starting export 1/{} -> {} (lookahead {}s)",
+            autoexport_vram(),
+            exp.repeats,
+            first_out.display(),
             exp.lookahead_secs
         );
         app.invoke_start_export();


### PR DESCRIPTION
## Description

The D3D11VA zero-copy export path imports each staging texture into CUDA but never freed the buffers from `cuExternalMemoryGetMappedBuffer` before destroying the external-memory object. CUDA's reference to the staging textures stayed live, so their VRAM was never reclaimed - a per-export leak on NVIDIA that scales with the lookahead pool size, eventually starving later exports in the same session. The drop now frees the mapped buffers before `cuDestroyExternalMemory` and ensures a CUDA context on the dropping thread, per the CUDA driver-API contract.

The CUDA import is also skipped when no CUDA-resident detector requested it, rather than importing every staging slot and discarding the result.

A second commit adds an automation-only repeat-export driver (`RECO_AUTOEXPORT_REPEAT=N`) that runs N exports in one GUI session and logs VRAM between runs, used to reproduce and confirm the fix on the GUI path (preview release/rebuild) that the `vram_leak_repro` example cannot reach.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [ ] `cargo test --all` passes
- [x] I added or updated tests where it made sense