### PR TITLE
fix(reco-core): make CUDA context current before freeing shared memory

### DIFF
--- a/crates/reco-core/src/interop/cuda.rs
+++ b/crates/reco-core/src/interop/cuda.rs
@@ -418,6 +418,14 @@ pub struct CudaSharedMemory {
 impl Drop for CudaSharedMemory {
     fn drop(&mut self) {
         if let Ok(cuda) = cuda() {
+            // This may drop on a thread without the CUDA context current (the
+            // session thread rather than the decode thread that allocated).
+            // Without a current context the cleanup calls below fail and the VMM
+            // allocation leaks. Ensure one first, as the other CUDA drops do.
+            if let Err(e) = cuda_ensure_context() {
+                log::warn!("CudaSharedMemory drop: no CUDA context, leaking allocation: {e}");
+                return;
+            }
             unsafe {
                 let unmap_rc = (cuda.cu_mem_unmap)(self.device_ptr, self.alloc_size);
                 if unmap_rc != CUDA_SUCCESS {


### PR DESCRIPTION
## Description

`CudaSharedMemory::drop` unmapped and freed its VMM allocation without ensuring a current CUDA context. When the drop runs on a thread that never set one (the session thread rather than the decode thread that allocated), `cuMemUnmap`/`cuMemAddressFree` fail and the address reservation plus physical pages leak. This guards the drop with `cuda_ensure_context()` first, matching the existing `CudaKernel` and `CudaImportedNv12` drop impls (the latter from #381), so all CUDA drop paths now ensure a context. No-op on non-CUDA systems.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [ ] I added or updated tests where it made sense
