### PR TITLE
fix(reco-core): trust free VRAM for the lookahead budget on small cards

### DIFF
--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -286,12 +286,15 @@ impl StitchSession {
             // VramPool::new plus graceful teardown for any slip-through.
             match self.core.pipeline().gpu().available_vram() {
                 Some((free, total)) => {
-                    // Budget from total VRAM, not the driver's "free" figure:
-                    // the latter is unreliable (can read 0 on a multi-GB card
-                    // mid-session) and would block viable exports. Shared with
-                    // the export-panel risk slider so the two always agree.
-                    // Over-allocation is caught gracefully at pool creation.
-                    let budget = super::vram_pool::lookahead_budget_bytes(total);
+                    // Budget trusts the driver's "free" figure when it is
+                    // believable (it already excludes the compositor and the
+                    // rest of the pipeline) and falls back to a fraction of
+                    // total when free reads bogus (~0 on a multi-GB card).
+                    // Sampled here just before pool creation, after the GUI
+                    // preview is released, so it reflects real export-time room.
+                    // Shared with the export-panel risk slider for consistency;
+                    // over-allocation is caught gracefully at pool creation.
+                    let budget = super::vram_pool::lookahead_budget_bytes(free, total);
                     log::info!(
                         "VRAM budget: {:.2} GB usable of {:.2} GB total ({:.2} GB reported free); \
                          lookahead pool needs {:.2} GB ({pool_size} slots @ {w}x{h})",

--- a/crates/reco-core/src/session/vram_pool.rs
+++ b/crates/reco-core/src/session/vram_pool.rs
@@ -282,22 +282,44 @@ pub struct LookaheadFit {
 /// Headroom fraction for the comfortable (`safe`/green) ceiling.
 const LOOKAHEAD_SAFE_FRACTION: f64 = 0.75;
 
-/// Fraction of total VRAM treated as usable for the lookahead pool.
+/// Ceiling fraction of *total* VRAM the lookahead pool may use.
 ///
-/// The pool competes with decode surfaces, the stitch pipeline, the encoder,
-/// AI tensors, and the OS compositor, so part of total VRAM is reserved.
+/// Acts as an upper bound (and the fallback when `free` is unusable). The pool
+/// competes with decode surfaces, the stitch pipeline, the encoder, AI tensors,
+/// and the OS compositor, so the pool is never allowed past this fraction of
+/// total even when the driver reports more free.
 const LOOKAHEAD_BUDGET_FRACTION: f64 = 0.70;
 
-/// VRAM budget (bytes) available to the lookahead pool, derived from *total*
-/// VRAM rather than the driver's "free" figure.
+/// Runtime margin held back below the driver's "free" figure.
 ///
-/// The free query is unreliable on some GPUs - it can report 0 bytes free on a
-/// multi-GB card mid-session, which would otherwise block a perfectly viable
-/// export. A total-based estimate is used instead, and over-allocation is
-/// caught gracefully at pool creation on every platform. Shared by the export
-/// pre-flight check and the GUI risk slider so the two always agree.
-pub fn lookahead_budget_bytes(total_vram: u64) -> usize {
-    (total_vram as f64 * LOOKAHEAD_BUDGET_FRACTION) as usize
+/// `free` is sampled just before the pool allocates, but the encoder output
+/// surfaces, extra decode buffering, and AI tensors still grow during the run.
+/// This fixed margin leaves room for that growth so the pool does not consume
+/// the last byte of free VRAM.
+const LOOKAHEAD_FREE_RESERVE_BYTES: u64 = 512 * 1024 * 1024;
+
+/// VRAM budget (bytes) available to the lookahead pool, from the driver's
+/// `free` figure when it is trustworthy, else a fraction of `total`.
+///
+/// `free` is the honest signal: it already excludes the OS compositor and the
+/// rest of the pipeline, so on small cards it avoids the over-estimate a flat
+/// `total * fraction` makes (a fixed baseline is a large share of an 8 GB card).
+/// But some drivers report a bogus ~0 free on a multi-GB card mid-session, which
+/// would block a viable export, so `free` is trusted only when it is a
+/// believable fraction of total; otherwise the total-based estimate is used and
+/// over-allocation is caught gracefully at pool creation. Capped at
+/// `total * LOOKAHEAD_BUDGET_FRACTION` either way. Shared by the export
+/// pre-flight check and the GUI risk slider so the two stay consistent.
+pub fn lookahead_budget_bytes(free_vram: u64, total_vram: u64) -> usize {
+    let total_based = (total_vram as f64 * LOOKAHEAD_BUDGET_FRACTION) as u64;
+    let budget = if free_vram >= total_vram / 8 {
+        free_vram
+            .saturating_sub(LOOKAHEAD_FREE_RESERVE_BYTES)
+            .min(total_based)
+    } else {
+        total_based
+    };
+    budget as usize
 }
 
 /// Compute lookahead fit thresholds for a source resolution and VRAM budget.
@@ -364,14 +386,45 @@ mod tests {
     }
 
     #[test]
-    fn budget_is_total_based_and_reserves_headroom() {
-        // zzz's case: 5.52 GB total. A bogus free=0 must not zero the budget;
-        // the budget is derived from total and leaves a reserve.
+    fn bogus_free_falls_back_to_total() {
+        // zzz's case: 5.52 GB total, driver reports a bogus free=0. The budget
+        // must not collapse to ~0; it falls back to the total-based estimate.
         let total = 5_520_000_000u64;
-        let budget = lookahead_budget_bytes(total);
+        let budget = lookahead_budget_bytes(0, total);
         assert!(budget > 0);
         assert!(budget < total as usize); // reserves headroom
-        // The 2.49 GB pool from the forum report fits in the usable budget.
+        // The 2.49 GB pool from the forum report still fits.
         assert!(budget >= 2_490_000_000);
+        // Falls back to exactly the total-based estimate.
+        assert_eq!(budget, (total as f64 * 0.70) as usize);
+    }
+
+    #[test]
+    fn clean_small_card_trusts_free_no_false_green() {
+        // Problem 2: a clean 8 GB card. DXGI budget ~7.6 GB total, but a fixed
+        // baseline (compositor + pipeline) leaves ~4.5 GB actually free. The old
+        // total*0.70 = 5.33 GB over-estimated and let a 4.71 GB pool pass
+        // pre-flight, then OOM. The free-trusting budget must stay below the
+        // real free so that pool is correctly rejected.
+        let total = 7_600_000_000u64;
+        let free = 4_500_000_000u64;
+        let budget = lookahead_budget_bytes(free, total);
+        // Below total*0.70 - free constrained it.
+        assert!(budget < (total as f64 * 0.70) as usize);
+        // Below the actual free (reserve held back), so it never promises more
+        // than the card has.
+        assert!(budget < free as usize);
+        // The 4.71 GB default pool does NOT fit -> no false green.
+        assert!(budget < 4_710_000_000);
+    }
+
+    #[test]
+    fn big_card_capped_at_total_fraction() {
+        // 24 GB card, 22 GB free. free - reserve (21.5 GB) exceeds the total
+        // ceiling, so the pool is capped at total*0.70, not the huge free.
+        let total = 24_000_000_000u64;
+        let free = 22_000_000_000u64;
+        let budget = lookahead_budget_bytes(free, total);
+        assert_eq!(budget, (total as f64 * 0.70) as usize);
     }
 }

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -4016,12 +4016,14 @@ fn run_autoload(
 
 /// VRAM budget (bytes) available to the lookahead pool at export time.
 ///
-/// The preview pipeline is released during export, so we estimate from total
-/// VRAM minus a reserve for decode/stitch/encode/AI rather than the
-/// preview-occupied "free" figure (which is also unreliable on some Windows
-/// GPUs). A test build can override the budget via `RECO_VRAM_BUDGET_GB` to
-/// exercise the risk zones on a large GPU.
-fn budget_for_lookahead(total_vram: u64) -> usize {
+/// Uses the same free-trusting estimate as the export pre-flight. Note the
+/// slider samples `free` while the live preview is still resident, whereas the
+/// export releases the preview first, so this figure is slightly conservative
+/// (it counts the preview against the budget) - a safe direction: the slider
+/// never shows green for a lookahead the export would reject. A test build can
+/// override the budget via `RECO_VRAM_BUDGET_GB` to exercise the risk zones on a
+/// large GPU.
+fn budget_for_lookahead(free_vram: u64, total_vram: u64) -> usize {
     #[cfg(feature = "automation")]
     if let Ok(gb) = std::env::var("RECO_VRAM_BUDGET_GB")
         && let Ok(v) = gb.parse::<f64>()
@@ -4029,8 +4031,8 @@ fn budget_for_lookahead(total_vram: u64) -> usize {
         return (v * 1e9) as usize;
     }
     // Same budget the export pre-flight uses, so the slider's risk zones match
-    // exactly what the engine will accept.
-    reco_core::session::lookahead_budget_bytes(total_vram)
+    // what the engine will accept.
+    reco_core::session::lookahead_budget_bytes(free_vram, total_vram)
 }
 
 fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<RecoApp>) {
@@ -4103,8 +4105,8 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     .as_ref()
                     .and_then(|b| b.renderer().gpu().available_vram())
                 {
-                    Some((_free, total)) if total > 0 && in_w > 0 && in_h > 0 => {
-                        let budget = budget_for_lookahead(total);
+                    Some((free, total)) if total > 0 && in_w > 0 && in_h > 0 => {
+                        let budget = budget_for_lookahead(free, total);
                         let fit = reco_core::session::lookahead_fit(in_w, in_h, 1, budget, fps);
                         app.set_lookahead_green_max(fit.safe_secs as f32);
                         app.set_lookahead_red_min(fit.max_secs as f32);


### PR DESCRIPTION
## Description

Related to #381 (the cross-export VRAM leak fix, which makes the driver's `free` figure reliable again). This change is independent code-wise and targets `main` on its own; it simply benefits from the leak being gone.

`lookahead_budget_bytes` estimated usable VRAM as `total * 0.70`. A flat percentage ignores the fixed baseline (OS compositor + the app's own pipeline) already consumed, which is a large share of a small card. On an 8 GB GPU this over-reported usable VRAM, so the export risk slider showed lookahead values as green that did not actually fit, and the pre-flight check passed a pool that then OOMd at allocation.

The budget now takes both `free` and `total`: it uses `free` (the honest signal - already net of the baseline) minus a fixed runtime reserve when `free` is believable, capped at `total * 0.70`, and falls back to `total * 0.70` only when `free` reads bogus (~0 on a multi-GB card mid-session). The same function feeds the export pre-flight and the GUI slider, so they stay consistent. The slider samples `free` while the preview is still resident, making it slightly conservative - a safe direction.

Background: an over-allocation experiment confirmed that on Windows/D3D11VA the driver over-commits (a 14 GB pool allocated onto an 11 GB card via WDDM paging rather than failing), so a predictive budget is required - relying on allocation-time failure is not reliable on that path.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [ ] `cargo test --all` passes
- [x] I added or updated tests where it made sense
