### PR TITLE
feat(reco-core): CPU stitching backend (GPU/CPU selectable, projection-agnostic)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -66,6 +66,13 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # The GPU-execution tests (CPU-vs-GPU stitch agreement, KB4) run against a
+    # software Vulkan adapter (lavapipe) so they are actually exercised in CI
+    # instead of silently skipping on the GPU-less runner. RECO_REQUIRE_GPU
+    # turns "no adapter" into a hard failure, so a missing/broken adapter fails
+    # CI loudly rather than letting the agreement tests pass vacuously.
+    env:
+      RECO_REQUIRE_GPU: "1"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: dtolnay/rust-toolchain@stable
@@ -73,6 +80,12 @@ jobs:
       - uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05 # v1.6.0
         with:
           packages: ${{ env.APT_PACKAGES }}
+      - name: Install software Vulkan (lavapipe) for GPU-execution tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y mesa-vulkan-drivers vulkan-tools
+          echo "--- vulkaninfo --summary ---"
+          vulkaninfo --summary 2>&1 | head -40 || true
       - name: Run tests (default)
         run: cargo test --workspace
       - name: Run tests (with profiling)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5203,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/crates/reco-core/src/lib.rs
+++ b/crates/reco-core/src/lib.rs
@@ -90,4 +90,5 @@ pub mod projection;
 pub mod render;
 pub mod session;
 pub mod source;
+pub mod stitch;
 pub mod telemetry;

--- a/crates/reco-core/src/render/renderer.rs
+++ b/crates/reco-core/src/render/renderer.rs
@@ -36,9 +36,9 @@ use wgpu::util::DeviceExt;
 // ---- Constants ----
 
 /// Near clipping plane for the perspective projection.
-const NEAR_PLANE: f32 = 0.01;
+pub(crate) const NEAR_PLANE: f32 = 0.01;
 /// Far clipping plane for the perspective projection.
-const FAR_PLANE: f32 = 5.0;
+pub(crate) const FAR_PLANE: f32 = 5.0;
 /// Aspect ratio of scene planes (matches GoPro 16:9 capture).
 ///
 /// Deprecated: derive the aspect ratio from camera parameters instead.
