### PR TITLE
Runtime env-var controls for encoder and nvargus

### DIFF
--- a/crates/reco-io/src/ffmpeg/encoder.rs
+++ b/crates/reco-io/src/ffmpeg/encoder.rs
@@ -842,8 +842,10 @@ impl VideoEncoder {
         );
         // B-frames cause negative initial PTS offsets and frame reordering
         // in the encoded output. For real-time stitching they add latency
-        // with no visual benefit, so disable unconditionally.
-        opts.set("bf", "0");
+        // with no visual benefit, so default to 0. RECO_X264_BFRAMES
+        // overrides for offline encodes that can tolerate the reordering.
+        let bf = std::env::var("RECO_X264_BFRAMES").unwrap_or_else(|_| "0".to_string());
+        opts.set("bf", &bf);
         let encoder = enc.open_with(opts)?;
         ost.set_parameters(&encoder);
 
@@ -1848,8 +1850,12 @@ fn build_encoder_opts(
                     .unwrap_or_default()
                     .contains("nvidia,tegra")
             {
-                log::info!("Tegra platform detected, limiting libx264 to 4 threads");
-                opts.set("threads", "4");
+                let threads = std::env::var("RECO_X264_THREADS")
+                    .ok()
+                    .and_then(|v| v.parse::<u32>().ok())
+                    .unwrap_or(4);
+                log::info!("Tegra platform detected, limiting libx264 to {threads} threads");
+                opts.set("threads", &threads.to_string());
             }
         }
         _ => {

--- a/crates/reco-io/src/gstreamer/camera.rs
+++ b/crates/reco-io/src/gstreamer/camera.rs
@@ -107,8 +107,11 @@ fn build_pipeline_string(
         // Jetson: nvarguscamerasrc runs the full NVIDIA ISP
         // (debayer, AWB, AE, denoise). Output is NV12 in NVMM;
         // nvvidconv copies to system memory (and converts format if needed).
+        // RECO_NVARGUS_OPTS injects extra source properties (e.g. aelock,
+        // exposuretimerange, gainrange, wbmode) for seam-matched capture.
+        let nvargus_opts = std::env::var("RECO_NVARGUS_OPTS").unwrap_or_default();
         format!(
-            "nvarguscamerasrc sensor-id={device} ! \
+            "nvarguscamerasrc sensor-id={device} {nvargus_opts} ! \
              video/x-raw(memory:NVMM),width={width},height={height},format=NV12,framerate={fps}/1 ! \
              nvvidconv ! \
              video/x-raw,format={fmt_str} ! \
@@ -608,8 +611,11 @@ mod nvmm_source {
         }
 
         validate_device_string(device)?;
+        // RECO_NVARGUS_OPTS injects extra source properties (e.g. aelock,
+        // exposuretimerange, gainrange, wbmode) for seam-matched capture.
+        let nvargus_opts = std::env::var("RECO_NVARGUS_OPTS").unwrap_or_default();
         Ok(format!(
-            "nvarguscamerasrc sensor-id={device} ! \
+            "nvarguscamerasrc sensor-id={device} {nvargus_opts} ! \
              video/x-raw(memory:NVMM),width={width},height={height},format=NV12,framerate={fps}/1 ! \
              appsink name=sink emit-signals=false sync=false max-buffers=4 drop=true"
         ))


### PR DESCRIPTION
Adds three opt-in environment-variable overrides so the gameday panel can tune encode and capture per device without rebuilding:

- `RECO_X264_BFRAMES` - x264 B-frames (default 0)
- `RECO_X264_THREADS` - Tegra x264 thread count (default unchanged at 4)
- `RECO_NVARGUS_OPTS` - extra nvarguscamerasrc properties (aelock, exposuretimerange, gainrange, wbmode) for seam-matched capture

All reads live in reco-io (encoder + camera pipeline builders) and are `RECO_`-prefixed; reco-core is untouched, so they are easy to grep and remove later. Defaults preserve current behaviour - the vars only take effect when set.