### PR TITLE
Lookahead on the live NVMM camera path

### DIFF
--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -46,6 +46,10 @@ pub struct CameraRunConfig<'a> {
     /// Write a snapshot every N frames (only with `snapshot_dir`).
     #[cfg(feature = "snapshot")]
     pub snapshot_interval: u64,
+    /// Lookahead buffer in seconds. The panner leads by this window and
+    /// the loop centered-smooths past+future poses. 0 disables it.
+    /// Only effective with AI tracking (a model + non-sweep mode).
+    pub lookahead: f64,
     pub quality_value: Option<u8>,
     pub preset: Option<String>,
     /// Output container (`mp4` / `fmp4` / `mkv`). None -> `mp4`.
@@ -100,6 +104,7 @@ pub fn run_camera(
         snapshot_dir,
         #[cfg(feature = "snapshot")]
         snapshot_interval,
+        lookahead,
         quality_value,
         preset,
         container,
@@ -214,6 +219,25 @@ pub fn run_camera(
     #[cfg(not(feature = "autocam"))]
     if model_path.is_some() {
         log::warn!("--model specified but autocam feature is disabled");
+    }
+
+    // Lookahead buffer (same semantics as `reco stitch --lookahead`): the
+    // panner leads by this window and the loop centered-smooths past +
+    // future poses. It only helps when an AI panner drives the camera, so
+    // gate it on a model + non-sweep tracking mode. Converts seconds ->
+    // frames using the capture rate, then routes the live path through the
+    // session's buffered loop (`run_buffered`).
+    let ai_tracking = model_path.is_some() && tracking != "sweep";
+    if lookahead > 0.0 {
+        if ai_tracking {
+            let frames = (lookahead * capture_fps as f64).round() as usize;
+            session.set_lookahead(frames);
+            println!("Lookahead: {lookahead:.2}s buffer ({frames} frames @ {capture_fps} fps)");
+        } else {
+            log::debug!(
+                "Lookahead {lookahead:.2}s ignored: no AI tracking (needs --model, non-sweep)"
+            );
+        }
     }
 
     let mode_str = if v4l2_direct {
@@ -525,148 +549,51 @@ pub fn run_camera(
     } else if use_nvmm {
         // NVMM zero-copy path: DMA-buf Vulkan import for rendering,
         // NvBufSurfTransform for detection. No CPU copies at all.
+        //
+        // Driven by the session's unified frame loop (`run` / `run_buffered`)
+        // through the `FrameSource` + `StereoFrame::NvmmResident` path - the
+        // same machinery the file-stitch path uses. So lookahead, centered
+        // smoothing, and the VRAM pool all work here for free; the per-frame
+        // import + NvBufSurfTransform happen inside the session's produce
+        // step (see `copy_nvmm_to_vram_pool` / `nvmm_run_detection`).
         #[cfg(target_os = "linux")]
         {
-            use reco_core::interop::dmabuf::DmaBufTextureCache;
-            use reco_core::nvbuf_transform::NvBufDetectionSurface;
             use reco_io::gstreamer::camera::GstreamerNvmmCameraSource;
 
             let mut source = GstreamerNvmmCameraSource::open(&cam_config)?;
 
-            // Detection surface size must match the TRT engine's input dims.
-            // All shipped yolo26 engines use 1280x1280.
-            let model_size = 1280u32;
-            log::info!("NVMM detection surface size: {model_size}x{model_size}");
-            let mut det_left =
-                NvBufDetectionSurface::new(model_size, capture_width, capture_height)
-                    .map_err(|e| anyhow::anyhow!("left detection surface: {e}"))?;
-            let mut det_right =
-                NvBufDetectionSurface::new(model_size, capture_width, capture_height)
-                    .map_err(|e| anyhow::anyhow!("right detection surface: {e}"))?;
-
-            let det_surface_mb =
-                (det_left.pitch as f64 * model_size as f64 * 2.0) / 1024.0 / 1024.0;
-            let tensor_mb =
-                (model_size as f64 * model_size as f64 * 3.0 * 4.0 * 2.0) / 1024.0 / 1024.0;
-            let nvmm_buf_mb =
-                (capture_width as f64 * capture_height as f64 * 1.5 * 8.0) / 1024.0 / 1024.0;
-            log::info!(
-                "NVMM detection surfaces: {}x{} RGBA, letterbox scale={:.4}, pitch={}",
-                model_size,
-                model_size,
-                det_left.scale,
-                det_left.pitch,
-            );
-            log::info!(
-                "Memory budget: det_surfaces={:.1}MB, trt_tensors={:.1}MB, nvmm_bufs={:.1}MB",
-                det_surface_mb,
-                tensor_mb,
-                nvmm_buf_mb,
-            );
-
-            let mut dmabuf_cache = DmaBufTextureCache::new();
-
-            // Warmup: pull first pair to initialize ISP + Argus
-            let warmup = source
-                .next_pair()?
-                .ok_or_else(|| anyhow::anyhow!("NVMM source returned no frames"))?;
-            source.release_previous();
-            log::info!(
-                "NVMM warmup: {}x{} NV12, fd_left={}, fd_right={}",
-                warmup.left.width,
-                warmup.left.height,
-                warmup.left.dmabuf_fd,
-                warmup.right.dmabuf_fd,
-            );
-            log::info!("Warmup complete, starting NVMM capture");
-
-            let progress = helpers::ProgressReporter::new(30);
-
-            while frame_count < frame_limit && !interrupted.load(Ordering::Relaxed) {
-                let pair = {
-                    reco_core::profile_scope!("wait_capture");
-                    match source.next_pair()? {
-                        Some(p) => p,
-                        None => break,
-                    }
-                };
-
-                // Detection: NvBufSurfTransform on the raw NVMM surface pointers
-                if session.detection_should_run() {
-                    reco_core::profile_scope!("nvbuf_detect");
-                    unsafe {
-                        det_left
-                            .transform_from_nvmm(pair.left.surface_ptr)
-                            .map_err(|e| anyhow::anyhow!("left transform: {e}"))?;
-                        det_right
-                            .transform_from_nvmm(pair.right.surface_ptr)
-                            .map_err(|e| anyhow::anyhow!("right transform: {e}"))?;
-                    }
-                    session.detect_and_update_director_preletterboxed(
-                        det_left.data_ptr,
-                        det_right.data_ptr,
-                        capture_width,
-                        capture_height,
-                        start.elapsed(),
-                    )?;
-                } else {
-                    session.update_director(start.elapsed())?;
-                }
-
-                // Rendering: ensure DMA-buf textures are cached, then borrow both
-                {
-                    reco_core::profile_scope!("dmabuf_ensure_cached");
-                    dmabuf_cache
-                        .ensure_imported(
-                            session.gpu(),
-                            pair.left.dmabuf_fd,
-                            pair.left.width,
-                            pair.left.height,
-                            pair.left.y_offset,
-                            pair.left.uv_offset,
-                            pair.left.total_size,
-                        )
-                        .map_err(|e| anyhow::anyhow!("left DMA-buf import: {e}"))?;
-                    dmabuf_cache
-                        .ensure_imported(
-                            session.gpu(),
-                            pair.right.dmabuf_fd,
-                            pair.right.width,
-                            pair.right.height,
-                            pair.right.y_offset,
-                            pair.right.uv_offset,
-                            pair.right.total_size,
-                        )
-                        .map_err(|e| anyhow::anyhow!("right DMA-buf import: {e}"))?;
-                }
-                let left_textures = dmabuf_cache.get(pair.left.dmabuf_fd);
-                let right_textures = dmabuf_cache.get(pair.right.dmabuf_fd);
-
-                let pos = session.director_position();
-                {
-                    reco_core::profile_scope!("stitch_and_encode");
-                    session.process_frame_imported_nv12(
-                        &left_textures.y_texture,
-                        &left_textures.uv_texture,
-                        &right_textures.y_texture,
-                        &right_textures.uv_texture,
-                        pos.yaw,
-                        pos.pitch,
-                    )?;
-                }
-
-                source.release_previous();
-
-                frame_count += 1;
-                progress.report(frame_count);
+            // Allocate the NvBufSurfTransform detection surfaces. The model
+            // input is square; all shipped yolo26 engines use 1280x1280.
+            // Skipped when there is no detector (sweep / no model) - the
+            // detection arm then no-ops and the director still advances.
+            if ai_tracking {
+                let model_size = 1280u32;
+                session
+                    .setup_nvmm_detection(model_size, capture_width, capture_height)
+                    .map_err(|e| anyhow::anyhow!("NVMM detection setup: {e}"))?;
             }
+
+            // Periodic "Processed N frames (… fps)" lines (parsed by gameday.py).
+            let reporter = helpers::ProgressReporter::new(30);
+            let on_progress: reco_core::session::types::ProgressCallback =
+                Box::new(move |p: &reco_core::session::types::FrameProgress| {
+                    reporter.report_with_elapsed(p.frames_completed, p.elapsed);
+                });
+
+            println!("Starting NVMM capture...");
+            frame_count = session.run(&mut source, frame_limit, interrupted, Some(on_progress))?;
 
             source.stop();
             #[cfg(feature = "replay")]
             session.clear_stacked_gpu_recorder();
             session.finish()?;
 
-            progress.finish(frame_count, output);
+            // Finish summary (matches `ProgressReporter::finish` formatting).
+            let secs = start.elapsed().as_secs_f64().max(1e-9);
+            println!(
+                "\n\nDone: {frame_count} frames in {secs:.1}s ({:.1} fps) \u{2192} {output}",
+                frame_count as f64 / secs
+            );
         }
 
         #[cfg(not(target_os = "linux"))]

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -399,6 +399,15 @@ enum Commands {
         #[arg(long, default_value_t = 30)]
         snapshot_interval: u64,
 
+        /// Lookahead buffer in seconds for the live camera path. The panner
+        /// leads the play by this window and the loop centered-smooths the
+        /// pose lag-free, the same as `stitch --lookahead`. Adds ~this much
+        /// latency and a VRAM pool sized to the window, so the live default
+        /// is modest. Only engages with AI tracking (needs --model,
+        /// non-sweep). 0 = off (immediate render).
+        #[arg(long, default_value_t = 0.75)]
+        lookahead: f64,
+
         /// Encoder quality on a 0-100 scale (higher = better). Overrides the
         /// quality preset. See `stitch --help` for the full mapping table.
         #[arg(long = "quality-value")]
@@ -881,6 +890,7 @@ fn main() -> anyhow::Result<()> {
             snapshot_dir,
             #[cfg(feature = "snapshot")]
             snapshot_interval,
+            lookahead,
             quality_value,
             preset,
             container,
@@ -949,6 +959,7 @@ fn main() -> anyhow::Result<()> {
                     snapshot_dir: snapshot_dir.as_deref(),
                     #[cfg(feature = "snapshot")]
                     snapshot_interval,
+                    lookahead,
                     quality_value,
                     preset,
                     container: container.as_deref(),

--- a/crates/reco-core/src/session/detection_dispatch.rs
+++ b/crates/reco-core/src/session/detection_dispatch.rs
@@ -109,6 +109,8 @@ impl StitchSession {
                     left.width(),
                     left.height(),
                 ),
+                #[cfg(target_os = "linux")]
+                StereoFrame::NvmmResident { left, right } => self.nvmm_run_detection(left, right),
                 _ => {
                     let (w, h) = self.core.pipeline().source_info();
                     self.detection.run_detection(frame, w, h)
@@ -133,6 +135,82 @@ impl StitchSession {
         );
 
         Ok(world)
+    }
+
+    /// Allocate the NVMM detection surfaces for the Jetson zero-copy path.
+    ///
+    /// Call once before [`run`](Self::run) when feeding a
+    /// `StereoFrame::NvmmResident` source (mirrors
+    /// [`setup_gpu_source`](Self::setup_gpu_source) for the desktop GPU
+    /// path). `model_size` is the detector's square input dimension (e.g.
+    /// 1280); `src_width`/`src_height` are the capture resolution, used to
+    /// compute the letterbox geometry. Without this the NVMM detection arm
+    /// no-ops (the director still advances, just without detections).
+    #[cfg(target_os = "linux")]
+    pub fn setup_nvmm_detection(
+        &mut self,
+        model_size: u32,
+        src_width: u32,
+        src_height: u32,
+    ) -> Result<(), SessionError> {
+        let left =
+            crate::nvbuf_transform::NvBufDetectionSurface::new(model_size, src_width, src_height)
+                .map_err(|e| SessionError::ZeroCopy(format!("NVMM left detection surface: {e}")))?;
+        let right =
+            crate::nvbuf_transform::NvBufDetectionSurface::new(model_size, src_width, src_height)
+                .map_err(|e| SessionError::ZeroCopy(format!("NVMM right detection surface: {e}")))?;
+        self.nvmm_det_left = Some(left);
+        self.nvmm_det_right = Some(right);
+        log::info!(
+            "NVMM detection surfaces ready: {model_size}x{model_size} (src {src_width}x{src_height})"
+        );
+        Ok(())
+    }
+
+    /// Run detection on a stereo NVMM frame via NvBufSurfTransform.
+    ///
+    /// Letterboxes both cameras' raw NVMM surfaces into the pre-allocated
+    /// CUDA RGBA detection buffers (set up by
+    /// [`setup_nvmm_detection`](Self::setup_nvmm_detection)) and runs the
+    /// detector on them. Returns empty if the surfaces are not set up or a
+    /// transform fails. Shared by the buffered produce arm
+    /// ([`detect_and_track_only`](Self::detect_and_track_only)) and the
+    /// immediate-render detect arm.
+    #[cfg(target_os = "linux")]
+    pub(crate) fn nvmm_run_detection(
+        &mut self,
+        left: &crate::source::NvmmPlaneInfo,
+        right: &crate::source::NvmmPlaneInfo,
+    ) -> Vec<Detection> {
+        // Transform both surfaces, capturing the (Copy) device pointers so
+        // the &mut borrows on the detection surfaces end before the
+        // detection pipeline borrow begins.
+        let (left_ptr, right_ptr) = {
+            let (Some(det_left), Some(det_right)) =
+                (self.nvmm_det_left.as_mut(), self.nvmm_det_right.as_mut())
+            else {
+                return Vec::new();
+            };
+            unsafe {
+                if let Err(e) = det_left.transform_from_nvmm(left.surface_ptr) {
+                    log::warn!("NVMM left detection transform failed: {e}");
+                    return Vec::new();
+                }
+                if let Err(e) = det_right.transform_from_nvmm(right.surface_ptr) {
+                    log::warn!("NVMM right detection transform failed: {e}");
+                    return Vec::new();
+                }
+            }
+            (det_left.data_ptr, det_right.data_ptr)
+        };
+        self.detection.run_detection_preletterboxed(
+            left_ptr,
+            left.width,
+            left.height,
+            right_ptr,
+            right.width,
+            right.height,
+        )
     }
 
     /// Run detection on a CPU-resident stereo frame (YUV420P / NV12).

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -170,6 +170,18 @@ impl StitchSession {
                         false
                     }
                 }
+                #[cfg(target_os = "linux")]
+                StereoFrame::NvmmResident { left, right } => {
+                    // Immediate (non-lookahead) NVMM detection: letterbox via
+                    // NvBufSurfTransform, then detect. (The buffered path runs
+                    // detection during produce and skips this whole step.)
+                    if scheduled_detection {
+                        let detections = self.nvmm_run_detection(left, right);
+                        self.detection.last_detections = self.map_detections(detections);
+                    }
+                    self.fire_sink_and_update_director(elapsed, scheduled_detection)?;
+                    scheduled_detection
+                }
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
                 StereoFrame::MetalResident { left, right } => {
                     self.detect_and_update_director_metal(
@@ -235,6 +247,18 @@ impl StitchSession {
                 right_slot,
             } => {
                 self.render_gpu_resident(*left_slot, *right_slot, pos.yaw, pos.pitch)?;
+            }
+            #[cfg(target_os = "linux")]
+            StereoFrame::NvmmResident { left, right } => {
+                if self.current_vram_slot.is_some() {
+                    // Buffered path: the frame was already imported + copied
+                    // into the pool slot during produce; render from it. The
+                    // slot args are ignored when current_vram_slot is set.
+                    self.render_gpu_resident(0, 0, pos.yaw, pos.pitch)?;
+                } else {
+                    // Immediate path: import the DMA-buf and render directly.
+                    self.render_nvmm_immediate(left, right, pos.yaw, pos.pitch)?;
+                }
             }
             #[cfg(target_os = "windows")]
             StereoFrame::D3d11Resident {
@@ -505,6 +529,58 @@ impl StitchSession {
         Ok(())
     }
 
+    /// Render an NVMM frame directly from imported DMA-buf textures
+    /// (immediate / non-lookahead path).
+    ///
+    /// Imports both cameras' DMA-bufs into Vulkan textures (cached by fd)
+    /// and renders via [`process_frame_imported_nv12`](Self::process_frame_imported_nv12).
+    /// The buffered (lookahead) path uses the VRAM pool instead; this is the
+    /// fallback when no pool exists (`lookahead == 0`).
+    #[cfg(target_os = "linux")]
+    fn render_nvmm_immediate(
+        &mut self,
+        left: &crate::source::NvmmPlaneInfo,
+        right: &crate::source::NvmmPlaneInfo,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<(), SessionError> {
+        if self.nvmm_dmabuf_cache.is_none() {
+            self.nvmm_dmabuf_cache = Some(crate::interop::dmabuf::DmaBufTextureCache::new());
+        }
+        let gpu = self.core.pipeline().gpu();
+        let cache = self.nvmm_dmabuf_cache.as_mut().unwrap();
+        cache
+            .ensure_imported(
+                gpu,
+                left.dmabuf_fd,
+                left.width,
+                left.height,
+                left.y_offset,
+                left.uv_offset,
+                left.total_size,
+            )
+            .map_err(|e| SessionError::ZeroCopy(format!("left NVMM DMA-buf import: {e}")))?;
+        cache
+            .ensure_imported(
+                gpu,
+                right.dmabuf_fd,
+                right.width,
+                right.height,
+                right.y_offset,
+                right.uv_offset,
+                right.total_size,
+            )
+            .map_err(|e| SessionError::ZeroCopy(format!("right NVMM DMA-buf import: {e}")))?;
+
+        // Clone the texture handles (cheap, Arc-backed) to drop the cache
+        // borrow before the &mut self render call.
+        let left_tex = cache.get(left.dmabuf_fd);
+        let right_tex = cache.get(right.dmabuf_fd);
+        let (ly, lu) = (left_tex.y_texture.clone(), left_tex.uv_texture.clone());
+        let (ry, ru) = (right_tex.y_texture.clone(), right_tex.uv_texture.clone());
+        self.process_frame_imported_nv12(&ly, &lu, &ry, &ru, yaw, pitch)
+    }
+
     /// Stage D3D11VA decoded frames into the shared staging pool.
     ///
     /// Lazily creates the pool on first call. Performs `CopySubresourceRegion`
@@ -750,6 +826,13 @@ impl StitchSession {
         frame: &StereoFrame,
         _produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
+        // NVMM zero-copy: import the DMA-buf as Vulkan textures and copy
+        // them into a VRAM pool slot - the same import-then-copy pattern
+        // as the macOS Metal arm, just sourced from an NvBufSurface fd
+        // instead of a CVPixelBuffer.
+        if let StereoFrame::NvmmResident { left, right } = frame {
+            return self.copy_nvmm_to_vram_pool(left, right);
+        }
         let (ls, rs) = match frame {
             StereoFrame::GpuResident {
                 left_slot,
@@ -787,6 +870,74 @@ impl StitchSession {
             }
         }
         Ok(None)
+    }
+
+    /// Import a stereo NVMM frame's DMA-bufs and copy them into a VRAM
+    /// pool slot for buffered (lookahead) rendering.
+    ///
+    /// Mirrors the macOS Metal import path: the per-camera DMA-buf is
+    /// imported into Vulkan textures (cached by fd, since the ISP rotates a
+    /// small fd pool), then `copy_from_textures` blits both cameras' Y/UV
+    /// planes into a freshly acquired pool slot. The blit is awaited before
+    /// returning so the source may recycle the DMA-buf immediately after.
+    #[cfg(target_os = "linux")]
+    fn copy_nvmm_to_vram_pool(
+        &mut self,
+        left: &crate::source::NvmmPlaneInfo,
+        right: &crate::source::NvmmPlaneInfo,
+    ) -> Result<Option<usize>, SessionError> {
+        if self.vram_pool.is_none() {
+            return Ok(None);
+        }
+        if self.nvmm_dmabuf_cache.is_none() {
+            self.nvmm_dmabuf_cache = Some(crate::interop::dmabuf::DmaBufTextureCache::new());
+        }
+
+        let gpu = self.core.pipeline().gpu();
+        let cache = self.nvmm_dmabuf_cache.as_mut().unwrap();
+        cache
+            .ensure_imported(
+                gpu,
+                left.dmabuf_fd,
+                left.width,
+                left.height,
+                left.y_offset,
+                left.uv_offset,
+                left.total_size,
+            )
+            .map_err(|e| SessionError::ZeroCopy(format!("left NVMM DMA-buf import: {e}")))?;
+        cache
+            .ensure_imported(
+                gpu,
+                right.dmabuf_fd,
+                right.width,
+                right.height,
+                right.y_offset,
+                right.uv_offset,
+                right.total_size,
+            )
+            .map_err(|e| SessionError::ZeroCopy(format!("right NVMM DMA-buf import: {e}")))?;
+
+        let left_tex = cache.get(left.dmabuf_fd);
+        let right_tex = cache.get(right.dmabuf_fd);
+        let pool = self.vram_pool.as_mut().unwrap();
+        let slot = pool.acquire().ok_or_else(|| {
+            SessionError::Config(format!(
+                "VRAM pool exhausted ({} slots, {} available)",
+                pool.capacity(),
+                pool.available()
+            ))
+        })?;
+        pool.copy_from_textures(
+            gpu,
+            slot,
+            &left_tex.y_texture,
+            &left_tex.uv_texture,
+            &right_tex.y_texture,
+            &right_tex.uv_texture,
+        );
+        let _ = gpu.device.poll(wgpu::PollType::wait_indefinitely());
+        Ok(Some(slot))
     }
 
     #[cfg(target_os = "windows")]

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -173,6 +173,19 @@ pub struct StitchSession {
     #[cfg(target_os = "windows")]
     pub(crate) d3d11_staging_pool: Option<crate::interop::d3d11::D3d11StagingPool>,
 
+    /// DMA-buf -> Vulkan texture cache for the NVMM zero-copy render path
+    /// (Jetson). Keyed by DMA-buf fd; the ISP rotates a small fd pool so
+    /// each is imported once. Created lazily on the first NvmmResident frame.
+    #[cfg(target_os = "linux")]
+    pub(crate) nvmm_dmabuf_cache: Option<crate::interop::dmabuf::DmaBufTextureCache>,
+    /// Left-camera NvBufSurfTransform detection surface (Jetson NVMM path).
+    /// Allocated by [`setup_nvmm_detection`](Self::setup_nvmm_detection).
+    #[cfg(target_os = "linux")]
+    pub(crate) nvmm_det_left: Option<crate::nvbuf_transform::NvBufDetectionSurface>,
+    /// Right-camera NvBufSurfTransform detection surface (Jetson NVMM path).
+    #[cfg(target_os = "linux")]
+    pub(crate) nvmm_det_right: Option<crate::nvbuf_transform::NvBufDetectionSurface>,
+
     /// Camera rotation from stream metadata, populated by
     /// [`configure_from_source`](Self::configure_from_source).
     /// Used to tell the GPU detector to flip frames during preprocessing.
@@ -293,6 +306,12 @@ impl StitchSession {
             metal_texture_cache: None,
             #[cfg(target_os = "windows")]
             d3d11_staging_pool: None,
+            #[cfg(target_os = "linux")]
+            nvmm_dmabuf_cache: None,
+            #[cfg(target_os = "linux")]
+            nvmm_det_left: None,
+            #[cfg(target_os = "linux")]
+            nvmm_det_right: None,
             #[cfg(any(target_os = "linux", target_os = "windows"))]
             left_rotation: 0,
             #[cfg(any(target_os = "linux", target_os = "windows"))]

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -258,6 +258,42 @@ pub struct Nv12FramePair {
     pub right: Nv12Data,
 }
 
+/// Per-camera metadata for an NVMM zero-copy frame (Jetson).
+///
+/// Carries the DMA-buf fd (Vulkan render import) and the raw
+/// `NvBufSurface*` pointer (NvBufSurfTransform detection preprocessing)
+/// for one camera, plus the plane geometry needed for the Vulkan import.
+/// This is the reco-core mirror of reco-io's `NvmmFrameInfo` - reco-core
+/// has no I/O deps, so the I/O backend constructs this from its own type.
+///
+/// Both the fd and the surface pointer are only valid while the source
+/// holds the underlying GStreamer sample alive (until the session has
+/// copied the frame into the VRAM pool and run detection on it).
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy)]
+pub struct NvmmPlaneInfo {
+    /// DMA-buf file descriptor for Vulkan import (render path).
+    pub dmabuf_fd: i32,
+    /// Frame width in pixels.
+    pub width: u32,
+    /// Frame height in pixels.
+    pub height: u32,
+    /// Y plane byte offset within the DMA-buf.
+    pub y_offset: u32,
+    /// UV plane byte offset within the DMA-buf.
+    pub uv_offset: u32,
+    /// Total allocation size (Vulkan memory import).
+    pub total_size: u32,
+    /// Raw `NvBufSurface*` pointer for `NvBufSurfTransform` (detection path).
+    pub surface_ptr: *mut std::ffi::c_void,
+}
+
+// SAFETY: the surface pointer is a stable kernel-managed NVMM pool address;
+// the source's capture thread keeps the GstSample alive until release. The
+// session that consumes this never moves it across threads.
+#[cfg(target_os = "linux")]
+unsafe impl Send for NvmmPlaneInfo {}
+
 /// A stereo frame in any supported format.
 ///
 /// Sources produce whichever format is most efficient for their backend:
@@ -265,6 +301,7 @@ pub struct Nv12FramePair {
 /// - Jetson ISP / NVDEC NV12: `Nv12`
 /// - CUDA/Vulkan zero-copy shared textures: `GpuResident`
 /// - VideoToolbox/Metal zero-copy: `MetalResident`
+/// - Jetson NVMM zero-copy (DMA-buf + NvBufSurface): `NvmmResident`
 #[non_exhaustive]
 pub enum StereoFrame {
     /// CPU-resident YUV420P planes (3 planes per camera).
@@ -301,6 +338,17 @@ pub enum StereoFrame {
         right_texture: *mut std::ffi::c_void,
         /// Array slice index within the D3D11VA decode pool for right camera.
         right_slice: usize,
+    },
+    /// Jetson NVMM zero-copy: NV12 frames in NvBufSurface DMA-buf memory.
+    /// The session imports the DMA-buf as Vulkan textures for rendering
+    /// (copied into the VRAM pool) and runs `NvBufSurfTransform` on the
+    /// surface pointer for detection. Produced by the NVMM camera source.
+    #[cfg(target_os = "linux")]
+    NvmmResident {
+        /// Left camera NVMM plane metadata.
+        left: NvmmPlaneInfo,
+        /// Right camera NVMM plane metadata.
+        right: NvmmPlaneInfo,
     },
 }
 

--- a/crates/reco-io/src/gstreamer/camera.rs
+++ b/crates/reco-io/src/gstreamer/camera.rs
@@ -739,6 +739,10 @@ mod nvmm_source {
         right_release: mpsc::SyncSender<()>,
         info: SourceInfo,
         stop: Arc<AtomicBool>,
+        /// Whether a frame from the most recent `next_frame()` is still
+        /// holding its DMA-buf (must be released before pulling the next).
+        /// Drives the deferred release in the `FrameSource` impl.
+        outstanding: bool,
     }
 
     impl GstreamerNvmmCameraSource {
@@ -786,6 +790,7 @@ mod nvmm_source {
                 right_release,
                 info,
                 stop,
+                outstanding: false,
             })
         }
 
@@ -821,6 +826,59 @@ mod nvmm_source {
         /// Stop capture gracefully.
         pub fn stop(&self) {
             self.stop.store(true, Ordering::Relaxed);
+        }
+    }
+
+    /// Convert reco-io's `NvmmFrameInfo` into reco-core's `NvmmPlaneInfo`.
+    fn to_plane_info(info: &NvmmFrameInfo) -> reco_core::source::NvmmPlaneInfo {
+        reco_core::source::NvmmPlaneInfo {
+            dmabuf_fd: info.dmabuf_fd,
+            width: info.width,
+            height: info.height,
+            y_offset: info.y_offset,
+            uv_offset: info.uv_offset,
+            total_size: info.total_size,
+            surface_ptr: info.surface_ptr,
+        }
+    }
+
+    impl reco_core::source::FrameSource for GstreamerNvmmCameraSource {
+        fn info(&self) -> SourceInfo {
+            self.info.clone()
+        }
+
+        /// Pull the next NVMM stereo frame as [`StereoFrame::NvmmResident`].
+        ///
+        /// Releases the previous frame's DMA-buf first (deferred release):
+        /// the capture thread blocks until released, and the session has
+        /// finished importing + detecting the prior frame by the time this
+        /// is called again, so the buffer is safe to recycle. Exactly one
+        /// frame is ever unreleased.
+        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+            if self.outstanding {
+                self.release_previous();
+                self.outstanding = false;
+            }
+            match self.next_pair()? {
+                Some(pair) => {
+                    self.outstanding = true;
+                    Ok(Some(StereoFrame::NvmmResident {
+                        left: to_plane_info(&pair.left),
+                        right: to_plane_info(&pair.right),
+                    }))
+                }
+                None => Ok(None),
+            }
+        }
+
+        /// NVMM frames are GPU-resident (DMA-buf imported into Vulkan).
+        fn is_gpu_resident(&self) -> bool {
+            true
+        }
+
+        /// NVMM cameras deliver NV12 (NVIDIA ISP native format).
+        fn gpu_pixel_format(&self) -> reco_core::render::renderer::GpuPixelFormat {
+            reco_core::render::renderer::GpuPixelFormat::Nv12
         }
     }
 


### PR DESCRIPTION
Routes the Jetson NVMM zero-copy camera through the session's buffered frame loop, so lookahead, centered smoothing, and the VRAM pool work on the live path - the same machinery the file-stitch path already uses. Additive: desktop NVDEC / D3D11 / Metal paths are untouched.

- **reco-core** `source.rs`: `StereoFrame::NvmmResident` + `NvmmPlaneInfo` (reco-core mirror of reco-io's `NvmmFrameInfo`; reco-core keeps no I/O deps).
- **reco-core** `frame_processing.rs`: a Linux arm that imports the DMA-buf into the VRAM pool (same import-then-`copy_from_textures` pattern as the macOS Metal arm) for buffered render, an immediate-render fallback, and the NVMM detect arm.
- **reco-core** `detection_dispatch.rs`: `setup_nvmm_detection` + `nvmm_run_detection` (NvBufSurfTransform letterbox -> `run_detection_preletterboxed`).
- **reco-io**: `GstreamerNvmmCameraSource` implements `FrameSource` with a one-frame-deferred release (the capture thread blocks until release; the session copies+detects synchronously before the next pull).
- **reco-cli**: the camera NVMM branch collapses to `session.run()`; adds `--lookahead` (default 0.75s, AI-gated).

Validated live on a Jetson Orin: NVMM zero-copy + TensorRT YOLO + 0.75s lookahead, full 30fps real-time, clean output. Reconciled on top of the env-var (#383) and snapshot (#384) changes.