@@ -1174,7 +1174,7 @@ fn upload_nv12(
 /// planes meet) by default. This matches v1 Three.js where the OrbitControls
 /// target is `[0, 0, 0]`. `yaw` rotates around Y (left/right from center),
 /// `pitch` rotates around X (up/down).
-fn view_matrix(
+pub(crate) fn view_matrix(
     position: &[f32; 3],
     yaw: f32,
     pitch: f32,

--- a/crates/reco-core/src/stitch/backend.rs
+++ b/crates/reco-core/src/stitch/backend.rs
@@ -1,0 +1,305 @@
+//! Backend selection: one interface to stitch a frame on the GPU or the CPU.
+//!
+//! [`StitchBackend`] is a deliberately narrow, synchronous contract -
+//! "NV12 planes + pan -> RGBA bytes" - the common denominator both backends
+//! produce naturally. It does NOT try to unify the GPU pipeline's specialised
+//! paths (zero-copy import, triple-buffered streaming readback, GUI texture
+//! handoff); those keep their dedicated route through [`crate::core`]. This
+//! trait covers the headless "give me stitched RGBA, GPU or CPU" case - cloud
+//! encode, edge devices, CLI - where the two backends converge on RGBA.
+//!
+//! - [`CpuStitchBackend`] wraps the pure-Rust [`stitch_l_shape_rgba`].
+//! - [`GpuStitchBackend`] wraps the wgpu [`StitchPipeline`], absorbing its own
+//!   render + blocking-readback so it satisfies the synchronous contract.
+//!
+//! When `wgpu` becomes optional (Phase 3), [`GpuStitchBackend`] moves behind a
+//! feature; [`CpuStitchBackend`] stays unconditional.
+
+use crate::calibration::MatchCalibration;
+use crate::gpu::GpuContext;
+use crate::gpu::rgba_readback::{RgbaReadback, RgbaReadbackError};
+use crate::render::pipeline::{PipelineError, StitchPipeline};
+use crate::render::planes::Nv12Planes;
+use crate::render::renderer::InputFormat;
+use crate::render::viewport::ViewportConfig;
+
+use super::stitch_l_shape_rgba;
+
+/// Errors a [`StitchBackend`] can return.
+#[derive(Debug, thiserror::Error)]
+pub enum StitchError {
+    /// The GPU pipeline failed to record or upload a frame.
+    #[error("gpu pipeline: {0}")]
+    Pipeline(#[from] PipelineError),
+    /// The GPU readback failed.
+    #[error("gpu readback: {0}")]
+    Readback(#[from] RgbaReadbackError),
+    /// The GPU pipeline did not yield a frame when one was expected.
+    #[error("gpu produced no frame")]
+    NoOutput,
+}
+
+/// One frame's stitch, GPU or CPU, behind a single interface.
+///
+/// Backends are configured for a fixed source size and output viewport at
+/// construction; [`stitch`](Self::stitch) takes only the per-frame planes and
+/// pan. Output is `width * height * 4` sRGB-domain RGBA, identical in layout
+/// across backends (the GPU and CPU agree to ~1 LSB).
+pub trait StitchBackend {
+    /// Stitch one NV12 frame pair to RGBA at the configured output size.
+    fn stitch(
+        &mut self,
+        left: &Nv12Planes,
+        right: &Nv12Planes,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Vec<u8>, StitchError>;
+
+    /// Output dimensions `(width, height)` in pixels.
+    fn output_dims(&self) -> (u32, u32);
+
+    /// Short backend name for logs and diagnostics.
+    fn name(&self) -> &'static str;
+}
+
+/// CPU software backend - pure Rust, no GPU. The portable / GPU-less path.
+pub struct CpuStitchBackend {
+    calib: MatchCalibration,
+    config: ViewportConfig,
+    cam: (u32, u32),
+    full_range: bool,
+}
+
+impl CpuStitchBackend {
+    /// Configure a CPU backend for a fixed source size and output viewport.
+    pub fn new(
+        calib: MatchCalibration,
+        config: ViewportConfig,
+        cam_w: u32,
+        cam_h: u32,
+        full_range: bool,
+    ) -> Self {
+        Self {
+            calib,
+            config,
+            cam: (cam_w, cam_h),
+            full_range,
+        }
+    }
+}
+
+impl StitchBackend for CpuStitchBackend {
+    fn stitch(
+        &mut self,
+        left: &Nv12Planes,
+        right: &Nv12Planes,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Vec<u8>, StitchError> {
+        Ok(stitch_l_shape_rgba(
+            left,
+            right,
+            self.cam,
+            &self.calib,
+            &self.config,
+            yaw,
+            pitch,
+            self.full_range,
+        ))
+    }
+
+    fn output_dims(&self) -> (u32, u32) {
+        (self.config.width, self.config.height)
+    }
+
+    fn name(&self) -> &'static str {
+        "cpu"
+    }
+}
+
+/// GPU backend - wraps the wgpu [`StitchPipeline`]. Renders one frame and
+/// blocks on readback so it satisfies the synchronous [`StitchBackend`]
+/// contract. Streaming consumers that want pipelined throughput should use
+/// [`crate::core`] directly instead.
+pub struct GpuStitchBackend {
+    pipeline: StitchPipeline,
+    readback: RgbaReadback,
+    dims: (u32, u32),
+}
+
+impl GpuStitchBackend {
+    /// Configure a GPU backend. `gpu` is injected so reco-core does not pull an
+    /// async runtime into non-test code; callers create it via
+    /// [`GpuContext::new`].
+    pub fn new(
+        gpu: GpuContext,
+        calib: MatchCalibration,
+        config: ViewportConfig,
+        cam_w: u32,
+        cam_h: u32,
+        full_range: bool,
+    ) -> Result<Self, StitchError> {
+        let mut pipeline = StitchPipeline::with_gpu(
+            gpu,
+            calib,
+            config.clone(),
+            cam_w,
+            cam_h,
+            wgpu::TextureFormat::Rgba8Unorm,
+            InputFormat::Nv12,
+        )?;
+        pipeline.set_full_range(full_range);
+        let readback = RgbaReadback::new(pipeline.gpu(), config.width, config.height)?;
+        Ok(Self {
+            pipeline,
+            readback,
+            dims: (config.width, config.height),
+        })
+    }
+}
+
+impl StitchBackend for GpuStitchBackend {
+    fn stitch(
+        &mut self,
+        left: &Nv12Planes,
+        right: &Nv12Planes,
+        yaw: f32,
+        pitch: f32,
+    ) -> Result<Vec<u8>, StitchError> {
+        // Record the frame, submit it via the readback, then drain it
+        // synchronously: one render in, this frame's RGBA out.
+        let cmd = self
+            .pipeline
+            .render_to_target_nv12(left, right, yaw, pitch)?;
+        let tex = self.pipeline.render_target();
+        self.readback.readback(self.pipeline.gpu(), tex, cmd)?;
+        match self.readback.flush_pending(self.pipeline.gpu())? {
+            Some(bytes) => Ok(bytes.to_vec()),
+            None => Err(StitchError::NoOutput),
+        }
+    }
+
+    fn output_dims(&self) -> (u32, u32) {
+        self.dims
+    }
+
+    fn name(&self) -> &'static str {
+        "gpu"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calibration::{CameraParams, PlaneLayout};
+
+    fn test_calib(w: u32, h: u32) -> MatchCalibration {
+        let cam = || CameraParams {
+            width: w,
+            height: h,
+            fx: w as f64 * 0.5,
+            fy: w as f64 * 0.5,
+            cx: w as f64 * 0.5,
+            cy: h as f64 * 0.5,
+            d: [-0.02, 0.004, 0.0, 0.0],
+        };
+        MatchCalibration {
+            left: cam(),
+            right: cam(),
+            layout: PlaneLayout {
+                camera_axis_offset: 0.25,
+                intersect: 0.5,
+                x_ty: 0.0,
+                x_rz: 0.0,
+                z_rx: 0.0,
+                x_rx: 0.0,
+                z_rz: 0.0,
+            },
+            rig_tilt: 0.0,
+            rig_roll: 0.0,
+            sync_offset: 0,
+            field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
+        }
+    }
+
+    fn nv12(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>) {
+        let y: Vec<u8> = (0..w * h)
+            .map(|i| ((i % w) as usize * 255 / w as usize) as u8)
+            .map(|val| val.saturating_add(bias))
+            .collect();
+        let uv = vec![128u8; (w * (h / 2)) as usize];
+        (y, uv)
+    }
+
+    #[test]
+    fn cpu_backend_reports_dims_and_name() {
+        let (w, h) = (64u32, 36u32);
+        let backend = CpuStitchBackend::new(
+            test_calib(w, h),
+            ViewportConfig {
+                width: w,
+                height: h,
+                ..Default::default()
+            },
+            w,
+            h,
+            false,
+        );
+        assert_eq!(backend.output_dims(), (w, h));
+        assert_eq!(backend.name(), "cpu");
+    }
+
+    #[test]
+    fn cpu_and_gpu_backends_agree() {
+        use crate::gpu::GpuError;
+
+        let gpu = match pollster::block_on(GpuContext::new()) {
+            Ok(g) => g,
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                eprintln!("skipping backend agreement: no adapter");
+                return;
+            }
+            Err(e) => panic!("gpu init: {e}"),
+        };
+
+        let (cam_w, cam_h) = (192u32, 108u32);
+        let (out_w, out_h) = (160u32, 90u32);
+        let calib = test_calib(cam_w, cam_h);
+        let config = ViewportConfig {
+            width: out_w,
+            height: out_h,
+            ..Default::default()
+        };
+        let (ly, luv) = nv12(cam_w, cam_h, 0);
+        let (ry, ruv) = nv12(cam_w, cam_h, 30);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let (yaw, pitch) = (0.08f32, -0.04f32);
+
+        let mut cpu = CpuStitchBackend::new(calib.clone(), config.clone(), cam_w, cam_h, false);
+        let mut gpu =
+            GpuStitchBackend::new(gpu, calib, config, cam_w, cam_h, false).expect("gpu backend");
+
+        // Drive both through the trait object to prove selection works.
+        let backends: [&mut dyn StitchBackend; 2] = [&mut cpu, &mut gpu];
+        let mut outputs = Vec::new();
+        for b in backends {
+            assert_eq!(b.output_dims(), (out_w, out_h));
+            outputs.push(b.stitch(&left, &right, yaw, pitch).expect("stitch"));
+        }
+        let (cpu_rgba, gpu_rgba) = (&outputs[0], &outputs[1]);
+        assert_eq!(cpu_rgba.len(), (out_w * out_h * 4) as usize);
+        assert_eq!(cpu_rgba.len(), gpu_rgba.len());
+
+        let mut max = 0i32;
+        for (c, g) in cpu_rgba.chunks_exact(4).zip(gpu_rgba.chunks_exact(4)) {
+            for k in 0..3 {
+                max = max.max((c[k] as i32 - g[k] as i32).abs());
+            }
+        }
+        eprintln!("backend CPU-vs-GPU max RGB diff: {max}");
+        assert!(max <= 4, "backends disagree by {max} (>4)");
+    }
+}

--- a/crates/reco-core/src/stitch/backend.rs
+++ b/crates/reco-core/src/stitch/backend.rs
@@ -87,6 +87,9 @@ impl CpuStitchBackend {
         cam_h: u32,
         full_range: bool,
     ) -> Result<Self, StitchError> {
+        calib
+            .validate()
+            .map_err(|e| StitchError::InvalidConfig(e.to_string()))?;
         config.validate().map_err(StitchError::InvalidConfig)?;
         if cam_w < 2 || cam_h < 2 {
             return Err(StitchError::InvalidConfig(format!(
@@ -110,26 +113,9 @@ impl StitchBackend for CpuStitchBackend {
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
-        // Validate plane sizes (the GPU backend does too, via upload_nv12) so
-        // both backends return a typed error rather than the CPU path panicking
-        // on a short/truncated frame.
-        let (w, h) = (self.cam.0 as usize, self.cam.1 as usize);
-        let (y_len, uv_len) = (w * h, w * (h / 2));
-        for p in [left, right] {
-            if p.y.len() < y_len {
-                return Err(StitchError::FrameSizeMismatch {
-                    expected: y_len,
-                    actual: p.y.len(),
-                });
-            }
-            if p.uv.len() < uv_len {
-                return Err(StitchError::FrameSizeMismatch {
-                    expected: uv_len,
-                    actual: p.uv.len(),
-                });
-            }
-        }
-        Ok(stitch_l_shape_rgba(
+        // Plane-size + dimension validation lives in stitch_l_shape_rgba, which
+        // returns a typed error instead of panicking on a short/truncated frame.
+        stitch_l_shape_rgba(
             left,
             right,
             self.cam,
@@ -138,7 +124,7 @@ impl StitchBackend for CpuStitchBackend {
             yaw,
             pitch,
             self.full_range,
-        ))
+        )
     }
 
     fn output_dims(&self) -> (u32, u32) {
@@ -172,6 +158,9 @@ impl GpuStitchBackend {
         cam_h: u32,
         full_range: bool,
     ) -> Result<Self, StitchError> {
+        calib
+            .validate()
+            .map_err(|e| StitchError::InvalidConfig(e.to_string()))?;
         let mut pipeline = StitchPipeline::with_gpu(
             gpu,
             calib,

--- a/crates/reco-core/src/stitch/backend.rs
+++ b/crates/reco-core/src/stitch/backend.rs
@@ -34,9 +34,9 @@ pub enum StitchError {
     /// The GPU readback failed.
     #[error("gpu readback: {0}")]
     Readback(#[from] RgbaReadbackError),
-    /// The GPU pipeline did not yield a frame when one was expected.
-    #[error("gpu produced no frame")]
-    NoOutput,
+    /// Backend configuration is invalid (e.g. degenerate dimensions).
+    #[error("invalid stitch config: {0}")]
+    InvalidConfig(String),
     /// A source plane is smaller than the configured frame size.
     #[error("frame size mismatch: plane has {actual} bytes, need at least {expected}")]
     FrameSizeMismatch {
@@ -86,13 +86,19 @@ impl CpuStitchBackend {
         cam_w: u32,
         cam_h: u32,
         full_range: bool,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, StitchError> {
+        config.validate().map_err(StitchError::InvalidConfig)?;
+        if cam_w < 2 || cam_h < 2 {
+            return Err(StitchError::InvalidConfig(format!(
+                "source dimensions must be >= 2, got {cam_w}x{cam_h}"
+            )));
+        }
+        Ok(Self {
             calib,
             config,
             cam: (cam_w, cam_h),
             full_range,
-        }
+        })
     }
 }
 
@@ -200,10 +206,12 @@ impl StitchBackend for GpuStitchBackend {
             .render_to_target_nv12(left, right, yaw, pitch)?;
         let tex = self.pipeline.render_target();
         self.readback.readback(self.pipeline.gpu(), tex, cmd)?;
-        match self.readback.flush_pending(self.pipeline.gpu())? {
-            Some(bytes) => Ok(bytes.to_vec()),
-            None => Err(StitchError::NoOutput),
-        }
+        // A frame was just submitted, so flush_pending always drains it.
+        let frame = self
+            .readback
+            .flush_pending(self.pipeline.gpu())?
+            .expect("flush_pending yields the just-submitted frame");
+        Ok(frame.to_vec())
     }
 
     fn output_dims(&self) -> (u32, u32) {
@@ -218,53 +226,13 @@ impl StitchBackend for GpuStitchBackend {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calibration::{CameraParams, PlaneLayout};
-
-    fn test_calib(w: u32, h: u32) -> MatchCalibration {
-        let cam = || CameraParams {
-            width: w,
-            height: h,
-            fx: w as f64 * 0.5,
-            fy: w as f64 * 0.5,
-            cx: w as f64 * 0.5,
-            cy: h as f64 * 0.5,
-            d: [-0.02, 0.004, 0.0, 0.0],
-        };
-        MatchCalibration {
-            left: cam(),
-            right: cam(),
-            layout: PlaneLayout {
-                camera_axis_offset: 0.25,
-                intersect: 0.5,
-                x_ty: 0.0,
-                x_rz: 0.0,
-                z_rx: 0.0,
-                x_rx: 0.0,
-                z_rz: 0.0,
-            },
-            rig_tilt: 0.0,
-            rig_roll: 0.0,
-            sync_offset: 0,
-            field_roi: None,
-            lens_correction_amount: 1.0,
-            blend_width: 0.05,
-        }
-    }
-
-    fn nv12(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>) {
-        let y: Vec<u8> = (0..w * h)
-            .map(|i| ((i % w) as usize * 255 / w as usize) as u8)
-            .map(|val| val.saturating_add(bias))
-            .collect();
-        let uv = vec![128u8; (w * (h / 2)) as usize];
-        (y, uv)
-    }
+    use crate::stitch::test_support::{calib, gpu_or_skip, nv12};
 
     #[test]
     fn cpu_backend_reports_dims_and_name() {
         let (w, h) = (64u32, 36u32);
         let backend = CpuStitchBackend::new(
-            test_calib(w, h),
+            calib(w, h),
             ViewportConfig {
                 width: w,
                 height: h,
@@ -273,7 +241,8 @@ mod tests {
             w,
             h,
             false,
-        );
+        )
+        .expect("cpu backend");
         assert_eq!(backend.output_dims(), (w, h));
         assert_eq!(backend.name(), "cpu");
     }
@@ -282,7 +251,7 @@ mod tests {
     fn cpu_backend_rejects_undersized_planes() {
         let (w, h) = (64u32, 36u32);
         let mut backend = CpuStitchBackend::new(
-            test_calib(w, h),
+            calib(w, h),
             ViewportConfig {
                 width: w,
                 height: h,
@@ -291,7 +260,8 @@ mod tests {
             w,
             h,
             false,
-        );
+        )
+        .expect("cpu backend");
         let short = vec![0u8; 10];
         let planes = Nv12Planes {
             y: &short,
@@ -304,24 +274,13 @@ mod tests {
 
     #[test]
     fn cpu_and_gpu_backends_agree() {
-        use crate::gpu::GpuError;
-
-        let gpu = match pollster::block_on(GpuContext::new()) {
-            Ok(g) => g,
-            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
-                assert!(
-                    std::env::var("RECO_REQUIRE_GPU").is_err(),
-                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
-                );
-                eprintln!("skipping backend agreement: no adapter");
-                return;
-            }
-            Err(e) => panic!("gpu init: {e}"),
+        let Some(gpu) = gpu_or_skip() else {
+            return;
         };
 
         let (cam_w, cam_h) = (192u32, 108u32);
         let (out_w, out_h) = (160u32, 90u32);
-        let calib = test_calib(cam_w, cam_h);
+        let calib = calib(cam_w, cam_h);
         let config = ViewportConfig {
             width: out_w,
             height: out_h,
@@ -333,7 +292,8 @@ mod tests {
         let right = Nv12Planes { y: &ry, uv: &ruv };
         let (yaw, pitch) = (0.08f32, -0.04f32);
 
-        let mut cpu = CpuStitchBackend::new(calib.clone(), config.clone(), cam_w, cam_h, false);
+        let mut cpu = CpuStitchBackend::new(calib.clone(), config.clone(), cam_w, cam_h, false)
+            .expect("cpu backend");
         let mut gpu =
             GpuStitchBackend::new(gpu, calib, config, cam_w, cam_h, false).expect("gpu backend");
 

--- a/crates/reco-core/src/stitch/backend.rs
+++ b/crates/reco-core/src/stitch/backend.rs
@@ -309,6 +309,10 @@ mod tests {
         let gpu = match pollster::block_on(GpuContext::new()) {
             Ok(g) => g,
             Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                assert!(
+                    std::env::var("RECO_REQUIRE_GPU").is_err(),
+                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
+                );
                 eprintln!("skipping backend agreement: no adapter");
                 return;
             }

--- a/crates/reco-core/src/stitch/backend.rs
+++ b/crates/reco-core/src/stitch/backend.rs
@@ -37,6 +37,14 @@ pub enum StitchError {
     /// The GPU pipeline did not yield a frame when one was expected.
     #[error("gpu produced no frame")]
     NoOutput,
+    /// A source plane is smaller than the configured frame size.
+    #[error("frame size mismatch: plane has {actual} bytes, need at least {expected}")]
+    FrameSizeMismatch {
+        /// Minimum bytes the plane must contain for the configured dimensions.
+        expected: usize,
+        /// Bytes the supplied plane actually contains.
+        actual: usize,
+    },
 }
 
 /// One frame's stitch, GPU or CPU, behind a single interface.
@@ -96,6 +104,25 @@ impl StitchBackend for CpuStitchBackend {
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
+        // Validate plane sizes (the GPU backend does too, via upload_nv12) so
+        // both backends return a typed error rather than the CPU path panicking
+        // on a short/truncated frame.
+        let (w, h) = (self.cam.0 as usize, self.cam.1 as usize);
+        let (y_len, uv_len) = (w * h, w * (h / 2));
+        for p in [left, right] {
+            if p.y.len() < y_len {
+                return Err(StitchError::FrameSizeMismatch {
+                    expected: y_len,
+                    actual: p.y.len(),
+                });
+            }
+            if p.uv.len() < uv_len {
+                return Err(StitchError::FrameSizeMismatch {
+                    expected: uv_len,
+                    actual: p.uv.len(),
+                });
+            }
+        }
         Ok(stitch_l_shape_rgba(
             left,
             right,
@@ -249,6 +276,30 @@ mod tests {
         );
         assert_eq!(backend.output_dims(), (w, h));
         assert_eq!(backend.name(), "cpu");
+    }
+
+    #[test]
+    fn cpu_backend_rejects_undersized_planes() {
+        let (w, h) = (64u32, 36u32);
+        let mut backend = CpuStitchBackend::new(
+            test_calib(w, h),
+            ViewportConfig {
+                width: w,
+                height: h,
+                ..Default::default()
+            },
+            w,
+            h,
+            false,
+        );
+        let short = vec![0u8; 10];
+        let planes = Nv12Planes {
+            y: &short,
+            uv: &short,
+        };
+        // Must return a typed error, not panic (matches the GPU backend).
+        let err = backend.stitch(&planes, &planes, 0.0, 0.0).unwrap_err();
+        assert!(matches!(err, StitchError::FrameSizeMismatch { .. }));
     }
 
     #[test]

--- a/crates/reco-core/src/stitch/cpu.rs
+++ b/crates/reco-core/src/stitch/cpu.rs
@@ -1,0 +1,213 @@
+//! Float CPU gather and composite.
+//!
+//! Projection-independent: it queries the L-shape [`SurfaceMap`]s and
+//! composites the covered surfaces, mirroring `fisheye.wgsl`'s fragment stage
+//! per output pixel - live KB4 geometry (in [`super::geometry`]), float
+//! bilinear sampling, BT.709 YUV->RGB, and a smoothstep seam. The output is
+//! sRGB-domain RGBA written exactly as the GPU render target would, so it
+//! doubles as the agreement oracle.
+
+use crate::calibration::MatchCalibration;
+use crate::render::planes::Nv12Planes;
+use crate::render::viewport::ViewportConfig;
+
+use super::SurfaceMap;
+use super::geometry::l_shape_plane_maps;
+
+/// Stitch two NV12 camera frames into an RGBA panorama on the CPU.
+///
+/// The float reference / oracle for the L-shape projection. Output is
+/// `config.width * config.height * 4` bytes in `(R, G, B, A)` order, opaque.
+///
+/// * `left`, `right` - tightly packed NV12 source frames.
+/// * `cam` - source frame dimensions `(width, height)`.
+/// * `calib` - stereo calibration (intrinsics + plane layout).
+/// * `config` - output dimensions, FOV, blend width, rig and lens correction.
+/// * `yaw`, `pitch` - per-frame virtual-camera pan, in radians.
+/// * `full_range` - `true` for full-range (0-255) YUV, `false` for limited
+///   (16-235) BT.709, matching the source decoder.
+#[allow(clippy::too_many_arguments)]
+pub fn stitch_l_shape_rgba(
+    left: &Nv12Planes,
+    right: &Nv12Planes,
+    cam: (u32, u32),
+    calib: &MatchCalibration,
+    config: &ViewportConfig,
+    yaw: f32,
+    pitch: f32,
+    full_range: bool,
+) -> Vec<u8> {
+    let (cam_w, cam_h) = cam;
+    let (out_w, out_h) = (config.width, config.height);
+    let (lmap, rmap) = l_shape_plane_maps(calib, config, yaw, pitch);
+    let blend_width = config.blend_width as f64;
+
+    let mut out = vec![0u8; (out_w * out_h * 4) as usize];
+    for py in 0..out_h {
+        for px in 0..out_w {
+            // Left plane is the opaque base; right plane fades in over it.
+            let left_rgb = lmap
+                .sample_uv(px, py)
+                .map(|s| sample_nv12(left, cam_w, cam_h, s.u, s.v, full_range));
+            let right_s = rmap.sample_uv(px, py);
+            let right_rgb = right_s.map(|s| sample_nv12(right, cam_w, cam_h, s.u, s.v, full_range));
+            let right_alpha = match right_s {
+                Some(s) if blend_width > 0.0 => smoothstep(0.0, blend_width, s.edge),
+                Some(_) => 1.0,
+                None => 0.0,
+            };
+
+            let base = left_rgb.unwrap_or([0.0; 3]);
+            let rgb = match right_rgb {
+                Some(r) => [
+                    base[0] + (r[0] - base[0]) * right_alpha,
+                    base[1] + (r[1] - base[1]) * right_alpha,
+                    base[2] + (r[2] - base[2]) * right_alpha,
+                ],
+                None => base,
+            };
+
+            let i = ((py * out_w + px) * 4) as usize;
+            out[i] = to_u8(rgb[0]);
+            out[i + 1] = to_u8(rgb[1]);
+            out[i + 2] = to_u8(rgb[2]);
+            out[i + 3] = 255;
+        }
+    }
+    out
+}
+
+/// Sample an NV12 frame at normalised UV and convert to sRGB-domain RGB.
+///
+/// Mirrors `fisheye.wgsl::sample_yuv`: bilinear Y + bilinear interleaved
+/// chroma (with the GPU sampler's half-texel convention), then BT.709
+/// YCbCr->R'G'B' with limited/full range handling.
+#[inline]
+fn sample_nv12(
+    planes: &Nv12Planes,
+    cam_w: u32,
+    cam_h: u32,
+    u: f64,
+    v: f64,
+    full_range: bool,
+) -> [f64; 3] {
+    let (w, h) = (cam_w as usize, cam_h as usize);
+    // Luma: full-resolution plane, row stride = width.
+    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
+    // Chroma: half-resolution interleaved (U, V) texels, row stride = width bytes.
+    let (cw, ch) = (w / 2, h / 2);
+    let (u_raw, v_raw) = bilinear_chroma(
+        planes.uv,
+        w,
+        cw,
+        ch,
+        u * cw as f64 - 0.5,
+        v * ch as f64 - 0.5,
+    );
+
+    // BT.709 YCbCr -> R'G'B'. Limited range rescales to full before the matrix.
+    let (y, cb, cr) = if full_range {
+        (y_raw, u_raw / 255.0 - 0.5, v_raw / 255.0 - 0.5)
+    } else {
+        (
+            (y_raw - 16.0 / 255.0) * (255.0 / 219.0),
+            (u_raw / 255.0 - 128.0 / 255.0) * (255.0 / 224.0),
+            (v_raw / 255.0 - 128.0 / 255.0) * (255.0 / 224.0),
+        )
+    };
+    [
+        (y + 1.5748 * cr).clamp(0.0, 1.0),
+        (y - 0.1873 * cb - 0.4681 * cr).clamp(0.0, 1.0),
+        (y + 1.8556 * cb).clamp(0.0, 1.0),
+    ]
+}
+
+/// Bilinear sample of a single-byte plane with clamp-to-edge addressing.
+#[inline]
+fn bilinear_u8(data: &[u8], stride: usize, w: usize, h: usize, fx: f64, fy: f64) -> f64 {
+    let fx = fx.clamp(0.0, (w - 1) as f64);
+    let fy = fy.clamp(0.0, (h - 1) as f64);
+    let x0 = fx.floor() as usize;
+    let y0 = fy.floor() as usize;
+    let x1 = (x0 + 1).min(w - 1);
+    let y1 = (y0 + 1).min(h - 1);
+    let dx = fx - x0 as f64;
+    let dy = fy - y0 as f64;
+    let p = |x: usize, y: usize| data[y * stride + x] as f64;
+    let top = p(x0, y0) * (1.0 - dx) + p(x1, y0) * dx;
+    let bot = p(x0, y1) * (1.0 - dx) + p(x1, y1) * dx;
+    top * (1.0 - dy) + bot * dy
+}
+
+/// Bilinear sample of an interleaved NV12 chroma plane (2 bytes per texel),
+/// returning `(U, V)` in raw `[0, 255]` units. Clamp-to-edge addressing.
+#[inline]
+fn bilinear_chroma(uv: &[u8], stride: usize, cw: usize, ch: usize, fx: f64, fy: f64) -> (f64, f64) {
+    let fx = fx.clamp(0.0, (cw - 1) as f64);
+    let fy = fy.clamp(0.0, (ch - 1) as f64);
+    let x0 = fx.floor() as usize;
+    let y0 = fy.floor() as usize;
+    let x1 = (x0 + 1).min(cw - 1);
+    let y1 = (y0 + 1).min(ch - 1);
+    let dx = fx - x0 as f64;
+    let dy = fy - y0 as f64;
+    let p = |x: usize, y: usize, off: usize| uv[y * stride + x * 2 + off] as f64;
+    let lerp = |off: usize| {
+        let top = p(x0, y0, off) * (1.0 - dx) + p(x1, y0, off) * dx;
+        let bot = p(x0, y1, off) * (1.0 - dx) + p(x1, y1, off) * dx;
+        top * (1.0 - dy) + bot * dy
+    };
+    (lerp(0), lerp(1))
+}
+
+/// Hermite smoothstep, matching WGSL `smoothstep`.
+#[inline]
+fn smoothstep(edge0: f64, edge1: f64, x: f64) -> f64 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Quantise an sRGB-domain channel in `[0, 1]` to a `u8`, matching the GPU's
+/// `Rgba8Unorm` write (round-to-nearest).
+#[inline]
+fn to_u8(v: f64) -> u8 {
+    (v * 255.0).round().clamp(0.0, 255.0) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoothstep_endpoints_and_midpoint() {
+        assert_eq!(smoothstep(0.0, 1.0, -1.0), 0.0);
+        assert_eq!(smoothstep(0.0, 1.0, 2.0), 1.0);
+        assert!((smoothstep(0.0, 1.0, 0.5) - 0.5).abs() < 1e-12);
+    }
+
+    #[test]
+    fn to_u8_rounds_and_clamps() {
+        assert_eq!(to_u8(0.0), 0);
+        assert_eq!(to_u8(1.0), 255);
+        assert_eq!(to_u8(0.5), 128); // 127.5 rounds to 128
+        assert_eq!(to_u8(2.0), 255);
+    }
+
+    #[test]
+    fn bilinear_flat_plane_is_constant() {
+        let data = vec![200u8; 16 * 16];
+        let s = bilinear_u8(&data, 16, 16, 16, 3.3, 7.8);
+        assert!((s - 200.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn full_range_grey_is_neutral() {
+        // Full-range Y=128, chroma 128 -> mid-grey, near-equal channels.
+        let y = vec![128u8; 4 * 4];
+        let uv = vec![128u8; 4 * 2];
+        let planes = Nv12Planes { y: &y, uv: &uv };
+        let rgb = sample_nv12(&planes, 4, 4, 0.5, 0.5, true);
+        assert!((rgb[0] - rgb[1]).abs() < 0.02 && (rgb[1] - rgb[2]).abs() < 0.02);
+        assert!((rgb[0] - 128.0 / 255.0).abs() < 0.02);
+    }
+}

--- a/crates/reco-core/src/stitch/cpu.rs
+++ b/crates/reco-core/src/stitch/cpu.rs
@@ -1,14 +1,14 @@
 //! Float CPU gather and composite.
 //!
-//! Projection-independent: it queries the L-shape [`SurfaceMap`]s and
-//! composites the covered surfaces, mirroring `fisheye.wgsl`'s fragment stage
-//! per output pixel - live KB4 geometry (in [`super::geometry`]), float
-//! bilinear sampling, BT.709 YUV->RGB, and a smoothstep seam. The output is
-//! sRGB-domain RGBA written exactly as the GPU render target would, so it
-//! doubles as the agreement oracle.
+//! Two-axis-agnostic: the gather loop ([`stitch_l_shape_with`]) is independent
+//! of both the projection (it queries [`SurfaceMap`]s from [`super::geometry`])
+//! and the pixel format (it works through a `sample(u, v) -> rgb` closure). It
+//! mirrors `fisheye.wgsl`'s fragment stage per output pixel - float bilinear,
+//! BT.709 YUV->RGB, and a smoothstep seam - writing sRGB-domain RGBA exactly as
+//! the GPU render target would, so it doubles as the agreement oracle.
 
 use crate::calibration::MatchCalibration;
-use crate::render::planes::Nv12Planes;
+use crate::render::planes::{Nv12Planes, YuvPlanes};
 use crate::render::viewport::ViewportConfig;
 
 use super::SurfaceMap;
@@ -37,7 +37,58 @@ pub fn stitch_l_shape_rgba(
     pitch: f32,
     full_range: bool,
 ) -> Vec<u8> {
-    let (cam_w, cam_h) = cam;
+    let (cw, ch) = cam;
+    stitch_l_shape_with(
+        calib,
+        config,
+        yaw,
+        pitch,
+        |u, v| sample_nv12(left, cw, ch, u, v, full_range),
+        |u, v| sample_nv12(right, cw, ch, u, v, full_range),
+    )
+}
+
+/// Stitch two YUV420p (planar) camera frames into an RGBA panorama on the CPU.
+///
+/// Identical to [`stitch_l_shape_rgba`] but for the software-decode planar
+/// format (separate Y, U, V planes). Useful as the GPU-less rendering path on
+/// desktop/cloud where FFmpeg software decode yields YUV420p.
+#[allow(clippy::too_many_arguments)]
+pub fn stitch_l_shape_rgba_yuv420p(
+    left: &YuvPlanes,
+    right: &YuvPlanes,
+    cam: (u32, u32),
+    calib: &MatchCalibration,
+    config: &ViewportConfig,
+    yaw: f32,
+    pitch: f32,
+    full_range: bool,
+) -> Vec<u8> {
+    let (cw, ch) = cam;
+    stitch_l_shape_with(
+        calib,
+        config,
+        yaw,
+        pitch,
+        |u, v| sample_yuv420p(left, cw, ch, u, v, full_range),
+        |u, v| sample_yuv420p(right, cw, ch, u, v, full_range),
+    )
+}
+
+/// Format-agnostic L-shape gather and composite.
+///
+/// `sample_left` / `sample_right` map a normalised camera UV to sRGB-domain
+/// RGB for their respective source frame; the loop itself knows nothing about
+/// the pixel format. Left plane is the opaque base; the right plane fades in
+/// over it with a smoothstep seam, matching the GPU's two-draw alpha blend.
+fn stitch_l_shape_with(
+    calib: &MatchCalibration,
+    config: &ViewportConfig,
+    yaw: f32,
+    pitch: f32,
+    sample_left: impl Fn(f64, f64) -> [f64; 3],
+    sample_right: impl Fn(f64, f64) -> [f64; 3],
+) -> Vec<u8> {
     let (out_w, out_h) = (config.width, config.height);
     let (lmap, rmap) = l_shape_plane_maps(calib, config, yaw, pitch);
     let blend_width = config.blend_width as f64;
@@ -45,12 +96,9 @@ pub fn stitch_l_shape_rgba(
     let mut out = vec![0u8; (out_w * out_h * 4) as usize];
     for py in 0..out_h {
         for px in 0..out_w {
-            // Left plane is the opaque base; right plane fades in over it.
-            let left_rgb = lmap
-                .sample_uv(px, py)
-                .map(|s| sample_nv12(left, cam_w, cam_h, s.u, s.v, full_range));
+            let left_rgb = lmap.sample_uv(px, py).map(|s| sample_left(s.u, s.v));
             let right_s = rmap.sample_uv(px, py);
-            let right_rgb = right_s.map(|s| sample_nv12(right, cam_w, cam_h, s.u, s.v, full_range));
+            let right_rgb = right_s.map(|s| sample_right(s.u, s.v));
             let right_alpha = match right_s {
                 Some(s) if blend_width > 0.0 => smoothstep(0.0, blend_width, s.edge),
                 Some(_) => 1.0,
@@ -77,11 +125,7 @@ pub fn stitch_l_shape_rgba(
     out
 }
 
-/// Sample an NV12 frame at normalised UV and convert to sRGB-domain RGB.
-///
-/// Mirrors `fisheye.wgsl::sample_yuv`: bilinear Y + bilinear interleaved
-/// chroma (with the GPU sampler's half-texel convention), then BT.709
-/// YCbCr->R'G'B' with limited/full range handling.
+/// Sample an NV12 frame at normalised UV (bilinear Y + interleaved chroma).
 #[inline]
 fn sample_nv12(
     planes: &Nv12Planes,
@@ -92,10 +136,8 @@ fn sample_nv12(
     full_range: bool,
 ) -> [f64; 3] {
     let (w, h) = (cam_w as usize, cam_h as usize);
-    // Luma: full-resolution plane, row stride = width.
-    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
-    // Chroma: half-resolution interleaved (U, V) texels, row stride = width bytes.
     let (cw, ch) = (w / 2, h / 2);
+    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
     let (u_raw, v_raw) = bilinear_chroma(
         planes.uv,
         w,
@@ -104,15 +146,54 @@ fn sample_nv12(
         u * cw as f64 - 0.5,
         v * ch as f64 - 0.5,
     );
+    yuv_to_rgb(y_raw, u_raw / 255.0, v_raw / 255.0, full_range)
+}
 
-    // BT.709 YCbCr -> R'G'B'. Limited range rescales to full before the matrix.
+/// Sample a YUV420p frame at normalised UV (bilinear Y + separate U, V planes).
+#[inline]
+fn sample_yuv420p(
+    planes: &YuvPlanes,
+    cam_w: u32,
+    cam_h: u32,
+    u: f64,
+    v: f64,
+    full_range: bool,
+) -> [f64; 3] {
+    let (w, h) = (cam_w as usize, cam_h as usize);
+    let (cw, ch) = (w / 2, h / 2);
+    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
+    let u_raw = bilinear_u8(
+        planes.u,
+        cw,
+        cw,
+        ch,
+        u * cw as f64 - 0.5,
+        v * ch as f64 - 0.5,
+    ) / 255.0;
+    let v_raw = bilinear_u8(
+        planes.v,
+        cw,
+        cw,
+        ch,
+        u * cw as f64 - 0.5,
+        v * ch as f64 - 0.5,
+    ) / 255.0;
+    yuv_to_rgb(y_raw, u_raw, v_raw, full_range)
+}
+
+/// BT.709 YCbCr -> sRGB-domain R'G'B', inputs normalised to `[0, 1]`.
+///
+/// Limited range rescales to full before the matrix. Mirrors
+/// `fisheye.wgsl::sample_yuv`.
+#[inline]
+fn yuv_to_rgb(y_raw: f64, u_raw: f64, v_raw: f64, full_range: bool) -> [f64; 3] {
     let (y, cb, cr) = if full_range {
-        (y_raw, u_raw / 255.0 - 0.5, v_raw / 255.0 - 0.5)
+        (y_raw, u_raw - 0.5, v_raw - 0.5)
     } else {
         (
             (y_raw - 16.0 / 255.0) * (255.0 / 219.0),
-            (u_raw / 255.0 - 128.0 / 255.0) * (255.0 / 224.0),
-            (v_raw / 255.0 - 128.0 / 255.0) * (255.0 / 224.0),
+            (u_raw - 128.0 / 255.0) * (255.0 / 224.0),
+            (v_raw - 128.0 / 255.0) * (255.0 / 224.0),
         )
     };
     [
@@ -201,13 +282,31 @@ mod tests {
     }
 
     #[test]
-    fn full_range_grey_is_neutral() {
-        // Full-range Y=128, chroma 128 -> mid-grey, near-equal channels.
-        let y = vec![128u8; 4 * 4];
-        let uv = vec![128u8; 4 * 2];
-        let planes = Nv12Planes { y: &y, uv: &uv };
-        let rgb = sample_nv12(&planes, 4, 4, 0.5, 0.5, true);
-        assert!((rgb[0] - rgb[1]).abs() < 0.02 && (rgb[1] - rgb[2]).abs() < 0.02);
-        assert!((rgb[0] - 128.0 / 255.0).abs() < 0.02);
+    fn nv12_and_yuv420p_agree_on_grey() {
+        // Limited-range Y=128, chroma 128 -> the two formats must agree, since
+        // they carry the same samples in different layouts.
+        let y = vec![128u8; 8 * 8];
+        let nv12_uv = vec![128u8; 8 * 4]; // interleaved, (w) * (h/2)
+        let u = vec![128u8; 4 * 4]; // (w/2)*(h/2)
+        let v = vec![128u8; 4 * 4];
+        let nv = Nv12Planes {
+            y: &y,
+            uv: &nv12_uv,
+        };
+        let yuv = YuvPlanes {
+            y: &y,
+            u: &u,
+            v: &v,
+        };
+        let a = sample_nv12(&nv, 8, 8, 0.5, 0.5, false);
+        let b = sample_yuv420p(&yuv, 8, 8, 0.5, 0.5, false);
+        for k in 0..3 {
+            assert!(
+                (a[k] - b[k]).abs() < 1e-9,
+                "channel {k}: {} vs {}",
+                a[k],
+                b[k]
+            );
+        }
     }
 }

--- a/crates/reco-core/src/stitch/cpu.rs
+++ b/crates/reco-core/src/stitch/cpu.rs
@@ -4,8 +4,9 @@
 //! of both the projection (it queries [`SurfaceMap`]s from [`super::geometry`])
 //! and the pixel format (it works through a `sample(u, v) -> rgb` closure). It
 //! mirrors `fisheye.wgsl`'s fragment stage per output pixel - float bilinear,
-//! BT.709 YUV->RGB, and a smoothstep seam - writing sRGB-domain RGBA exactly as
-//! the GPU render target would, so it doubles as the agreement oracle.
+//! BT.709 YUV->RGB, and a smoothstep seam - agreeing with the GPU render target
+//! to ~1 LSB (the GPU blends through an 8-bit intermediate and uses
+//! implementation-defined unorm rounding), so it doubles as the agreement oracle.
 
 use crate::calibration::MatchCalibration;
 use crate::render::planes::{Nv12Planes, YuvPlanes};
@@ -137,7 +138,7 @@ fn sample_nv12(
 ) -> [f64; 3] {
     let (w, h) = (cam_w as usize, cam_h as usize);
     let (cw, ch) = (w / 2, h / 2);
-    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
+    let y_raw = bilinear_u8(planes.y, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
     let (u_raw, v_raw) = bilinear_chroma(
         planes.uv,
         w,
@@ -161,23 +162,9 @@ fn sample_yuv420p(
 ) -> [f64; 3] {
     let (w, h) = (cam_w as usize, cam_h as usize);
     let (cw, ch) = (w / 2, h / 2);
-    let y_raw = bilinear_u8(planes.y, w, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
-    let u_raw = bilinear_u8(
-        planes.u,
-        cw,
-        cw,
-        ch,
-        u * cw as f64 - 0.5,
-        v * ch as f64 - 0.5,
-    ) / 255.0;
-    let v_raw = bilinear_u8(
-        planes.v,
-        cw,
-        cw,
-        ch,
-        u * cw as f64 - 0.5,
-        v * ch as f64 - 0.5,
-    ) / 255.0;
+    let y_raw = bilinear_u8(planes.y, w, h, u * w as f64 - 0.5, v * h as f64 - 0.5) / 255.0;
+    let u_raw = bilinear_u8(planes.u, cw, ch, u * cw as f64 - 0.5, v * ch as f64 - 0.5) / 255.0;
+    let v_raw = bilinear_u8(planes.v, cw, ch, u * cw as f64 - 0.5, v * ch as f64 - 0.5) / 255.0;
     yuv_to_rgb(y_raw, u_raw, v_raw, full_range)
 }
 
@@ -203,9 +190,10 @@ fn yuv_to_rgb(y_raw: f64, u_raw: f64, v_raw: f64, full_range: bool) -> [f64; 3] 
     ]
 }
 
-/// Bilinear sample of a single-byte plane with clamp-to-edge addressing.
+/// Bilinear sample of a tightly-packed single-byte plane (row stride = `w`),
+/// with clamp-to-edge addressing.
 #[inline]
-fn bilinear_u8(data: &[u8], stride: usize, w: usize, h: usize, fx: f64, fy: f64) -> f64 {
+fn bilinear_u8(data: &[u8], w: usize, h: usize, fx: f64, fy: f64) -> f64 {
     let fx = fx.clamp(0.0, (w - 1) as f64);
     let fy = fy.clamp(0.0, (h - 1) as f64);
     let x0 = fx.floor() as usize;
@@ -214,7 +202,7 @@ fn bilinear_u8(data: &[u8], stride: usize, w: usize, h: usize, fx: f64, fy: f64)
     let y1 = (y0 + 1).min(h - 1);
     let dx = fx - x0 as f64;
     let dy = fy - y0 as f64;
-    let p = |x: usize, y: usize| data[y * stride + x] as f64;
+    let p = |x: usize, y: usize| data[y * w + x] as f64;
     let top = p(x0, y0) * (1.0 - dx) + p(x1, y0) * dx;
     let bot = p(x0, y1) * (1.0 - dx) + p(x1, y1) * dx;
     top * (1.0 - dy) + bot * dy
@@ -248,8 +236,9 @@ fn smoothstep(edge0: f64, edge1: f64, x: f64) -> f64 {
     t * t * (3.0 - 2.0 * t)
 }
 
-/// Quantise an sRGB-domain channel in `[0, 1]` to a `u8`, matching the GPU's
-/// `Rgba8Unorm` write (round-to-nearest).
+/// Quantise an sRGB-domain channel in `[0, 1]` to a `u8` (round-to-nearest).
+/// The GPU's `Rgba8Unorm` unorm rounding is implementation-defined, so this
+/// agrees to ~1 LSB rather than bit-exactly.
 #[inline]
 fn to_u8(v: f64) -> u8 {
     (v * 255.0).round().clamp(0.0, 255.0) as u8
@@ -277,7 +266,7 @@ mod tests {
     #[test]
     fn bilinear_flat_plane_is_constant() {
         let data = vec![200u8; 16 * 16];
-        let s = bilinear_u8(&data, 16, 16, 16, 3.3, 7.8);
+        let s = bilinear_u8(&data, 16, 16, 3.3, 7.8);
         assert!((s - 200.0).abs() < 1e-9);
     }
 

--- a/crates/reco-core/src/stitch/cpu.rs
+++ b/crates/reco-core/src/stitch/cpu.rs
@@ -12,8 +12,31 @@ use crate::calibration::MatchCalibration;
 use crate::render::planes::{Nv12Planes, YuvPlanes};
 use crate::render::viewport::ViewportConfig;
 
+use super::StitchError;
 use super::SurfaceMap;
 use super::geometry::l_shape_plane_maps;
+
+/// Reject degenerate source dimensions that would underflow chroma indexing.
+fn check_source_dims(cw: u32, ch: u32) -> Result<(), StitchError> {
+    if cw < 2 || ch < 2 {
+        return Err(StitchError::InvalidConfig(format!(
+            "source dimensions must be >= 2, got {cw}x{ch}"
+        )));
+    }
+    Ok(())
+}
+
+/// Reject a plane shorter than the configured frame requires (would otherwise
+/// index out of bounds in the gather and panic).
+fn check_plane(plane: &[u8], expected: usize) -> Result<(), StitchError> {
+    if plane.len() < expected {
+        return Err(StitchError::FrameSizeMismatch {
+            expected,
+            actual: plane.len(),
+        });
+    }
+    Ok(())
+}
 
 /// Stitch two NV12 camera frames into an RGBA panorama on the CPU.
 ///
@@ -27,6 +50,11 @@ use super::geometry::l_shape_plane_maps;
 /// * `yaw`, `pitch` - per-frame virtual-camera pan, in radians.
 /// * `full_range` - `true` for full-range (0-255) YUV, `false` for limited
 ///   (16-235) BT.709, matching the source decoder.
+///
+/// Returns [`StitchError::InvalidConfig`] for degenerate source dimensions and
+/// [`StitchError::FrameSizeMismatch`] if a plane is shorter than `cam` requires,
+/// rather than panicking - this is the GPU-less render path, so callers (e.g.
+/// the X5) get a typed error instead of an out-of-bounds panic.
 #[allow(clippy::too_many_arguments)]
 pub fn stitch_l_shape_rgba(
     left: &Nv12Planes,
@@ -37,16 +65,22 @@ pub fn stitch_l_shape_rgba(
     yaw: f32,
     pitch: f32,
     full_range: bool,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, StitchError> {
     let (cw, ch) = cam;
-    stitch_l_shape_with(
+    check_source_dims(cw, ch)?;
+    let (w, h) = (cw as usize, ch as usize);
+    check_plane(left.y, w * h)?;
+    check_plane(left.uv, w * (h / 2))?;
+    check_plane(right.y, w * h)?;
+    check_plane(right.uv, w * (h / 2))?;
+    Ok(stitch_l_shape_with(
         calib,
         config,
         yaw,
         pitch,
         |u, v| sample_nv12(left, cw, ch, u, v, full_range),
         |u, v| sample_nv12(right, cw, ch, u, v, full_range),
-    )
+    ))
 }
 
 /// Stitch two YUV420p (planar) camera frames into an RGBA panorama on the CPU.
@@ -64,16 +98,25 @@ pub fn stitch_l_shape_rgba_yuv420p(
     yaw: f32,
     pitch: f32,
     full_range: bool,
-) -> Vec<u8> {
+) -> Result<Vec<u8>, StitchError> {
     let (cw, ch) = cam;
-    stitch_l_shape_with(
+    check_source_dims(cw, ch)?;
+    let (w, h) = (cw as usize, ch as usize);
+    let chroma = (w / 2) * (h / 2);
+    check_plane(left.y, w * h)?;
+    check_plane(left.u, chroma)?;
+    check_plane(left.v, chroma)?;
+    check_plane(right.y, w * h)?;
+    check_plane(right.u, chroma)?;
+    check_plane(right.v, chroma)?;
+    Ok(stitch_l_shape_with(
         calib,
         config,
         yaw,
         pitch,
         |u, v| sample_yuv420p(left, cw, ch, u, v, full_range),
         |u, v| sample_yuv420p(right, cw, ch, u, v, full_range),
-    )
+    ))
 }
 
 /// Format-agnostic L-shape gather and composite.

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -27,8 +27,10 @@ use super::{SurfaceMap, SurfaceUv};
 /// [`sample_uv`]: SurfaceMap::sample_uv
 pub struct PlaneMap {
     /// Inverse of the MVP's drop-z 3x3: maps `[ndc_x, ndc_y, 1]` (up to scale)
-    /// to plane-local `[x, y, 1]`.
-    m3_inv: Matrix3<f64>,
+    /// to plane-local `[x, y, 1]`. `None` if the MVP is singular (e.g. an
+    /// edge-on plane), in which case the plane covers nothing - like the GPU's
+    /// zero-area quad.
+    m3_inv: Option<Matrix3<f64>>,
     /// Output dimensions in pixels.
     out_w: f64,
     out_h: f64,
@@ -71,7 +73,7 @@ impl PlaneMap {
             mvp[(3, 1)] as f64,
             mvp[(3, 3)] as f64,
         );
-        let m3_inv = m3.try_inverse().unwrap_or_else(Matrix3::identity);
+        let m3_inv = m3.try_inverse();
         let w = cam.width as f64;
         let h = cam.height as f64;
         Self {
@@ -95,9 +97,14 @@ impl SurfaceMap for PlaneMap {
         let ndc_x = (out_x as f64 + 0.5) / self.out_w * 2.0 - 1.0;
         let ndc_y = 1.0 - (out_y as f64 + 0.5) / self.out_h * 2.0;
 
+        // A singular MVP (edge-on plane) covers nothing.
+        let m3_inv = self.m3_inv?;
         // Inverse rasterize to plane-local coordinates (homogeneous divide).
-        let p = self.m3_inv * Vector3::new(ndc_x, ndc_y, 1.0);
-        if p.z.abs() < 1e-12 {
+        let p = m3_inv * Vector3::new(ndc_x, ndc_y, 1.0);
+        // p.z = 1 / clip_w: reject points at or behind the virtual camera
+        // (clip_w <= 0), matching the GPU rasterizer's near/w clip. A plain
+        // `p.z.abs()` guard would wrongly admit behind-camera geometry.
+        if p.z <= 1e-12 {
             return None;
         }
         let local_x = p.x / p.z;
@@ -107,6 +114,13 @@ impl SurfaceMap for PlaneMap {
         // `local_x = uv_x - 0.5`, `local_y = (0.5 - uv_y) / aspect`).
         let uv_x = local_x + 0.5;
         let uv_y = 0.5 - local_y * self.plane_aspect;
+
+        // The GPU rasterizes a FINITE quad (uv in [0,1]); the extended-UV remap
+        // below only widens the sampling domain, not the rasterized footprint.
+        // Reject pixels outside the quad so CPU coverage matches the GPU's.
+        if !(0.0..=1.0).contains(&uv_x) || !(0.0..=1.0).contains(&uv_y) {
+            return None;
+        }
 
         // Shader's extended-UV remap (`uv * 2 - 0.5`) that widens the sampling
         // domain so undistortion can reach past the plane edge.

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -215,43 +215,12 @@ pub fn l_shape_plane_maps(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calibration::PlaneLayout;
-
-    fn calib() -> MatchCalibration {
-        let cam = CameraParams {
-            width: 1920,
-            height: 1080,
-            fx: 960.0,
-            fy: 960.0,
-            cx: 960.0,
-            cy: 540.0,
-            d: [-0.02, 0.004, 0.0, 0.0],
-        };
-        MatchCalibration {
-            left: cam.clone(),
-            right: cam,
-            layout: PlaneLayout {
-                camera_axis_offset: 0.25,
-                intersect: 0.5,
-                x_ty: 0.0,
-                x_rz: 0.0,
-                z_rx: 0.0,
-                x_rx: 0.0,
-                z_rz: 0.0,
-            },
-            rig_tilt: 0.0,
-            rig_roll: 0.0,
-            sync_offset: 0,
-            field_roi: None,
-            lens_correction_amount: 1.0,
-            blend_width: 0.05,
-        }
-    }
+    use crate::stitch::test_support::calib;
 
     #[test]
     fn covered_pixels_return_uv_in_range() {
         let cfg = ViewportConfig::default();
-        let (left, right) = l_shape_plane_maps(&calib(), &cfg, 0.0, 0.0);
+        let (left, right) = l_shape_plane_maps(&calib(1920, 1080), &cfg, 0.0, 0.0);
         // Across the output, every covered pixel must report a UV inside [0,1],
         // and at least one plane must cover a healthy fraction of the frame.
         let mut covered = 0usize;

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -5,7 +5,7 @@
 //! KB4 distortion. For a planar quad that forward transform is a homography,
 //! so the CPU dual - output pixel back to plane UV - is the *inverse* of the
 //! MVP's drop-z 3x3. This module builds that inverse once per frame per plane
-//! (reusing [`crate::render`]'s exact view/projection and [`crate::lens::kb4`])
+//! (reusing [`crate::render`]'s exact view/projection and `crate::lens::kb4`)
 //! and exposes it as a [`SurfaceMap`].
 
 use nalgebra::{Matrix3, Matrix4, Perspective3, Vector3};

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -1,0 +1,259 @@
+//! L-shape projection geometry: output pixel -> source-camera UV per plane.
+//!
+//! The GPU rasterizes each camera plane (a textured quad) through the
+//! model-view-projection matrix and the fragment shader applies the forward
+//! KB4 distortion. For a planar quad that forward transform is a homography,
+//! so the CPU dual - output pixel back to plane UV - is the *inverse* of the
+//! MVP's drop-z 3x3. This module builds that inverse once per frame per plane
+//! (reusing [`crate::render`]'s exact view/projection and [`crate::lens::kb4`])
+//! and exposes it as a [`SurfaceMap`].
+
+use nalgebra::{Matrix3, Matrix4, Perspective3, Vector3};
+
+use crate::calibration::{CameraParams, MatchCalibration};
+use crate::lens::kb4;
+use crate::render::renderer::{FAR_PLANE, NEAR_PLANE, opengl_to_wgpu_matrix, view_matrix};
+use crate::render::scene::SceneGeometry;
+use crate::render::viewport::ViewportConfig;
+
+use super::{SurfaceMap, SurfaceUv};
+
+/// Inverse map for one camera plane of the L-shape projection.
+///
+/// Holds the per-frame inverse rasterization (output NDC -> plane-local) plus
+/// the camera's normalised intrinsics and KB4 coefficients, so [`sample_uv`]
+/// is a closed-form per-pixel evaluation with no allocation.
+///
+/// [`sample_uv`]: SurfaceMap::sample_uv
+pub struct PlaneMap {
+    /// Inverse of the MVP's drop-z 3x3: maps `[ndc_x, ndc_y, 1]` (up to scale)
+    /// to plane-local `[x, y, 1]`.
+    m3_inv: Matrix3<f64>,
+    /// Output dimensions in pixels.
+    out_w: f64,
+    out_h: f64,
+    /// Camera aspect (`width / height`) baked into the plane quad's half-height.
+    plane_aspect: f64,
+    /// Normalised intrinsics: `fx/w`, `fy/h`, `cx/w`, `cy/h` (by calibration
+    /// resolution, so they are independent of the actual frame size).
+    fx_n: f64,
+    fy_n: f64,
+    cx_n: f64,
+    cy_n: f64,
+    /// KB4 distortion coefficients `[k1, k2, k3, k4]`.
+    d: [f64; 4],
+    /// Lens-correction amount in `[0, 1]` (`1` = full KB4, `0` = pinhole).
+    correction: f64,
+}
+
+impl PlaneMap {
+    /// Build a plane map from its model matrix and the shared view-projection.
+    fn new(
+        model: Matrix4<f32>,
+        view_projection: &Matrix4<f32>,
+        cam: &CameraParams,
+        out_w: u32,
+        out_h: u32,
+        plane_aspect: f64,
+        correction: f64,
+    ) -> Self {
+        let mvp = view_projection * model;
+        // For a quad at z = 0 in model space, `clip = M3 * [x, y, 1]` where M3
+        // takes the x, y and translation columns of the MVP (z dropped).
+        let m3 = Matrix3::new(
+            mvp[(0, 0)] as f64,
+            mvp[(0, 1)] as f64,
+            mvp[(0, 3)] as f64,
+            mvp[(1, 0)] as f64,
+            mvp[(1, 1)] as f64,
+            mvp[(1, 3)] as f64,
+            mvp[(3, 0)] as f64,
+            mvp[(3, 1)] as f64,
+            mvp[(3, 3)] as f64,
+        );
+        let m3_inv = m3.try_inverse().unwrap_or_else(Matrix3::identity);
+        let w = cam.width as f64;
+        let h = cam.height as f64;
+        Self {
+            m3_inv,
+            out_w: out_w as f64,
+            out_h: out_h as f64,
+            plane_aspect,
+            fx_n: cam.fx / w,
+            fy_n: cam.fy / h,
+            cx_n: cam.cx / w,
+            cy_n: cam.cy / h,
+            d: cam.d,
+            correction,
+        }
+    }
+}
+
+impl SurfaceMap for PlaneMap {
+    fn sample_uv(&self, out_x: u32, out_y: u32) -> Option<SurfaceUv> {
+        // Output pixel centre -> wgpu NDC (x right, y up).
+        let ndc_x = (out_x as f64 + 0.5) / self.out_w * 2.0 - 1.0;
+        let ndc_y = 1.0 - (out_y as f64 + 0.5) / self.out_h * 2.0;
+
+        // Inverse rasterize to plane-local coordinates (homogeneous divide).
+        let p = self.m3_inv * Vector3::new(ndc_x, ndc_y, 1.0);
+        if p.z.abs() < 1e-12 {
+            return None;
+        }
+        let local_x = p.x / p.z;
+        let local_y = p.y / p.z;
+
+        // Plane-local -> texture UV (inverse of the quad vertex layout:
+        // `local_x = uv_x - 0.5`, `local_y = (0.5 - uv_y) / aspect`).
+        let uv_x = local_x + 0.5;
+        let uv_y = 0.5 - local_y * self.plane_aspect;
+
+        // Shader's extended-UV remap (`uv * 2 - 0.5`) that widens the sampling
+        // domain so undistortion can reach past the plane edge.
+        let euv_x = uv_x * 2.0 - 0.5;
+        let euv_y = uv_y * 2.0 - 0.5;
+
+        // Forward KB4: extended-UV -> distorted (source) camera UV.
+        let xn = (euv_x - self.cx_n) / self.fx_n;
+        let yn = (euv_y - self.cy_n) / self.fy_n;
+        let r = (xn * xn + yn * yn).sqrt();
+        let scale = if r < 1e-9 {
+            1.0
+        } else {
+            // `mix(theta, theta_d, correction) / r`, matching the shader's
+            // per-pixel correction lerp between pinhole and full KB4.
+            let pinhole = r.atan() / r;
+            let full = kb4::kb4_forward_scale(r, &self.d);
+            pinhole + (full - pinhole) * self.correction
+        };
+        let du = self.fx_n * xn * scale + self.cx_n;
+        let dv = self.fy_n * yn * scale + self.cy_n;
+
+        // Outside the source frame -> this surface does not cover the pixel.
+        if !(0.0..=1.0).contains(&du) || !(0.0..=1.0).contains(&dv) {
+            return None;
+        }
+
+        Some(SurfaceUv {
+            u: du,
+            v: dv,
+            edge: euv_x,
+        })
+    }
+}
+
+/// Build the two L-shape plane maps `(left, right)` for one frame.
+///
+/// Reuses the same scene geometry, view matrix, and perspective projection as
+/// the GPU stitch pass, so the CPU and GPU sample the identical source UV for
+/// every output pixel (up to f32/f64 precision).
+pub fn l_shape_plane_maps(
+    calib: &MatchCalibration,
+    config: &ViewportConfig,
+    yaw: f32,
+    pitch: f32,
+) -> (PlaneMap, PlaneMap) {
+    // Both planes share the camera aspect (a stereo rig's two cameras match).
+    let plane_aspect = calib.left.width as f32 / calib.left.height as f32;
+    let scene = SceneGeometry::from_layout_with_aspect(&calib.layout, plane_aspect);
+
+    let out_aspect = config.width as f32 / config.height as f32;
+    let projection = opengl_to_wgpu_matrix()
+        * Perspective3::new(
+            out_aspect,
+            config.fov_degrees.to_radians(),
+            NEAR_PLANE,
+            FAR_PLANE,
+        )
+        .to_homogeneous();
+    let view = view_matrix(
+        &scene.camera_position,
+        yaw,
+        pitch,
+        config.rig_tilt,
+        config.rig_roll,
+    );
+    let view_projection = projection * view;
+
+    let correction = config.lens_correction_amount as f64;
+    let aspect = plane_aspect as f64;
+    let left = PlaneMap::new(
+        scene.model_matrix_left(),
+        &view_projection,
+        &calib.left,
+        config.width,
+        config.height,
+        aspect,
+        correction,
+    );
+    let right = PlaneMap::new(
+        scene.model_matrix_right(),
+        &view_projection,
+        &calib.right,
+        config.width,
+        config.height,
+        aspect,
+        correction,
+    );
+    (left, right)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calibration::PlaneLayout;
+
+    fn calib() -> MatchCalibration {
+        let cam = CameraParams {
+            width: 1920,
+            height: 1080,
+            fx: 960.0,
+            fy: 960.0,
+            cx: 960.0,
+            cy: 540.0,
+            d: [-0.02, 0.004, 0.0, 0.0],
+        };
+        MatchCalibration {
+            left: cam.clone(),
+            right: cam,
+            layout: PlaneLayout {
+                camera_axis_offset: 0.25,
+                intersect: 0.5,
+                x_ty: 0.0,
+                x_rz: 0.0,
+                z_rx: 0.0,
+                x_rx: 0.0,
+                z_rz: 0.0,
+            },
+            rig_tilt: 0.0,
+            rig_roll: 0.0,
+            sync_offset: 0,
+            field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
+        }
+    }
+
+    #[test]
+    fn covered_pixels_return_uv_in_range() {
+        let cfg = ViewportConfig::default();
+        let (left, right) = l_shape_plane_maps(&calib(), &cfg, 0.0, 0.0);
+        // Across the output, every covered pixel must report a UV inside [0,1],
+        // and at least one plane must cover a healthy fraction of the frame.
+        let mut covered = 0usize;
+        for y in (0..cfg.height).step_by(17) {
+            for x in (0..cfg.width).step_by(17) {
+                for m in [&left, &right] {
+                    if let Some(s) = m.sample_uv(x, y) {
+                        assert!((0.0..=1.0).contains(&s.u) && (0.0..=1.0).contains(&s.v));
+                        covered += 1;
+                    }
+                }
+            }
+        }
+        assert!(
+            covered > 0,
+            "expected the planes to cover part of the output"
+        );
+    }
+}

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -31,6 +31,10 @@ pub struct PlaneMap {
     /// edge-on plane), in which case the plane covers nothing - like the GPU's
     /// zero-area quad.
     m3_inv: Option<Matrix3<f64>>,
+    /// The MVP's z-row restricted to the model-z=0 quad: `[m20, m21, m23]`, so
+    /// `clip_z = z_row . [local_x, local_y, 1]`. The 3x3 inverse drops z, but the
+    /// GPU rasterizer still depth-clips, so the z-row is kept to reconstruct it.
+    z_row: (f64, f64, f64),
     /// Output dimensions in pixels.
     out_w: f64,
     out_h: f64,
@@ -74,10 +78,13 @@ impl PlaneMap {
             mvp[(3, 3)] as f64,
         );
         let m3_inv = m3.try_inverse();
+        // z-row of the MVP for the model-z=0 quad (x, y, translation columns).
+        let z_row = (mvp[(2, 0)] as f64, mvp[(2, 1)] as f64, mvp[(2, 3)] as f64);
         let w = cam.width as f64;
         let h = cam.height as f64;
         Self {
             m3_inv,
+            z_row,
             out_w: out_w as f64,
             out_h: out_h as f64,
             plane_aspect,
@@ -109,6 +116,18 @@ impl SurfaceMap for PlaneMap {
         }
         let local_x = p.x / p.z;
         let local_y = p.y / p.z;
+
+        // Depth clip: the GPU rasterizer keeps only fragments with
+        // `0 <= clip_z <= clip_w` (wgpu NDC z in [0, 1]); geometry within
+        // NEAR_PLANE of the virtual camera is clipped. The 3x3 inverse dropped
+        // z, so reconstruct `clip_z` from the z-row and `clip_w = 1 / p.z`.
+        // Without this, a plane closer than NEAR_PLANE (tiny camera_axis_offset
+        // or an extreme FOV) is gathered by the CPU but clipped by the GPU.
+        let clip_w = 1.0 / p.z;
+        let clip_z = self.z_row.0 * local_x + self.z_row.1 * local_y + self.z_row.2;
+        if clip_z < 0.0 || clip_z > clip_w {
+            return None;
+        }
 
         // Plane-local -> texture UV (inverse of the quad vertex layout:
         // `local_x = uv_x - 0.5`, `local_y = (0.5 - uv_y) / aspect`).

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -1,0 +1,158 @@
+//! CPU stitching backend (projection-agnostic).
+//!
+//! A pure-Rust, no-wgpu software stitcher that mirrors the GPU fisheye shader
+//! ([`shaders/fisheye.wgsl`](../render/renderer/index.html)) per output pixel.
+//! It serves two roles:
+//!
+//! 1. **Correctness oracle** for the GPU path. The geometry reuses
+//!    [`crate::lens::kb4`] and the same view/projection matrices as
+//!    [`crate::render`], so the CPU and GPU outputs agree by construction
+//!    rather than by coincidence.
+//! 2. **Rendering path for GPU-less targets** (edge SoCs, cloud CPU workers)
+//!    where wgpu is unavailable or uneconomical.
+//!
+//! ## Projection seam
+//!
+//! [`SurfaceMap`] is the only projection-specific piece: it maps an output
+//! pixel to a source-camera UV. The two-plane L-shape provides one
+//! [`PlaneMap`] per camera; future projections (cylinder, N-camera) implement
+//! the same trait and the gather loop in [`cpu`] is unchanged.
+//!
+//! ## Phase 1 scope
+//!
+//! Float reference, NV12 input, RGBA output, L-shape only. The integer /
+//! memory-tuned specialisation and NV12-direct output are deliberate later
+//! additions, gated on profiling (see the cpu-stitch portability work).
+
+mod cpu;
+pub mod geometry;
+
+pub use cpu::stitch_l_shape_rgba;
+pub use geometry::{PlaneMap, l_shape_plane_maps};
+
+/// A source-camera sample location produced by a [`SurfaceMap`].
+#[derive(Debug, Clone, Copy)]
+pub struct SurfaceUv {
+    /// Normalised camera UV in `[0, 1]`. Multiply by the frame dimensions for
+    /// pixel coordinates.
+    pub u: f64,
+    /// Normalised camera UV in `[0, 1]`.
+    pub v: f64,
+    /// Extended-UV x of this surface (the shader's `uv.x * 2 - 0.5`). The
+    /// compositor uses it to compute the seam-blend alpha where surfaces
+    /// overlap.
+    pub edge: f64,
+}
+
+/// The projection seam: a per-output-pixel inverse map for one source surface.
+///
+/// Implemented once per projection. The L-shape supplies two (one per camera
+/// plane); the CPU gather loop queries each surface and composites the ones
+/// that cover a pixel, so adding a projection means implementing this trait -
+/// the loop never changes. This is the CPU dual of the GPU rasterizer's
+/// per-fragment plane-UV interpolation.
+pub trait SurfaceMap {
+    /// Map an output pixel centre to its source-camera UV, or `None` when this
+    /// surface does not cover the pixel (the GPU shader's bounds discard).
+    fn sample_uv(&self, out_x: u32, out_y: u32) -> Option<SurfaceUv>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::calibration::{CameraParams, MatchCalibration, PlaneLayout};
+    use crate::render::planes::Nv12Planes;
+    use crate::render::viewport::ViewportConfig;
+
+    /// A frontal-ish two-camera calibration with a mild fisheye, sized for fast
+    /// tests. Both cameras share dimensions (as a real stereo rig does).
+    fn test_calib(w: u32, h: u32) -> MatchCalibration {
+        let cam = || CameraParams {
+            width: w,
+            height: h,
+            fx: w as f64 * 0.5,
+            fy: w as f64 * 0.5,
+            cx: w as f64 * 0.5,
+            cy: h as f64 * 0.5,
+            d: [-0.02, 0.004, 0.0, 0.0],
+        };
+        MatchCalibration {
+            left: cam(),
+            right: cam(),
+            layout: PlaneLayout {
+                camera_axis_offset: 0.25,
+                intersect: 0.5,
+                x_ty: 0.0,
+                x_rz: 0.0,
+                z_rx: 0.0,
+                x_rx: 0.0,
+                z_rz: 0.0,
+            },
+            rig_tilt: 0.0,
+            rig_roll: 0.0,
+            sync_offset: 0,
+            field_roi: None,
+            lens_correction_amount: 1.0,
+            blend_width: 0.05,
+        }
+    }
+
+    /// Synthetic NV12 frame: a horizontal luma gradient + flat mid-grey chroma.
+    fn nv12(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>) {
+        let y: Vec<u8> = (0..w * h)
+            .map(|i| ((i % w as usize as u32) as usize * 255 / w as usize) as u8)
+            .map(|v| v.saturating_add(bias))
+            .collect();
+        let uv = vec![128u8; (w * (h / 2)) as usize];
+        (y, uv)
+    }
+
+    #[test]
+    fn output_dimensions_and_opaque_alpha() {
+        let (w, h) = (96u32, 54u32);
+        let calib = test_calib(w, h);
+        let cfg = ViewportConfig {
+            width: w,
+            height: h,
+            ..Default::default()
+        };
+        let (ly, luv) = nv12(w, h, 0);
+        let (ry, ruv) = nv12(w, h, 40);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+
+        let out = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
+        assert_eq!(out.len(), (w * h * 4) as usize);
+        // Alpha channel is fully opaque.
+        assert!(out.iter().skip(3).step_by(4).all(|&a| a == 255));
+    }
+
+    #[test]
+    fn produces_covered_pixels_and_is_deterministic() {
+        let (w, h) = (96u32, 54u32);
+        let calib = test_calib(w, h);
+        let cfg = ViewportConfig {
+            width: w,
+            height: h,
+            ..Default::default()
+        };
+        let (ly, luv) = nv12(w, h, 0);
+        let (ry, ruv) = nv12(w, h, 40);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+
+        let a = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
+        let b = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
+        assert_eq!(a, b, "stitch must be deterministic");
+
+        // Some pixels are covered (non-black) - the planes are in view.
+        let non_black = a
+            .chunks_exact(4)
+            .filter(|p| p[0] != 0 || p[1] != 0 || p[2] != 0)
+            .count();
+        assert!(
+            non_black > 0,
+            "expected some covered (non-black) output pixels"
+        );
+    }
+}

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -414,19 +414,43 @@ mod tests {
         (y, uv)
     }
 
-    /// Render a scene on the GPU and the CPU and return `(mean, pct>16, max)` of
-    /// the per-channel RGB difference, or `None` if there is no GPU adapter.
-    /// The single agreement primitive used across regimes. A geometry
-    /// divergence shows up as a large contiguous wrong region (high mean +
-    /// high pct>16); a correct result only has thin boundary f32/f64 flips.
-    fn gpu_cpu_diff(
+    /// High-frequency NV12 (fine luma + chroma checker) - "locks" the sampler:
+    /// a half-texel / coordinate-convention error is invisible on smooth content
+    /// (bilinear reproduces a gradient near-exactly) but shows as a large diff
+    /// on a checker.
+    fn checker_nv12(w: u32, h: u32) -> (Vec<u8>, Vec<u8>) {
+        let mut y = vec![0u8; (w * h) as usize];
+        for j in 0..h {
+            for i in 0..w {
+                let on = ((i / 3) + (j / 3)) % 2 == 0;
+                y[(j * w + i) as usize] = if on { 220 } else { 30 };
+            }
+        }
+        let mut uv = vec![128u8; (w * (h / 2)) as usize];
+        for j in 0..h / 2 {
+            for i in (0..w).step_by(2) {
+                let on = ((i / 4) + (j / 4)) % 2 == 0;
+                uv[(j * w + i) as usize] = if on { 200 } else { 60 };
+                uv[(j * w + i + 1) as usize] = if on { 60 } else { 200 };
+            }
+        }
+        (y, uv)
+    }
+
+    /// Render a scene on both the GPU and the CPU and return `(gpu_rgba,
+    /// cpu_rgba)`, or `None` if there is no GPU adapter. The shared agreement
+    /// primitive: callers diff the buffers however they need (aggregate stats,
+    /// coverage/black-region masks).
+    fn gpu_cpu_rgba(
         calib: &MatchCalibration,
         config: &ViewportConfig,
         cam: (u32, u32),
+        left: &Nv12Planes,
+        right: &Nv12Planes,
         yaw: f32,
         pitch: f32,
         full_range: bool,
-    ) -> Option<(f64, f64, u32)> {
+    ) -> Option<(Vec<u8>, Vec<u8>)> {
         use crate::render::renderer::InputFormat;
         let gpu = gpu_or_skip()?;
         let (cam_w, cam_h) = cam;
@@ -447,14 +471,10 @@ mod tests {
             config.height,
         )
         .expect("readback");
-        let (ly, luv) = textured_nv12(cam_w, cam_h, 0.0);
-        let (ry, ruv) = textured_nv12(cam_w, cam_h, 1.3);
-        let left = Nv12Planes { y: &ly, uv: &luv };
-        let right = Nv12Planes { y: &ry, uv: &ruv };
         let mut gpu_rgba = None;
         for _ in 0..3 {
             let cmd = pipeline
-                .render_to_target_nv12(&left, &right, yaw, pitch)
+                .render_to_target_nv12(left, right, yaw, pitch)
                 .expect("render");
             let tex = pipeline.render_target();
             if let Some(b) = readback
@@ -465,10 +485,16 @@ mod tests {
             }
         }
         let gpu_rgba = gpu_rgba.expect("gpu frame");
-        let cpu_rgba =
-            stitch_l_shape_rgba(&left, &right, cam, calib, config, yaw, pitch, full_range);
+        let cpu_rgba = stitch_l_shape_rgba(left, right, cam, calib, config, yaw, pitch, full_range);
+        Some((gpu_rgba, cpu_rgba))
+    }
+
+    /// `(mean, pct>16, max)` of the per-channel RGB difference. A geometry
+    /// divergence shows up as a large contiguous wrong region (high mean +
+    /// high pct>16); a correct result only has thin boundary f32/f64 flips.
+    fn rgb_diff_stats(gpu: &[u8], cpu: &[u8]) -> (f64, f64, u32) {
         let (mut sum, mut n, mut gt, mut max) = (0i64, 0i64, 0i64, 0i32);
-        for (g, c) in gpu_rgba.chunks_exact(4).zip(cpu_rgba.chunks_exact(4)) {
+        for (g, c) in gpu.chunks_exact(4).zip(cpu.chunks_exact(4)) {
             for k in 0..3 {
                 let d = (g[k] as i32 - c[k] as i32).abs();
                 sum += d as i64;
@@ -479,11 +505,11 @@ mod tests {
                 max = max.max(d);
             }
         }
-        Some((
+        (
             sum as f64 / n as f64,
             100.0 * gt as f64 / n as f64,
             max as u32,
-        ))
+        )
     }
 
     /// Regression guard for the regimes that masked the original behind-camera
@@ -494,10 +520,9 @@ mod tests {
     #[test]
     fn cpu_matches_gpu_across_regimes() {
         let (cam_w, cam_h) = (256u32, 144u32);
-        let (out_w, out_h) = (192u32, 108u32);
-        let cfg = |fov: f32, corr: f32| ViewportConfig {
-            width: out_w,
-            height: out_h,
+        let cfg = |w: u32, h: u32, fov: f32, corr: f32| ViewportConfig {
+            width: w,
+            height: h,
             fov_degrees: fov,
             lens_correction_amount: corr,
             ..Default::default()
@@ -509,22 +534,55 @@ mod tests {
             c
         };
         let base = calib(cam_w, cam_h);
-        let cases: [(&str, MatchCalibration, ViewportConfig, f32, f32, bool); 5] = [
-            ("wide-pan", base.clone(), cfg(75.0, 1.0), 0.9, 0.0, false),
-            ("wide-fov", base.clone(), cfg(130.0, 1.0), 0.0, 0.0, false),
+        let (ly, luv) = textured_nv12(cam_w, cam_h, 0.0);
+        let (ry, ruv) = textured_nv12(cam_w, cam_h, 1.3);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let cases: [(&str, MatchCalibration, ViewportConfig, f32, f32, bool); 6] = [
+            (
+                "wide-pan",
+                base.clone(),
+                cfg(192, 108, 75.0, 1.0),
+                0.9,
+                0.0,
+                false,
+            ),
+            (
+                "wide-fov",
+                base.clone(),
+                cfg(192, 108, 130.0, 1.0),
+                0.0,
+                0.0,
+                false,
+            ),
             (
                 "off-center-cx",
                 calib_cx(0.12),
-                cfg(75.0, 1.0),
+                cfg(192, 108, 75.0, 1.0),
                 0.2,
                 0.0,
                 false,
             ),
-            ("full-range", base.clone(), cfg(75.0, 1.0), 0.1, -0.05, true),
+            (
+                "full-range",
+                base.clone(),
+                cfg(192, 108, 75.0, 1.0),
+                0.1,
+                -0.05,
+                true,
+            ),
             (
                 "lens-corr-0.5",
                 base.clone(),
-                cfg(75.0, 0.5),
+                cfg(192, 108, 75.0, 0.5),
+                0.1,
+                -0.05,
+                false,
+            ),
+            (
+                "non-16:9 (4:3 out)",
+                base.clone(),
+                cfg(144, 108, 75.0, 1.0),
                 0.1,
                 -0.05,
                 false,
@@ -532,25 +590,123 @@ mod tests {
         ];
         let mut ran = false;
         for (label, calib, config, yaw, pitch, fr) in cases {
-            match gpu_cpu_diff(&calib, &config, (cam_w, cam_h), yaw, pitch, fr) {
-                None => {
-                    eprintln!("skipping regimes: no GPU adapter");
-                    return;
-                }
-                Some((mean, pct16, max)) => {
-                    ran = true;
-                    eprintln!("regime {label}: mean={mean:.3} >16:{pct16:.3}% max={max}");
-                    assert!(
-                        mean < 1.5,
-                        "{label}: mean RGB diff {mean} (geometry divergence?)"
-                    );
-                    assert!(
-                        pct16 < 0.5,
-                        "{label}: {pct16}% of channels off by >16 (geometry divergence?)"
-                    );
+            let Some((g, c)) = gpu_cpu_rgba(
+                &calib,
+                &config,
+                (cam_w, cam_h),
+                &left,
+                &right,
+                yaw,
+                pitch,
+                fr,
+            ) else {
+                eprintln!("skipping regimes: no GPU adapter");
+                return;
+            };
+            ran = true;
+            let (mean, pct16, max) = rgb_diff_stats(&g, &c);
+            eprintln!("regime {label}: mean={mean:.3} >16:{pct16:.3}% max={max}");
+            assert!(
+                mean < 1.5,
+                "{label}: mean RGB diff {mean} (geometry divergence?)"
+            );
+            assert!(
+                pct16 < 0.5,
+                "{label}: {pct16}% of channels off by >16 (geometry divergence?)"
+            );
+        }
+        assert!(ran, "regimes test did not run");
+    }
+
+    /// High-frequency content locks the sampler: smooth gradients hide a
+    /// half-texel / coordinate-convention error (bilinear of a ramp is
+    /// near-exact), a checker exposes it. Looser bounds than the smooth regimes
+    /// because sharp edges produce isolated f32/f64 + texture-filter-precision
+    /// spikes; a real convention bug would blow the mean into the tens.
+    #[test]
+    fn cpu_matches_gpu_high_frequency() {
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let cal = calib(cam_w, cam_h);
+        let config = ViewportConfig {
+            width: 192,
+            height: 108,
+            ..Default::default()
+        };
+        let (cy, cuv) = checker_nv12(cam_w, cam_h);
+        let left = Nv12Planes { y: &cy, uv: &cuv };
+        let right = Nv12Planes { y: &cy, uv: &cuv };
+        let Some((g, c)) = gpu_cpu_rgba(
+            &cal,
+            &config,
+            (cam_w, cam_h),
+            &left,
+            &right,
+            0.05,
+            -0.03,
+            false,
+        ) else {
+            return;
+        };
+        let (mean, pct16, max) = rgb_diff_stats(&g, &c);
+        eprintln!("high-freq GPU-vs-CPU: mean={mean:.3} >16:{pct16:.3}% max={max}");
+        assert!(
+            mean < 3.0,
+            "high-freq mean {mean} (sampler/convention error?)"
+        );
+        assert!(
+            pct16 < 3.0,
+            "high-freq {pct16}% off by >16 (sampler/convention error?)"
+        );
+    }
+
+    /// Consistency: where the GPU leaves the cleared-black background (no plane
+    /// covers the pixel), the CPU must also be black - it must NOT "fill in" the
+    /// uncovered region with extended plane content. A wide FOV leaves a real
+    /// black margin around the L-shape planes. (Edge-extend past the plane is a
+    /// deliberate future opt-in for *both* backends, not an accidental CPU-only
+    /// divergence.)
+    #[test]
+    fn cpu_black_region_matches_gpu() {
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let cal = calib(cam_w, cam_h);
+        let config = ViewportConfig {
+            width: 192,
+            height: 108,
+            fov_degrees: 140.0,
+            ..Default::default()
+        };
+        let (ly, luv) = textured_nv12(cam_w, cam_h, 0.0);
+        let (ry, ruv) = textured_nv12(cam_w, cam_h, 1.3);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let Some((g, c)) = gpu_cpu_rgba(
+            &cal,
+            &config,
+            (cam_w, cam_h),
+            &left,
+            &right,
+            0.0,
+            0.0,
+            false,
+        ) else {
+            return;
+        };
+        let (mut gpu_black, mut leak) = (0u32, 0u32);
+        for (gp, cp) in g.chunks_exact(4).zip(c.chunks_exact(4)) {
+            if gp[0] == 0 && gp[1] == 0 && gp[2] == 0 {
+                gpu_black += 1;
+                // > 8 ignores 1-LSB near-black blend noise at the boundary.
+                if cp[0] > 8 || cp[1] > 8 || cp[2] > 8 {
+                    leak += 1;
                 }
             }
         }
-        assert!(ran, "regimes test did not run");
+        eprintln!("black-region: gpu_black={gpu_black} cpu-leak={leak}");
+        assert!(gpu_black > 0, "expected a black margin at fov=140");
+        let leak_pct = 100.0 * leak as f64 / gpu_black as f64;
+        assert!(
+            leak_pct < 5.0,
+            "{leak_pct}% of GPU-black pixels are non-black on CPU (coverage divergence?)"
+        );
     }
 }

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -618,6 +618,67 @@ mod tests {
         assert!(ran, "regimes test did not run");
     }
 
+    /// The GPU rasterizer depth-clips fragments at NEAR_PLANE; the CPU inverse
+    /// map must apply the same `0 <= clip_z <= clip_w` test. A tiny
+    /// `camera_axis_offset` (or a FOV near the 179 singularity) places a plane
+    /// within the near plane, so without the clip the CPU gathers a near band
+    /// the GPU discards - a large coverage divergence (mean in the hundreds,
+    /// most channels off by >16). Regression guard for the near-plane clip.
+    #[test]
+    fn cpu_matches_gpu_near_plane_clip() {
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let (ly, luv) = textured_nv12(cam_w, cam_h, 0.0);
+        let (ry, ruv) = textured_nv12(cam_w, cam_h, 1.3);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let axis = |off: f64| {
+            let mut c = calib(cam_w, cam_h);
+            c.layout.camera_axis_offset = off;
+            c
+        };
+        let cfg = |fov: f32| ViewportConfig {
+            width: 192,
+            height: 108,
+            fov_degrees: fov,
+            ..Default::default()
+        };
+        // Each case puts a plane within NEAR_PLANE of the virtual camera before
+        // the fix: axis offset below ~0.012, or FOV near the projection limit.
+        let cases: [(&str, MatchCalibration, ViewportConfig); 3] = [
+            ("axis-offset 0.005", axis(0.005), cfg(75.0)),
+            ("axis-offset 0.012", axis(0.012), cfg(75.0)),
+            ("fov 178", calib(cam_w, cam_h), cfg(178.0)),
+        ];
+        let mut ran = false;
+        for (label, cal, config) in cases {
+            let Some((g, c)) = gpu_cpu_rgba(
+                &cal,
+                &config,
+                (cam_w, cam_h),
+                &left,
+                &right,
+                0.0,
+                0.0,
+                false,
+            ) else {
+                eprintln!("skipping near-plane: no GPU adapter");
+                return;
+            };
+            ran = true;
+            let (mean, pct16, max) = rgb_diff_stats(&g, &c);
+            eprintln!("near-plane {label}: mean={mean:.3} >16:{pct16:.3}% max={max}");
+            assert!(
+                mean < 1.5,
+                "{label}: mean RGB diff {mean} (missing near-plane clip?)"
+            );
+            assert!(
+                pct16 < 0.5,
+                "{label}: {pct16}% of channels off by >16 (missing near-plane clip?)"
+            );
+        }
+        assert!(ran, "near-plane test did not run");
+    }
+
     /// High-frequency content locks the sampler: smooth gradients hide a
     /// half-texel / coordinate-convention error (bilinear of a ramp is
     /// near-exact), a checker exposes it. Looser bounds than the smooth regimes

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -24,9 +24,11 @@
 //! memory-tuned specialisation and NV12-direct output are deliberate later
 //! additions, gated on profiling (see the cpu-stitch portability work).
 
+mod backend;
 mod cpu;
 pub mod geometry;
 
+pub use backend::{CpuStitchBackend, GpuStitchBackend, StitchBackend, StitchError};
 pub use cpu::{stitch_l_shape_rgba, stitch_l_shape_rgba_yuv420p};
 pub use geometry::{PlaneMap, l_shape_plane_maps};
 

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -155,4 +155,101 @@ mod tests {
             "expected some covered (non-black) output pixels"
         );
     }
+
+    /// The keystone: the CPU float reference must agree with the GPU shader on
+    /// the same scene. Because both share `view_matrix`, the projection, and
+    /// `lens::kb4`, the only differences are f32-vs-f64 and hardware-vs-software
+    /// bilinear - so the RGB match should be tight. Skips when no GPU adapter.
+    #[test]
+    fn cpu_matches_gpu_within_tolerance() {
+        use crate::gpu::{GpuContext, GpuError};
+        use crate::render::renderer::InputFormat;
+
+        let gpu = match pollster::block_on(GpuContext::new()) {
+            Ok(g) => g,
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                eprintln!("skipping GPU agreement: no adapter");
+                return;
+            }
+            Err(e) => panic!("gpu init: {e}"),
+        };
+
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let (out_w, out_h) = (192u32, 108u32);
+        let calib = test_calib(cam_w, cam_h);
+        let config = ViewportConfig {
+            width: out_w,
+            height: out_h,
+            ..Default::default()
+        };
+        let (ly, luv) = nv12(cam_w, cam_h, 0);
+        let (ry, ruv) = nv12(cam_w, cam_h, 30);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let (yaw, pitch) = (0.10f32, -0.05f32);
+
+        // GPU render -> RGBA. The readback is triple-buffered (N-2 latency), so
+        // render the same frame three times to drain one result.
+        let pipeline = crate::render::pipeline::StitchPipeline::with_gpu(
+            gpu,
+            calib.clone(),
+            config.clone(),
+            cam_w,
+            cam_h,
+            wgpu::TextureFormat::Rgba8Unorm,
+            InputFormat::Nv12,
+        )
+        .expect("pipeline");
+        let mut readback =
+            crate::gpu::rgba_readback::RgbaReadback::new(pipeline.gpu(), out_w, out_h)
+                .expect("readback");
+        let mut gpu_rgba: Option<Vec<u8>> = None;
+        for _ in 0..3 {
+            let cmd = pipeline
+                .render_to_target_nv12(&left, &right, yaw, pitch)
+                .expect("render");
+            let tex = pipeline.render_target();
+            if let Some(bytes) = readback
+                .readback(pipeline.gpu(), tex, cmd)
+                .expect("readback")
+            {
+                gpu_rgba = Some(bytes.to_vec());
+            }
+        }
+        let gpu_rgba = gpu_rgba.expect("gpu should produce a frame after 3 renders");
+
+        // CPU reference on the same inputs (limited range, matching the GPU default).
+        let cpu_rgba = stitch_l_shape_rgba(
+            &left,
+            &right,
+            (cam_w, cam_h),
+            &calib,
+            &config,
+            yaw,
+            pitch,
+            false,
+        );
+        assert_eq!(gpu_rgba.len(), cpu_rgba.len());
+
+        let (mut max, mut sum, mut n, mut gt4) = (0i32, 0i64, 0i64, 0i64);
+        for (g, c) in gpu_rgba.chunks_exact(4).zip(cpu_rgba.chunks_exact(4)) {
+            for k in 0..3 {
+                let d = (g[k] as i32 - c[k] as i32).abs();
+                max = max.max(d);
+                sum += d as i64;
+                n += 1;
+                if d > 4 {
+                    gt4 += 1;
+                }
+            }
+        }
+        let mean = sum as f64 / n as f64;
+        let pct_gt4 = 100.0 * gt4 as f64 / n as f64;
+        eprintln!("GPU-vs-CPU RGB: max={max} mean={mean:.3} >4:{pct_gt4:.3}%");
+        // Shared geometry + lens => agreement to ~1 LSB; tolerances leave room
+        // for f32-vs-f64 and cross-GPU bilinear/rounding without masking a
+        // real geometry regression (which would blow max into the tens).
+        assert!(mean < 1.0, "mean RGB diff too high: {mean}");
+        assert!(pct_gt4 < 0.5, "too many large RGB diffs: {pct_gt4}%");
+    }
 }

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -5,7 +5,7 @@
 //! It serves two roles:
 //!
 //! 1. **Correctness oracle** for the GPU path. The geometry reuses
-//!    [`crate::lens::kb4`] and the same view/projection matrices as
+//!    `crate::lens::kb4` and the same view/projection matrices as
 //!    [`crate::render`], so the CPU and GPU outputs agree by construction
 //!    rather than by coincidence.
 //! 2. **Rendering path for GPU-less targets** (edge SoCs, cloud CPU workers)
@@ -16,7 +16,7 @@
 //! [`SurfaceMap`] is the only projection-specific piece: it maps an output
 //! pixel to a source-camera UV. The two-plane L-shape provides one
 //! [`PlaneMap`] per camera; future projections (cylinder, N-camera) implement
-//! the same trait and the gather loop in [`cpu`] is unchanged.
+//! the same trait and the gather loop in `cpu` is unchanged.
 //!
 //! ## Phase 1 scope
 //!

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -149,7 +149,8 @@ mod tests {
         let left = Nv12Planes { y: &ly, uv: &luv };
         let right = Nv12Planes { y: &ry, uv: &ruv };
 
-        let out = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
+        let out =
+            stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false).unwrap();
         assert_eq!(out.len(), (w * h * 4) as usize);
         // Alpha channel is fully opaque.
         assert!(out.iter().skip(3).step_by(4).all(|&a| a == 255));
@@ -169,8 +170,8 @@ mod tests {
         let left = Nv12Planes { y: &ly, uv: &luv };
         let right = Nv12Planes { y: &ry, uv: &ruv };
 
-        let a = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
-        let b = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false);
+        let a = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false).unwrap();
+        let b = stitch_l_shape_rgba(&left, &right, (w, h), &calib, &cfg, 0.0, 0.0, false).unwrap();
         assert_eq!(a, b, "stitch must be deterministic");
 
         // Some pixels are covered (non-black) - the planes are in view.
@@ -250,7 +251,8 @@ mod tests {
             yaw,
             pitch,
             false,
-        );
+        )
+        .expect("cpu stitch");
         assert_eq!(gpu_rgba.len(), cpu_rgba.len());
 
         let (mut max, mut sum, mut n, mut gt4) = (0i32, 0i64, 0i64, 0i64);
@@ -366,7 +368,8 @@ mod tests {
             yaw,
             pitch,
             false,
-        );
+        )
+        .expect("cpu stitch yuv420p");
         assert_eq!(gpu_rgba.len(), cpu_rgba.len());
 
         let (mut max, mut sum, mut n, mut gt4) = (0i32, 0i64, 0i64, 0i64);
@@ -485,7 +488,8 @@ mod tests {
             }
         }
         let gpu_rgba = gpu_rgba.expect("gpu frame");
-        let cpu_rgba = stitch_l_shape_rgba(left, right, cam, calib, config, yaw, pitch, full_range);
+        let cpu_rgba =
+            stitch_l_shape_rgba(left, right, cam, calib, config, yaw, pitch, full_range).unwrap();
         Some((gpu_rgba, cpu_rgba))
     }
 

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -27,7 +27,7 @@
 mod cpu;
 pub mod geometry;
 
-pub use cpu::stitch_l_shape_rgba;
+pub use cpu::{stitch_l_shape_rgba, stitch_l_shape_rgba_yuv420p};
 pub use geometry::{PlaneMap, l_shape_plane_maps};
 
 /// A source-camera sample location produced by a [`SurfaceMap`].
@@ -249,6 +249,121 @@ mod tests {
         // Shared geometry + lens => agreement to ~1 LSB; tolerances leave room
         // for f32-vs-f64 and cross-GPU bilinear/rounding without masking a
         // real geometry regression (which would blow max into the tens).
+        assert!(mean < 1.0, "mean RGB diff too high: {mean}");
+        assert!(pct_gt4 < 0.5, "too many large RGB diffs: {pct_gt4}%");
+    }
+
+    /// Synthetic YUV420p: horizontal luma gradient + mild chroma gradients, so
+    /// the separate-plane U/V sampler is exercised (not just flat chroma).
+    fn yuv420(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>, Vec<u8>) {
+        let y: Vec<u8> = (0..w * h)
+            .map(|i| ((i % w) as usize * 255 / w as usize) as u8)
+            .map(|val| val.saturating_add(bias))
+            .collect();
+        let (cw, ch2) = (w / 2, h / 2);
+        let u: Vec<u8> = (0..cw * ch2)
+            .map(|i| ((i % cw) as usize * 255 / cw as usize) as u8)
+            .collect();
+        let v: Vec<u8> = (0..cw * ch2)
+            .map(|i| ((i / cw) as usize * 255 / ch2 as usize) as u8)
+            .collect();
+        (y, u, v)
+    }
+
+    /// YUV420p planar input must agree with the GPU's YUV420p path too,
+    /// validating the separate-plane chroma sampler against the shader.
+    #[test]
+    fn cpu_yuv420p_matches_gpu_within_tolerance() {
+        use crate::gpu::{GpuContext, GpuError};
+        use crate::render::planes::YuvPlanes;
+        use crate::render::renderer::InputFormat;
+
+        let gpu = match pollster::block_on(GpuContext::new()) {
+            Ok(g) => g,
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                eprintln!("skipping GPU agreement (yuv420p): no adapter");
+                return;
+            }
+            Err(e) => panic!("gpu init: {e}"),
+        };
+
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let (out_w, out_h) = (192u32, 108u32);
+        let calib = test_calib(cam_w, cam_h);
+        let config = ViewportConfig {
+            width: out_w,
+            height: out_h,
+            ..Default::default()
+        };
+        let (ly, lu, lv) = yuv420(cam_w, cam_h, 0);
+        let (ry, ru, rv) = yuv420(cam_w, cam_h, 30);
+        let left = YuvPlanes {
+            y: &ly,
+            u: &lu,
+            v: &lv,
+        };
+        let right = YuvPlanes {
+            y: &ry,
+            u: &ru,
+            v: &rv,
+        };
+        let (yaw, pitch) = (0.10f32, -0.05f32);
+
+        let pipeline = crate::render::pipeline::StitchPipeline::with_gpu(
+            gpu,
+            calib.clone(),
+            config.clone(),
+            cam_w,
+            cam_h,
+            wgpu::TextureFormat::Rgba8Unorm,
+            InputFormat::Yuv420p,
+        )
+        .expect("pipeline");
+        let mut readback =
+            crate::gpu::rgba_readback::RgbaReadback::new(pipeline.gpu(), out_w, out_h)
+                .expect("readback");
+        let mut gpu_rgba: Option<Vec<u8>> = None;
+        for _ in 0..3 {
+            let cmd = pipeline
+                .render_to_target(&left, &right, yaw, pitch)
+                .expect("render");
+            let tex = pipeline.render_target();
+            if let Some(bytes) = readback
+                .readback(pipeline.gpu(), tex, cmd)
+                .expect("readback")
+            {
+                gpu_rgba = Some(bytes.to_vec());
+            }
+        }
+        let gpu_rgba = gpu_rgba.expect("gpu should produce a frame after 3 renders");
+
+        let cpu_rgba = stitch_l_shape_rgba_yuv420p(
+            &left,
+            &right,
+            (cam_w, cam_h),
+            &calib,
+            &config,
+            yaw,
+            pitch,
+            false,
+        );
+        assert_eq!(gpu_rgba.len(), cpu_rgba.len());
+
+        let (mut max, mut sum, mut n, mut gt4) = (0i32, 0i64, 0i64, 0i64);
+        for (g, c) in gpu_rgba.chunks_exact(4).zip(cpu_rgba.chunks_exact(4)) {
+            for k in 0..3 {
+                let d = (g[k] as i32 - c[k] as i32).abs();
+                max = max.max(d);
+                sum += d as i64;
+                n += 1;
+                if d > 4 {
+                    gt4 += 1;
+                }
+            }
+        }
+        let mean = sum as f64 / n as f64;
+        let pct_gt4 = 100.0 * gt4 as f64 / n as f64;
+        eprintln!("YUV420p GPU-vs-CPU RGB: max={max} mean={mean:.3} >4:{pct_gt4:.3}%");
         assert!(mean < 1.0, "mean RGB diff too high: {mean}");
         assert!(pct_gt4 < 0.5, "too many large RGB diffs: {pct_gt4}%");
     }

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -170,6 +170,10 @@ mod tests {
         let gpu = match pollster::block_on(GpuContext::new()) {
             Ok(g) => g,
             Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                assert!(
+                    std::env::var("RECO_REQUIRE_GPU").is_err(),
+                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
+                );
                 eprintln!("skipping GPU agreement: no adapter");
                 return;
             }
@@ -287,6 +291,10 @@ mod tests {
         let gpu = match pollster::block_on(GpuContext::new()) {
             Ok(g) => g,
             Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                assert!(
+                    std::env::var("RECO_REQUIRE_GPU").is_err(),
+                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
+                );
                 eprintln!("skipping GPU agreement (yuv420p): no adapter");
                 return;
             }
@@ -417,7 +425,13 @@ mod tests {
         use crate::render::renderer::InputFormat;
         let gpu = match pollster::block_on(GpuContext::new()) {
             Ok(g) => g,
-            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => return None,
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                assert!(
+                    std::env::var("RECO_REQUIRE_GPU").is_err(),
+                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
+                );
+                return None;
+            }
             Err(e) => panic!("gpu init: {e}"),
         };
         let (cam_w, cam_h) = cam;

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -1,8 +1,8 @@
 //! CPU stitching backend (projection-agnostic).
 //!
 //! A pure-Rust, no-wgpu software stitcher that mirrors the GPU fisheye shader
-//! ([`shaders/fisheye.wgsl`](../render/renderer/index.html)) per output pixel.
-//! It serves two roles:
+//! (`shaders/fisheye.wgsl`, the fragment stage in [`crate::render`]) per output
+//! pixel. It serves two roles:
 //!
 //! 1. **Correctness oracle** for the GPU path. The geometry reuses
 //!    `crate::lens::kb4` and the same view/projection matrices as
@@ -15,8 +15,9 @@
 //!
 //! [`SurfaceMap`] is the only projection-specific piece: it maps an output
 //! pixel to a source-camera UV. The two-plane L-shape provides one
-//! [`PlaneMap`] per camera; future projections (cylinder, N-camera) implement
-//! the same trait and the gather loop in `cpu` is unchanged.
+//! [`PlaneMap`] per camera. The gather loop in `cpu` is currently specialised
+//! to the two-surface L-shape composite; the trait is the seam that N-surface
+//! projections (cylinder, N-camera) build on.
 //!
 //! ## Phase 1 scope
 //!
@@ -26,7 +27,7 @@
 
 mod backend;
 mod cpu;
-pub mod geometry;
+mod geometry;
 
 pub use backend::{CpuStitchBackend, GpuStitchBackend, StitchBackend, StitchError};
 pub use cpu::{stitch_l_shape_rgba, stitch_l_shape_rgba_yuv420p};
@@ -50,25 +51,23 @@ pub struct SurfaceUv {
 ///
 /// Implemented once per projection. The L-shape supplies two (one per camera
 /// plane); the CPU gather loop queries each surface and composites the ones
-/// that cover a pixel, so adding a projection means implementing this trait -
-/// the loop never changes. This is the CPU dual of the GPU rasterizer's
-/// per-fragment plane-UV interpolation.
+/// that cover a pixel. The L-shape composite loop is two-surface today; this
+/// trait is the seam future N-surface projections build on. It is the CPU dual
+/// of the GPU rasterizer's per-fragment plane-UV interpolation.
 pub trait SurfaceMap {
     /// Map an output pixel centre to its source-camera UV, or `None` when this
     /// surface does not cover the pixel (the GPU shader's bounds discard).
     fn sample_uv(&self, out_x: u32, out_y: u32) -> Option<SurfaceUv>;
 }
 
+/// Shared test fixtures + GPU acquisition for the stitch test modules.
 #[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) mod test_support {
     use crate::calibration::{CameraParams, MatchCalibration, PlaneLayout};
-    use crate::render::planes::Nv12Planes;
-    use crate::render::viewport::ViewportConfig;
+    use crate::gpu::{GpuContext, GpuError};
 
-    /// A frontal-ish two-camera calibration with a mild fisheye, sized for fast
-    /// tests. Both cameras share dimensions (as a real stereo rig does).
-    fn test_calib(w: u32, h: u32) -> MatchCalibration {
+    /// Two-camera calibration (shared dims, mild fisheye, centred) for tests.
+    pub fn calib(w: u32, h: u32) -> MatchCalibration {
         let cam = || CameraParams {
             width: w,
             height: h,
@@ -100,19 +99,46 @@ mod tests {
     }
 
     /// Synthetic NV12 frame: a horizontal luma gradient + flat mid-grey chroma.
-    fn nv12(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>) {
+    pub fn nv12(w: u32, h: u32, bias: u8) -> (Vec<u8>, Vec<u8>) {
         let y: Vec<u8> = (0..w * h)
-            .map(|i| ((i % w as usize as u32) as usize * 255 / w as usize) as u8)
-            .map(|v| v.saturating_add(bias))
+            .map(|i| ((i % w) as usize * 255 / w as usize) as u8)
+            .map(|val| val.saturating_add(bias))
             .collect();
         let uv = vec![128u8; (w * (h / 2)) as usize];
         (y, uv)
     }
 
+    /// Acquire a GPU context, or `None` to skip the test - unless
+    /// `RECO_REQUIRE_GPU` is set, in which case a missing adapter is a hard
+    /// failure (so CI with a software adapter cannot silently skip the
+    /// agreement tests).
+    pub fn gpu_or_skip() -> Option<GpuContext> {
+        match pollster::block_on(GpuContext::new()) {
+            Ok(g) => Some(g),
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
+                assert!(
+                    std::env::var("RECO_REQUIRE_GPU").is_err(),
+                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
+                );
+                None
+            }
+            Err(e) => panic!("gpu init: {e}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{calib, gpu_or_skip, nv12};
+    use super::*;
+    use crate::calibration::MatchCalibration;
+    use crate::render::planes::Nv12Planes;
+    use crate::render::viewport::ViewportConfig;
+
     #[test]
     fn output_dimensions_and_opaque_alpha() {
         let (w, h) = (96u32, 54u32);
-        let calib = test_calib(w, h);
+        let calib = calib(w, h);
         let cfg = ViewportConfig {
             width: w,
             height: h,
@@ -132,7 +158,7 @@ mod tests {
     #[test]
     fn produces_covered_pixels_and_is_deterministic() {
         let (w, h) = (96u32, 54u32);
-        let calib = test_calib(w, h);
+        let calib = calib(w, h);
         let cfg = ViewportConfig {
             width: w,
             height: h,
@@ -164,25 +190,15 @@ mod tests {
     /// bilinear - so the RGB match should be tight. Skips when no GPU adapter.
     #[test]
     fn cpu_matches_gpu_within_tolerance() {
-        use crate::gpu::{GpuContext, GpuError};
         use crate::render::renderer::InputFormat;
 
-        let gpu = match pollster::block_on(GpuContext::new()) {
-            Ok(g) => g,
-            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
-                assert!(
-                    std::env::var("RECO_REQUIRE_GPU").is_err(),
-                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
-                );
-                eprintln!("skipping GPU agreement: no adapter");
-                return;
-            }
-            Err(e) => panic!("gpu init: {e}"),
+        let Some(gpu) = gpu_or_skip() else {
+            return;
         };
 
         let (cam_w, cam_h) = (256u32, 144u32);
         let (out_w, out_h) = (192u32, 108u32);
-        let calib = test_calib(cam_w, cam_h);
+        let calib = calib(cam_w, cam_h);
         let config = ViewportConfig {
             width: out_w,
             height: out_h,
@@ -284,26 +300,16 @@ mod tests {
     /// validating the separate-plane chroma sampler against the shader.
     #[test]
     fn cpu_yuv420p_matches_gpu_within_tolerance() {
-        use crate::gpu::{GpuContext, GpuError};
         use crate::render::planes::YuvPlanes;
         use crate::render::renderer::InputFormat;
 
-        let gpu = match pollster::block_on(GpuContext::new()) {
-            Ok(g) => g,
-            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
-                assert!(
-                    std::env::var("RECO_REQUIRE_GPU").is_err(),
-                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
-                );
-                eprintln!("skipping GPU agreement (yuv420p): no adapter");
-                return;
-            }
-            Err(e) => panic!("gpu init: {e}"),
+        let Some(gpu) = gpu_or_skip() else {
+            return;
         };
 
         let (cam_w, cam_h) = (256u32, 144u32);
         let (out_w, out_h) = (192u32, 108u32);
-        let calib = test_calib(cam_w, cam_h);
+        let calib = calib(cam_w, cam_h);
         let config = ViewportConfig {
             width: out_w,
             height: out_h,
@@ -421,19 +427,8 @@ mod tests {
         pitch: f32,
         full_range: bool,
     ) -> Option<(f64, f64, u32)> {
-        use crate::gpu::{GpuContext, GpuError};
         use crate::render::renderer::InputFormat;
-        let gpu = match pollster::block_on(GpuContext::new()) {
-            Ok(g) => g,
-            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => {
-                assert!(
-                    std::env::var("RECO_REQUIRE_GPU").is_err(),
-                    "RECO_REQUIRE_GPU is set but no GPU adapter was found"
-                );
-                return None;
-            }
-            Err(e) => panic!("gpu init: {e}"),
-        };
+        let gpu = gpu_or_skip()?;
         let (cam_w, cam_h) = cam;
         let mut pipeline = crate::render::pipeline::StitchPipeline::with_gpu(
             gpu,
@@ -508,12 +503,12 @@ mod tests {
             ..Default::default()
         };
         let calib_cx = |cx_off: f64| {
-            let mut c = test_calib(cam_w, cam_h);
+            let mut c = calib(cam_w, cam_h);
             c.left.cx = cam_w as f64 * (0.5 + cx_off);
             c.right.cx = cam_w as f64 * (0.5 + cx_off);
             c
         };
-        let base = test_calib(cam_w, cam_h);
+        let base = calib(cam_w, cam_h);
         let cases: [(&str, MatchCalibration, ViewportConfig, f32, f32, bool); 5] = [
             ("wide-pan", base.clone(), cfg(75.0, 1.0), 0.9, 0.0, false),
             ("wide-fov", base.clone(), cfg(130.0, 1.0), 0.0, 0.0, false),

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -253,6 +253,10 @@ mod tests {
         // real geometry regression (which would blow max into the tens).
         assert!(mean < 1.0, "mean RGB diff too high: {mean}");
         assert!(pct_gt4 < 0.5, "too many large RGB diffs: {pct_gt4}%");
+        assert!(
+            max <= 8,
+            "max RGB diff {max} too high (geometry divergence?)"
+        );
     }
 
     /// Synthetic YUV420p: horizontal luma gradient + mild chroma gradients, so
@@ -368,5 +372,176 @@ mod tests {
         eprintln!("YUV420p GPU-vs-CPU RGB: max={max} mean={mean:.3} >4:{pct_gt4:.3}%");
         assert!(mean < 1.0, "mean RGB diff too high: {mean}");
         assert!(pct_gt4 < 0.5, "too many large RGB diffs: {pct_gt4}%");
+        assert!(
+            max <= 8,
+            "max RGB diff {max} too high (geometry divergence?)"
+        );
+    }
+
+    /// Textured NV12 (rippled luma + gradient interleaved chroma) - non-flat so
+    /// geometry divergences surface as large diffs, not LSB noise.
+    fn textured_nv12(w: u32, h: u32, phase: f64) -> (Vec<u8>, Vec<u8>) {
+        let mut y = vec![0u8; (w * h) as usize];
+        for j in 0..h {
+            for i in 0..w {
+                let g = 128.0
+                    + 80.0 * ((i as f64) * 0.05 + phase).sin()
+                    + 40.0 * ((j as f64) * 0.04).cos();
+                y[(j * w + i) as usize] = g.clamp(0.0, 255.0) as u8;
+            }
+        }
+        let mut uv = vec![128u8; (w * (h / 2)) as usize];
+        for j in 0..h / 2 {
+            for i in (0..w).step_by(2) {
+                uv[(j * w + i) as usize] = (i * 255 / w) as u8;
+                uv[(j * w + i + 1) as usize] = (j * 255 / (h / 2)) as u8;
+            }
+        }
+        (y, uv)
+    }
+
+    /// Render a scene on the GPU and the CPU and return `(mean, pct>16, max)` of
+    /// the per-channel RGB difference, or `None` if there is no GPU adapter.
+    /// The single agreement primitive used across regimes. A geometry
+    /// divergence shows up as a large contiguous wrong region (high mean +
+    /// high pct>16); a correct result only has thin boundary f32/f64 flips.
+    fn gpu_cpu_diff(
+        calib: &MatchCalibration,
+        config: &ViewportConfig,
+        cam: (u32, u32),
+        yaw: f32,
+        pitch: f32,
+        full_range: bool,
+    ) -> Option<(f64, f64, u32)> {
+        use crate::gpu::{GpuContext, GpuError};
+        use crate::render::renderer::InputFormat;
+        let gpu = match pollster::block_on(GpuContext::new()) {
+            Ok(g) => g,
+            Err(GpuError::NoAdapter | GpuError::AdapterRequest(_)) => return None,
+            Err(e) => panic!("gpu init: {e}"),
+        };
+        let (cam_w, cam_h) = cam;
+        let mut pipeline = crate::render::pipeline::StitchPipeline::with_gpu(
+            gpu,
+            calib.clone(),
+            config.clone(),
+            cam_w,
+            cam_h,
+            wgpu::TextureFormat::Rgba8Unorm,
+            InputFormat::Nv12,
+        )
+        .expect("pipeline");
+        pipeline.set_full_range(full_range);
+        let mut readback = crate::gpu::rgba_readback::RgbaReadback::new(
+            pipeline.gpu(),
+            config.width,
+            config.height,
+        )
+        .expect("readback");
+        let (ly, luv) = textured_nv12(cam_w, cam_h, 0.0);
+        let (ry, ruv) = textured_nv12(cam_w, cam_h, 1.3);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let mut gpu_rgba = None;
+        for _ in 0..3 {
+            let cmd = pipeline
+                .render_to_target_nv12(&left, &right, yaw, pitch)
+                .expect("render");
+            let tex = pipeline.render_target();
+            if let Some(b) = readback
+                .readback(pipeline.gpu(), tex, cmd)
+                .expect("readback")
+            {
+                gpu_rgba = Some(b.to_vec());
+            }
+        }
+        let gpu_rgba = gpu_rgba.expect("gpu frame");
+        let cpu_rgba =
+            stitch_l_shape_rgba(&left, &right, cam, calib, config, yaw, pitch, full_range);
+        let (mut sum, mut n, mut gt, mut max) = (0i64, 0i64, 0i64, 0i32);
+        for (g, c) in gpu_rgba.chunks_exact(4).zip(cpu_rgba.chunks_exact(4)) {
+            for k in 0..3 {
+                let d = (g[k] as i32 - c[k] as i32).abs();
+                sum += d as i64;
+                n += 1;
+                if d > 16 {
+                    gt += 1;
+                }
+                max = max.max(d);
+            }
+        }
+        Some((
+            sum as f64 / n as f64,
+            100.0 * gt as f64 / n as f64,
+            max as u32,
+        ))
+    }
+
+    /// Regression guard for the regimes that masked the original behind-camera
+    /// and quad-footprint divergences: wide pan, wide FOV, off-center principal
+    /// point, full-range, and partial lens correction. Each must agree with the
+    /// GPU (a geometry divergence blows mean and the >16 fraction far past these
+    /// bounds - the original bugs gave 35-68% wrong pixels here).
+    #[test]
+    fn cpu_matches_gpu_across_regimes() {
+        let (cam_w, cam_h) = (256u32, 144u32);
+        let (out_w, out_h) = (192u32, 108u32);
+        let cfg = |fov: f32, corr: f32| ViewportConfig {
+            width: out_w,
+            height: out_h,
+            fov_degrees: fov,
+            lens_correction_amount: corr,
+            ..Default::default()
+        };
+        let calib_cx = |cx_off: f64| {
+            let mut c = test_calib(cam_w, cam_h);
+            c.left.cx = cam_w as f64 * (0.5 + cx_off);
+            c.right.cx = cam_w as f64 * (0.5 + cx_off);
+            c
+        };
+        let base = test_calib(cam_w, cam_h);
+        let cases: [(&str, MatchCalibration, ViewportConfig, f32, f32, bool); 5] = [
+            ("wide-pan", base.clone(), cfg(75.0, 1.0), 0.9, 0.0, false),
+            ("wide-fov", base.clone(), cfg(130.0, 1.0), 0.0, 0.0, false),
+            (
+                "off-center-cx",
+                calib_cx(0.12),
+                cfg(75.0, 1.0),
+                0.2,
+                0.0,
+                false,
+            ),
+            ("full-range", base.clone(), cfg(75.0, 1.0), 0.1, -0.05, true),
+            (
+                "lens-corr-0.5",
+                base.clone(),
+                cfg(75.0, 0.5),
+                0.1,
+                -0.05,
+                false,
+            ),
+        ];
+        let mut ran = false;
+        for (label, calib, config, yaw, pitch, fr) in cases {
+            match gpu_cpu_diff(&calib, &config, (cam_w, cam_h), yaw, pitch, fr) {
+                None => {
+                    eprintln!("skipping regimes: no GPU adapter");
+                    return;
+                }
+                Some((mean, pct16, max)) => {
+                    ran = true;
+                    eprintln!("regime {label}: mean={mean:.3} >16:{pct16:.3}% max={max}");
+                    assert!(
+                        mean < 1.5,
+                        "{label}: mean RGB diff {mean} (geometry divergence?)"
+                    );
+                    assert!(
+                        pct16 < 0.5,
+                        "{label}: {pct16}% of channels off by >16 (geometry divergence?)"
+                    );
+                }
+            }
+        }
+        assert!(ran, "regimes test did not run");
     }
 }


### PR DESCRIPTION
Adds a pure-Rust CPU stitching backend to reco-core that mirrors the GPU fisheye shader, reusing the same view/projection and lens::kb4 so the two agree to ~1 LSB. A SurfaceMap seam isolates the projection (L-shape today); a StitchBackend trait lets a headless consumer select GPU or CPU behind one interface. NV12 + YUV420p input, RGBA output.

GPU-vs-CPU agreement tests cover frontal, wide pan, wide FOV, off-center principal point, full-range, and partial lens correction. The test job now installs lavapipe (software Vulkan) and sets RECO_REQUIRE_GPU so those tests execute in CI instead of skipping on the GPU-less runner.

Draft: Phase 1 + 2 of a staged effort. The integer/edge specialization and the cylinder projection come in later passes.