### PR TITLE
Periodic JPEG snapshots behind a snapshot feature

### DIFF
--- a/crates/reco-cli/Cargo.toml
+++ b/crates/reco-cli/Cargo.toml
@@ -36,6 +36,10 @@ tensorrt-native = ["autocam", "reco-autocam/tensorrt-native"]
 ncnn = ["autocam", "reco-autocam/ncnn"]
 gopro = ["reco-control/gopro"]
 gstreamer = ["reco-io/gstreamer"]
+# Periodic JPEG snapshots of the stitched output (live preview for the
+# gameday panel). Opt-in so it compiles out cleanly; implies gstreamer
+# since it's only wired into the camera path.
+snapshot = ["gstreamer"]
 v4l2 = ["reco-io/v4l2"]
 libcamera = ["reco-io/libcamera"]
 rpi = ["reco-io/rpi"]

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -12,6 +12,8 @@ use reco_core::source::StereoFrame;
 use reco_io::gstreamer::camera::CameraConfig;
 
 use crate::helpers;
+#[cfg(feature = "snapshot")]
+use crate::snapshot::SnapshotWriter;
 
 /// Run live camera stitching.
 ///
@@ -37,6 +39,13 @@ pub struct CameraRunConfig<'a> {
     pub capture_fps: u32,
     pub model_path: Option<&'a str>,
     pub detection_interval: u64,
+    /// Directory for periodic JPEG snapshots of the stitched output
+    /// (live preview). `snapshot` build feature only.
+    #[cfg(feature = "snapshot")]
+    pub snapshot_dir: Option<&'a str>,
+    /// Write a snapshot every N frames (only with `snapshot_dir`).
+    #[cfg(feature = "snapshot")]
+    pub snapshot_interval: u64,
     pub quality_value: Option<u8>,
     pub preset: Option<String>,
     /// Output container (`mp4` / `fmp4` / `mkv`). None -> `mp4`.
@@ -87,6 +96,10 @@ pub fn run_camera(
         capture_fps,
         model_path,
         detection_interval,
+        #[cfg(feature = "snapshot")]
+        snapshot_dir,
+        #[cfg(feature = "snapshot")]
+        snapshot_interval,
         quality_value,
         preset,
         container,
@@ -347,6 +360,20 @@ pub fn run_camera(
     println!("Encoder: {}", encoder.encoder_name());
 
     session.set_encoder(Box::new(encoder), 2);
+
+    // Snapshot writer for live preview (gameday panel). Taps the NV12
+    // readback after each frame and writes a JPEG every N frames on a
+    // background thread; held alive until the function returns. Gated
+    // behind the `snapshot` build feature.
+    #[cfg(feature = "snapshot")]
+    let mut _snapshot_writer: Option<SnapshotWriter> = None;
+    #[cfg(feature = "snapshot")]
+    if let Some(dir) = snapshot_dir {
+        let (writer, tap) = SnapshotWriter::new(Path::new(dir), snapshot_interval)?;
+        session.set_nv12_tap(tap);
+        println!("Snapshots: {dir}/snapshot.jpg (every {snapshot_interval} frames)");
+        _snapshot_writer = Some(writer);
+    }
 
     let frame_limit =
         reco_core::session::types::compute_frame_limit(end_time, max_frames, capture_fps as f64);

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -11,6 +11,8 @@ mod helpers;
 #[cfg(feature = "libcamera")]
 mod libcamera_cmd;
 mod preview;
+#[cfg(feature = "snapshot")]
+mod snapshot;
 mod stitch;
 
 use clap::{Parser, Subcommand};
@@ -383,6 +385,19 @@ enum Commands {
         /// Detection interval: run detection every N frames (default: 1).
         #[arg(long, default_value_t = 1)]
         detection_interval: u64,
+
+        /// Directory for periodic JPEG snapshots of the stitched output
+        /// (live preview for the gameday web panel). Requires the
+        /// `snapshot` build feature.
+        #[cfg(feature = "snapshot")]
+        #[arg(long)]
+        snapshot_dir: Option<String>,
+
+        /// Write a snapshot every N frames (default: 30). Only effective
+        /// when --snapshot-dir is set.
+        #[cfg(feature = "snapshot")]
+        #[arg(long, default_value_t = 30)]
+        snapshot_interval: u64,
 
         /// Encoder quality on a 0-100 scale (higher = better). Overrides the
         /// quality preset. See `stitch --help` for the full mapping table.
@@ -862,6 +877,10 @@ fn main() -> anyhow::Result<()> {
             end_time,
             model,
             detection_interval,
+            #[cfg(feature = "snapshot")]
+            snapshot_dir,
+            #[cfg(feature = "snapshot")]
+            snapshot_interval,
             quality_value,
             preset,
             container,
@@ -926,6 +945,10 @@ fn main() -> anyhow::Result<()> {
                     capture_fps,
                     model_path: model.as_deref(),
                     detection_interval,
+                    #[cfg(feature = "snapshot")]
+                    snapshot_dir: snapshot_dir.as_deref(),
+                    #[cfg(feature = "snapshot")]
+                    snapshot_interval,
                     quality_value,
                     preset,
                     container: container.as_deref(),

--- a/crates/reco-cli/src/snapshot.rs
+++ b/crates/reco-cli/src/snapshot.rs
@@ -1,0 +1,172 @@
+//! Periodic JPEG snapshot writer for live preview.
+//!
+//! Writes a JPEG snapshot of the stitched NV12 output to a directory at
+//! a configurable frame interval. Designed for the gameday control panel
+//! which reads the latest `snapshot.jpg` to show a live preview without
+//! waiting for the encoder to finish.
+//!
+//! The writer runs on a background thread with a capacity-1 channel so
+//! it never blocks the 30fps frame loop. If the JPEG encoder falls
+//! behind, old frames are silently dropped.
+
+use std::path::Path;
+use std::sync::mpsc;
+use std::thread::{self, JoinHandle};
+
+/// NV12 tap closure handed to `StitchSession::set_nv12_tap`:
+/// `(nv12_data, width, height)`.
+type Nv12Tap = Box<dyn FnMut(&[u8], u32, u32) + Send>;
+
+/// A snapshot job sent to the background thread.
+struct SnapshotJob {
+    nv12_data: Vec<u8>,
+    width: u32,
+    height: u32,
+}
+
+/// Writes periodic JPEG snapshots of the stitched output to disk.
+///
+/// Created once per camera session. Call [`create_nv12_tap`] to get a
+/// closure suitable for [`StitchSession::set_nv12_tap`], then call
+/// [`shutdown`] when the session ends.
+pub struct SnapshotWriter {
+    /// Kept alive to prevent the background thread from exiting early.
+    /// Dropped on shutdown to signal the thread to stop.
+    _tx: Option<mpsc::SyncSender<SnapshotJob>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl SnapshotWriter {
+    /// Create a snapshot writer and its NV12 tap closure.
+    ///
+    /// Returns `(writer, tap)` where `tap` is a closure that can be
+    /// passed to `session.set_nv12_tap()`. The tap internally tracks
+    /// the frame interval and uses `try_send` so it never blocks.
+    ///
+    /// The directory is created if it does not exist.
+    pub fn new(dir: &Path, interval: u64) -> std::io::Result<(Self, Nv12Tap)> {
+        std::fs::create_dir_all(dir)?;
+
+        let snapshot_path = dir.join("snapshot.jpg");
+        let tmp_path = dir.join(".snapshot.jpg.tmp");
+
+        // Capacity 1: the tap can always try_send without blocking.
+        // If the background thread is still encoding the previous
+        // snapshot, the new frame is silently dropped.
+        let (tx, rx) = mpsc::sync_channel::<SnapshotJob>(1);
+
+        let handle = thread::Builder::new()
+            .name("snapshot".into())
+            .spawn(move || encode_loop(rx, &snapshot_path, &tmp_path))
+            .expect("spawn snapshot thread");
+
+        let tap_tx = tx.clone();
+        let interval = interval.max(1);
+        let mut frame_count: u64 = 0;
+
+        let tap = Box::new(move |data: &[u8], w: u32, h: u32| {
+            let count = frame_count;
+            frame_count += 1;
+
+            if !count.is_multiple_of(interval) {
+                return;
+            }
+
+            let job = SnapshotJob {
+                nv12_data: data.to_vec(),
+                width: w,
+                height: h,
+            };
+            // try_send: drop the frame if the channel is full.
+            let _ = tap_tx.try_send(job);
+        });
+
+        let writer = Self {
+            _tx: Some(tx),
+            handle: Some(handle),
+        };
+
+        Ok((writer, tap))
+    }
+
+    /// Shut down the background thread gracefully.
+    pub fn shutdown(&mut self) {
+        // Drop the sender so the background thread's recv() returns Err.
+        self._tx.take();
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Drop for SnapshotWriter {
+    fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+/// Background thread loop: receive NV12 frames, convert to RGB, encode
+/// JPEG, and write atomically.
+fn encode_loop(rx: mpsc::Receiver<SnapshotJob>, snapshot_path: &Path, tmp_path: &Path) {
+    while let Ok(job) = rx.recv() {
+        if let Err(e) = write_snapshot(&job, snapshot_path, tmp_path) {
+            log::warn!("snapshot write failed: {e}");
+        }
+    }
+}
+
+/// Convert NV12 to RGB, encode as JPEG, and write atomically.
+fn write_snapshot(job: &SnapshotJob, snapshot_path: &Path, tmp_path: &Path) -> anyhow::Result<()> {
+    let w = job.width as usize;
+    let h = job.height as usize;
+    let y_size = w * h;
+
+    // NV12 layout: Y plane (w*h bytes), then interleaved UV plane (w*h/2 bytes).
+    if job.nv12_data.len() < y_size + y_size / 2 {
+        anyhow::bail!(
+            "NV12 data too short: expected {} bytes, got {}",
+            y_size + y_size / 2,
+            job.nv12_data.len()
+        );
+    }
+
+    let y_plane = &job.nv12_data[..y_size];
+    let uv_plane = &job.nv12_data[y_size..];
+
+    let mut rgb = vec![0u8; w * h * 3];
+
+    for row in 0..h {
+        for col in 0..w {
+            let yi = row * w + col;
+            let uv_idx = (row / 2) * w + (col & !1);
+
+            let y = y_plane[yi] as f32;
+            let u = uv_plane[uv_idx] as f32;
+            let v = uv_plane[uv_idx + 1] as f32;
+
+            let r = y + 1.402 * (v - 128.0);
+            let g = y - 0.344 * (u - 128.0) - 0.714 * (v - 128.0);
+            let b = y + 1.772 * (u - 128.0);
+
+            let pi = yi * 3;
+            rgb[pi] = r.clamp(0.0, 255.0) as u8;
+            rgb[pi + 1] = g.clamp(0.0, 255.0) as u8;
+            rgb[pi + 2] = b.clamp(0.0, 255.0) as u8;
+        }
+    }
+
+    // Encode JPEG and write atomically (tmp + rename).
+    let img = image::RgbImage::from_raw(job.width, job.height, rgb).ok_or_else(|| {
+        anyhow::anyhow!(
+            "failed to create image buffer ({}x{})",
+            job.width,
+            job.height
+        )
+    })?;
+    let mut out = std::io::BufWriter::new(std::fs::File::create(tmp_path)?);
+    img.write_to(&mut out, image::ImageFormat::Jpeg)?;
+    drop(out);
+    std::fs::rename(tmp_path, snapshot_path)?;
+
+    Ok(())
+}

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -639,6 +639,10 @@ impl StitchSession {
         &mut self,
         render_commands: wgpu::CommandBuffer,
     ) -> Result<(), SessionError> {
+        // Read NV12 dims up front (Copy) so the tap below can borrow `data`
+        // without re-borrowing self.nv12_converter.
+        let nv12_width = self.nv12_converter.width();
+        let nv12_height = self.nv12_converter.height();
         let readback_t0 = std::time::Instant::now();
         let nv12_data = self.nv12_converter.convert_and_readback(
             self.core.gpu(),
@@ -656,6 +660,12 @@ impl StitchSession {
             }
             for enc in &self.extra_encoders {
                 enc.submit(data, self.frame_count as i64)?;
+            }
+            // NV12 tap for snapshot / preview hooks (reco-cli's periodic
+            // JPEG writer). Runs after encode submit; the callback is
+            // expected to be non-blocking (try_send on a channel).
+            if let Some(ref mut tap) = self.nv12_tap {
+                tap(data, nv12_width, nv12_height);
             }
         }
         self.last_submit_time = encode_t0.elapsed();

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -61,6 +61,9 @@ use crate::gpu::{GpuContext, OutputFormat};
 use crate::render::pipeline::StitchPipeline;
 use crate::render::renderer::InputFormat;
 
+/// Callback type for the NV12 tap: receives `(nv12_data, width, height)`.
+pub type Nv12TapFn = Box<dyn FnMut(&[u8], u32, u32) + Send>;
+
 use types::{ErrorPolicy, SessionConfig, SessionError, SessionMetrics, StitchSessionBuilder};
 
 use detection::DetectionPipeline;
@@ -182,6 +185,10 @@ pub struct StitchSession {
     pub(crate) gpu_pixel_format: crate::render::renderer::GpuPixelFormat,
     /// Full-range YUV (0-255) vs limited range (16-235).
     pub(crate) is_full_range: bool,
+    /// Optional callback invoked with NV12 data after each frame.
+    /// Used by reco-cli's snapshot writer for periodic JPEG output.
+    /// The callback receives `(nv12_data, width, height)`.
+    pub(crate) nv12_tap: Option<Nv12TapFn>,
 }
 
 impl StitchSession {
@@ -292,6 +299,7 @@ impl StitchSession {
             right_rotation: 0,
             gpu_pixel_format: crate::render::renderer::GpuPixelFormat::Nv12,
             is_full_range: false,
+            nv12_tap: None,
         })
     }
 

--- a/crates/reco-core/src/session/wiring.rs
+++ b/crates/reco-core/src/session/wiring.rs
@@ -229,4 +229,19 @@ impl StitchSession {
     pub fn update_calibration(&mut self, calibration: crate::calibration::MatchCalibration) {
         self.core.update_calibration(calibration);
     }
+
+    /// Set an NV12 tap callback invoked after each frame's NV12 readback.
+    /// The callback receives `(nv12_data, width, height)`.
+    ///
+    /// Used by reco-cli's snapshot writer for periodic JPEG output. The
+    /// callback should return quickly (e.g. `try_send` on a channel) to
+    /// avoid blocking the frame loop.
+    pub fn set_nv12_tap(&mut self, tap: super::Nv12TapFn) {
+        self.nv12_tap = Some(tap);
+    }
+
+    /// Remove the NV12 tap callback.
+    pub fn clear_nv12_tap(&mut self) {
+        self.nv12_tap = None;
+    }
 }


### PR DESCRIPTION
Adds an opt-in `snapshot` cargo feature so `reco camera` can write a periodic JPEG of the stitched output for the gameday panel's live preview.

- **reco-core**: a generic `nv12_tap` hook - `set_nv12_tap`/`clear_nv12_tap` plus a call after encode submit. Always compiled but costs one `Option::is_some()` check per frame when unused; not snapshot-specific, so it is a reusable output tap.
- **reco-cli**: `snapshot.rs` writer (NV12 to JPEG on a background thread, capacity-1 channel with `try_send` so it never blocks the frame loop, atomic temp+rename write) plus `--snapshot-dir`/`--snapshot-interval`. All of it - module, flags, wiring - is behind `#[cfg(feature = "snapshot")]`.

`snapshot` is off by default and implies `gstreamer` (it is only wired into the camera path). A build without it compiles none of the snapshot code, so removing the feature later is a one-line change. The tap is not added to the recording command, so recording has zero snapshot overhead; only a separate preview process opts in. Verified compiling and clippy-clean both with and without the feature.