### PR TITLE
feat: CPU session loop + reco stitch --cpu (12d/12e)

### DIFF
--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -253,6 +253,12 @@ enum Commands {
         #[arg(long, default_value_t = false)]
         no_zero_copy: bool,
 
+        /// Stitch entirely on the CPU: software render + CPU decode,
+        /// no GPU touched. Much slower; for GPU-less machines and for
+        /// verifying output without GPU variance.
+        #[arg(long, default_value_t = false)]
+        cpu: bool,
+
         /// Record pipeline events (detections, filter decisions, pan
         /// decisions) to a JSONL file for offline analysis.
         #[arg(long)]
@@ -794,6 +800,7 @@ fn main() -> anyhow::Result<()> {
             replay_scale,
             allow_no_tracking,
             no_zero_copy,
+            cpu,
             events,
             trajectory,
             panner_config,
@@ -825,6 +832,7 @@ fn main() -> anyhow::Result<()> {
                 replay_scale,
                 allow_no_tracking,
                 no_zero_copy,
+                cpu,
                 events_path: events.as_deref(),
                 trajectory_path: trajectory.as_deref(),
                 panner_config_path: panner_config.as_deref(),

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -58,6 +58,7 @@ pub struct StitchArgs<'a> {
     pub allow_no_tracking: bool,
     /// Force CPU decode to enable ORT CPU detection without TensorRT.
     pub no_zero_copy: bool,
+    pub cpu: bool,
     /// Path for pipeline event JSONL output.
     pub events_path: Option<&'a str>,
     /// Precomputed trajectory CSV (overrides AI panner).
@@ -139,6 +140,9 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
     }
     if args.no_zero_copy {
         job = job.force_cpu_decode();
+    }
+    if args.cpu {
+        job = job.cpu();
     }
     // Lookahead only helps when an AI panner drives the camera: it buffers
     // future frames so the panner can lead and the loop can centered-smooth.

--- a/crates/reco-core/src/render/mod.rs
+++ b/crates/reco-core/src/render/mod.rs
@@ -5,6 +5,7 @@
 //! `scene` are pure value/math modules the CPU stitch path shares, so
 //! they stay available without the `gpu` feature.
 
+pub mod nv12_cpu;
 #[cfg(feature = "gpu")]
 pub mod pipeline;
 pub mod planes;

--- a/crates/reco-core/src/render/nv12_cpu.rs
+++ b/crates/reco-core/src/render/nv12_cpu.rs
@@ -1,0 +1,311 @@
+//! CPU RGBA -> NV12 conversion for the software delivery path.
+//!
+//! Mirrors the GPU compute converter byte-for-byte (within float
+//! rounding): BT.709 sRGB to limited-range YCbCr, one chroma sample
+//! per 2x2 block via plain averaging, `+0.5`-then-truncate rounding.
+//!
+//! SYNC_WITH: shaders/rgba_to_nv12.wgsl - the coefficient set, the
+//! chroma averaging order, and the rounding must match exactly; the
+//! GPU-vs-CPU oracle test pins the agreement to 1 LSB.
+
+use thiserror::Error;
+
+/// Errors from the CPU NV12 conversion.
+#[derive(Debug, Clone, Error)]
+pub enum Nv12CpuError {
+    /// NV12 needs even dimensions (one chroma sample per 2x2 block).
+    #[error("NV12 dimensions must be even, got {width}x{height}")]
+    OddDimensions {
+        /// Requested output width.
+        width: u32,
+        /// Requested output height.
+        height: u32,
+    },
+    /// The RGBA buffer is too small for the requested conversion.
+    #[error("RGBA buffer too small: {actual} bytes, need {expected}")]
+    ShortBuffer {
+        /// Bytes required for `stride * height * 4`.
+        expected: usize,
+        /// Bytes the supplied buffer actually contains.
+        actual: usize,
+    },
+}
+
+/// NV12-legal dimensions for a render output: width rounded down to a
+/// multiple of 4, height to a multiple of 2.
+///
+/// The single home for the rounding rule the GPU converter and the CPU
+/// kernel share; both delivery paths hand sinks identically-sized
+/// frames for the same viewport.
+pub fn nv12_dims(width: u32, height: u32) -> (u32, u32) {
+    (width & !3, height & !1)
+}
+
+/// Convert sRGB-domain RGBA bytes to NV12 (BT.709 limited range).
+///
+/// Reads a `width x height` region from `rgba`, whose rows are
+/// `stride_px` pixels wide (`stride_px >= width`; pass the render
+/// width when converting a rounded region of a wider frame). Output
+/// layout matches the GPU converter: Y plane (`width * height`
+/// bytes) followed by the interleaved UV plane (`width * height / 2`
+/// bytes). `out` is resized to fit and fully overwritten.
+pub fn rgba_to_nv12_into(
+    rgba: &[u8],
+    stride_px: u32,
+    width: u32,
+    height: u32,
+    out: &mut Vec<u8>,
+) -> Result<(), Nv12CpuError> {
+    if width == 0
+        || height == 0
+        || !width.is_multiple_of(2)
+        || !height.is_multiple_of(2)
+        || stride_px < width
+    {
+        return Err(Nv12CpuError::OddDimensions { width, height });
+    }
+    let stride = stride_px as usize;
+    let (w, h) = (width as usize, height as usize);
+    let expected = stride * h * 4;
+    if rgba.len() < expected {
+        return Err(Nv12CpuError::ShortBuffer {
+            expected,
+            actual: rgba.len(),
+        });
+    }
+
+    let y_size = w * h;
+    out.resize(y_size + y_size / 2, 0);
+    let (y_plane, uv_plane) = out.split_at_mut(y_size);
+
+    // sRGB bytes as-is (no transfer decode), scaled to [0,1] exactly
+    // like the GPU's Rgba8Unorm texture load.
+    let f = |b: u8| b as f32 / 255.0;
+    let px_rgb = |x: usize, y: usize| {
+        let i = (y * stride + x) * 4;
+        (f(rgba[i]), f(rgba[i + 1]), f(rgba[i + 2]))
+    };
+
+    for row in 0..h {
+        for col in 0..w {
+            let (r, g, b) = px_rgb(col, row);
+            let y = 16.0 + 219.0 * (0.2126 * r + 0.7152 * g + 0.0722 * b);
+            y_plane[row * w + col] = (y + 0.5).clamp(0.0, 255.0) as u8;
+        }
+
+        // One (Cb, Cr) pair per 2x2 block, averaging in the shader's
+        // exact order: top-left + top-right + bottom-left + bottom-right.
+        if row.is_multiple_of(2) {
+            for pair in 0..w / 2 {
+                let x = pair * 2;
+                let (tl_r, tl_g, tl_b) = px_rgb(x, row);
+                let (tr_r, tr_g, tr_b) = px_rgb(x + 1, row);
+                let (bl_r, bl_g, bl_b) = px_rgb(x, row + 1);
+                let (br_r, br_g, br_b) = px_rgb(x + 1, row + 1);
+                let r = (tl_r + tr_r + bl_r + br_r) * 0.25;
+                let g = (tl_g + tr_g + bl_g + br_g) * 0.25;
+                let b = (tl_b + tr_b + bl_b + br_b) * 0.25;
+
+                let cb = 128.0 + 224.0 * (-0.1146 * r - 0.3854 * g + 0.5 * b);
+                let cr = 128.0 + 224.0 * (0.5 * r - 0.4542 * g - 0.0458 * b);
+                let uv_idx = (row / 2) * w + x;
+                uv_plane[uv_idx] = (cb + 0.5).clamp(0.0, 255.0) as u8;
+                uv_plane[uv_idx + 1] = (cr + 0.5).clamp(0.0, 255.0) as u8;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn solid(r: u8, g: u8, b: u8, w: usize, h: usize) -> Vec<u8> {
+        let mut v = Vec::with_capacity(w * h * 4);
+        for _ in 0..w * h {
+            v.extend_from_slice(&[r, g, b, 255]);
+        }
+        v
+    }
+
+    fn convert(rgba: &[u8], stride: u32, w: u32, h: u32) -> Vec<u8> {
+        let mut out = Vec::new();
+        rgba_to_nv12_into(rgba, stride, w, h, &mut out).unwrap();
+        out
+    }
+
+    #[test]
+    fn black_maps_to_limited_range_floor() {
+        let nv12 = convert(&solid(0, 0, 0, 4, 2), 4, 4, 2);
+        assert!(nv12[..8].iter().all(|&y| y == 16), "black Y = 16");
+        assert!(nv12[8..].iter().all(|&uv| uv == 128), "neutral chroma");
+    }
+
+    #[test]
+    fn white_maps_to_limited_range_ceiling() {
+        let nv12 = convert(&solid(255, 255, 255, 4, 2), 4, 4, 2);
+        assert!(nv12[..8].iter().all(|&y| y == 235), "white Y = 235");
+        assert!(nv12[8..].iter().all(|&uv| uv == 128), "neutral chroma");
+    }
+
+    #[test]
+    fn pure_red_matches_bt709() {
+        // Y = 16 + 219*0.2126 = 62.56 -> 63; Cb = 128 - 224*0.1146 ->
+        // 102.3 -> 102; Cr = 128 + 224*0.5 = 240.
+        let nv12 = convert(&solid(255, 0, 0, 4, 2), 4, 4, 2);
+        assert_eq!(nv12[0], 63);
+        assert_eq!(nv12[8], 102);
+        assert_eq!(nv12[9], 240);
+    }
+
+    #[test]
+    fn chroma_averages_the_2x2_block() {
+        // Left 2x2 block: one white pixel, three black -> Y avg not
+        // relevant, chroma stays neutral (grey axis); instead use
+        // red/blue split so the average is measurable.
+        // Top row red, bottom row blue: avg = (0.5, 0, 0.5).
+        let w = 2usize;
+        let mut rgba = Vec::new();
+        rgba.extend_from_slice(&[255, 0, 0, 255, 255, 0, 0, 255]); // row 0: red red
+        rgba.extend_from_slice(&[0, 0, 255, 255, 0, 0, 255, 255]); // row 1: blue blue
+        let mut out = Vec::new();
+        rgba_to_nv12_into(&rgba, w as u32, w as u32, 2, &mut out).unwrap();
+        // avg rgb = (0.5, 0, 0.5): Cb = 128 + 224*(-0.0573 + 0.25) ->
+        // 171.2 -> 171; Cr = 128 + 224*(0.25 - 0.0229) -> 178.9 -> 179.
+        assert_eq!(out[4], 171, "Cb of the averaged block");
+        assert_eq!(out[5], 179, "Cr of the averaged block");
+    }
+
+    #[test]
+    fn stride_reads_the_left_region() {
+        // 6px-wide source, convert the left 4x2: right 2 columns are
+        // poison values that must not leak into the output.
+        let mut rgba = solid(100, 100, 100, 6, 2);
+        for row in 0..2 {
+            for col in 4..6 {
+                let i = (row * 6 + col) * 4;
+                rgba[i..i + 4].copy_from_slice(&[255, 0, 255, 255]);
+            }
+        }
+        let nv12 = convert(&rgba, 6, 4, 2);
+        let uniform = convert(&solid(100, 100, 100, 4, 2), 4, 4, 2);
+        assert_eq!(nv12, uniform, "poison columns leaked through stride");
+    }
+
+    #[test]
+    fn rejects_odd_dimensions_and_short_buffers() {
+        let mut out = Vec::new();
+        assert!(rgba_to_nv12_into(&solid(0, 0, 0, 3, 2), 3, 3, 2, &mut out).is_err());
+        assert!(rgba_to_nv12_into(&[0u8; 8], 4, 4, 2, &mut out).is_err());
+    }
+
+    #[test]
+    fn nv12_dims_rounds_like_the_gpu_converter() {
+        assert_eq!(nv12_dims(1920, 1080), (1920, 1080));
+        assert_eq!(nv12_dims(1923, 1081), (1920, 1080));
+        assert_eq!(nv12_dims(2, 3), (0, 2));
+    }
+}
+
+#[cfg(all(test, feature = "gpu"))]
+mod gpu_oracle {
+    use super::rgba_to_nv12_into;
+    use crate::gpu::nv12_converter::Nv12Converter;
+    use crate::stitch::test_support::gpu_or_skip;
+
+    /// The CPU kernel and the GPU compute shader run the same f32 math
+    /// on the same bytes; only FMA contraction can split them, so the
+    /// agreement bound is 1 LSB on every byte (unlike the full-stitch
+    /// oracle, there is no sampling or rasterization noise to admit).
+    #[test]
+    fn cpu_kernel_agrees_with_the_gpu_converter() {
+        let Some(gpu) = gpu_or_skip() else { return };
+        let (w, h) = (64u32, 32u32);
+
+        // Deterministic pseudo-random RGBA covering the value range.
+        let mut state = 0x1234_5678u32;
+        let mut rgba = vec![0u8; (w * h * 4) as usize];
+        for px in rgba.chunks_exact_mut(4) {
+            for channel in px.iter_mut().take(3) {
+                state = state.wrapping_mul(1_664_525).wrapping_add(1_013_904_223);
+                *channel = (state >> 24) as u8;
+            }
+            px[3] = 255;
+        }
+
+        let texture = gpu.device().create_texture(&wgpu::TextureDescriptor {
+            label: Some("nv12-oracle-input"),
+            size: wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
+            view_formats: &[],
+        });
+        gpu.queue().write_texture(
+            wgpu::TexelCopyTextureInfo {
+                texture: &texture,
+                mip_level: 0,
+                origin: wgpu::Origin3d::ZERO,
+                aspect: wgpu::TextureAspect::All,
+            },
+            &rgba,
+            wgpu::TexelCopyBufferLayout {
+                offset: 0,
+                bytes_per_row: Some(w * 4),
+                rows_per_image: Some(h),
+            },
+            wgpu::Extent3d {
+                width: w,
+                height: h,
+                depth_or_array_layers: 1,
+            },
+        );
+
+        let mut converter = Nv12Converter::new(&gpu, w, h).expect("converter");
+        let empty = gpu
+            .device()
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor::default())
+            .finish();
+        assert!(
+            converter
+                .convert_and_readback(&gpu, &texture, empty)
+                .expect("convert")
+                .is_none(),
+            "first call is a warmup"
+        );
+        let gpu_nv12 = converter
+            .flush_pending(&gpu)
+            .expect("flush")
+            .expect("one pending frame")
+            .to_vec();
+
+        let mut cpu_nv12 = Vec::new();
+        rgba_to_nv12_into(&rgba, w, w, h, &mut cpu_nv12).expect("cpu kernel");
+
+        assert_eq!(gpu_nv12.len(), cpu_nv12.len(), "NV12 layout mismatch");
+        let max = gpu_nv12
+            .iter()
+            .zip(&cpu_nv12)
+            .map(|(g, c)| (*g as i32 - *c as i32).abs())
+            .max()
+            .unwrap();
+        let diff_count = gpu_nv12
+            .iter()
+            .zip(&cpu_nv12)
+            .filter(|(g, c)| g != c)
+            .count();
+        eprintln!(
+            "[nv12 oracle] {} bytes, {diff_count} differ, max diff {max}",
+            gpu_nv12.len()
+        );
+        assert!(max <= 1, "CPU/GPU NV12 divergence beyond 1 LSB: {max}");
+    }
+}

--- a/crates/reco-core/src/session/mod.rs
+++ b/crates/reco-core/src/session/mod.rs
@@ -132,10 +132,9 @@ impl StitchSession {
     /// Use this when the caller needs to control GPU selection (e.g.
     /// for zero-copy decode where the GPU must match the CUDA device).
     pub fn with_gpu(gpu: GpuContext, config: SessionConfig) -> Result<Self, SessionError> {
-        // Build a `StitchCore` as the session's rendering foundation.
         // The executor owns the pipeline + projection + NV12 delivery;
         // the core layers readback + coverage on top. The session
-        // layers on async encoding, lookahead, and the per-platform
+        // layers on sink delivery, lookahead, and the per-platform
         // frame dispatch.
         //
         // Rotation is NOT applied here. It's handled by:
@@ -161,7 +160,20 @@ impl StitchSession {
             },
         )
         .map_err(StitchCoreError::from)?;
-        let core = StitchCore::new(Executor::Gpu(Box::new(executor)))?;
+        Self::with_executor(Executor::Gpu(Box::new(executor)))
+    }
+
+    /// Create a session over an already-configured executor.
+    ///
+    /// The primitive constructor: [`Self::with_gpu`] is the GPU
+    /// convenience that builds the executor from a [`SessionConfig`].
+    /// With a [`CpuExecutor`](crate::stitch::CpuExecutor) arm the
+    /// session runs the software stitch loop ([`Self::run`] dispatches
+    /// per arm) and needs no GPU at all; the GPU-only entry points
+    /// (resident-frame submits, [`Self::submit_render_output`]) panic
+    /// on the CPU arm - batch consumers drive [`Self::run`].
+    pub fn with_executor(executor: Executor) -> Result<Self, SessionError> {
+        let core = StitchCore::new(executor)?;
 
         Ok(Self {
             core,
@@ -254,9 +266,19 @@ impl StitchSession {
 
     /// Shared reference to the GPU context, for consumers that create
     /// auxiliary resources on the session's device (demosaic kernels,
-    /// preview textures).
+    /// preview textures). Panics on a CPU-executor session - use
+    /// [`DetectionTarget::gpu`](crate::detect::DetectionTarget::gpu)
+    /// for executor-agnostic access.
     pub fn gpu(&self) -> &GpuContext {
         self.gpu_exec_ref().pipeline.gpu()
+    }
+
+    /// NV12 delivery dimensions for the current output viewport:
+    /// the shared rounding rule over the executor-agnostic viewport,
+    /// so CPU and GPU sessions hand sinks identically-sized frames.
+    pub(crate) fn nv12_delivery_dims(&self) -> (u32, u32) {
+        let vp = self.core.executor.viewport();
+        crate::render::nv12_cpu::nv12_dims(vp.width, vp.height)
     }
 
     /// The name of the GPU this session is running on.
@@ -301,29 +323,30 @@ impl StitchSession {
         &mut self.telemetry
     }
 
-    /// Flush the NV12 triple-buffer and finalize every sink.
+    /// Flush any pending delivery frames and finalize every sink.
     ///
-    /// Drains all pending frames from the triple-buffer pipeline and
-    /// fans them out to the attached sinks, then calls
+    /// The GPU arm's NV12 delivery is triple-buffered, so its last two
+    /// frames are drained here and fanned out to the attached sinks;
+    /// the CPU arm delivers synchronously and has nothing pending.
+    /// Then calls
     /// [`OutputSink::finish`](crate::sink::OutputSink::finish) on each
-    /// in attach order. Must be called after the frame loop ends.
+    /// sink in attach order. Must be called after the frame loop ends.
     pub fn finish(&mut self) -> Result<(), SessionError> {
-        // Flush remaining frames from the NV12 triple-buffer. Field-path
-        // borrow: `nv12_data` borrows the executor inside `core` while
-        // the fan-out feeds the session-owned sinks.
+        // Field-path borrow: `nv12_data` borrows the executor inside
+        // `core` while the fan-out feeds the session-owned sinks.
         //
         // An Abort error here skips `finish_all`, but no output is left
         // without its trailer: dropping a SinkThread disconnects its
         // channel and the worker runs the sink's own `finish` on exit,
         // and inline sinks finalize in their Drop impls.
-        let (nv12_width, nv12_height) = self.gpu_exec_ref().nv12_dims();
-        while let Some(nv12_data) = self
-            .core
-            .executor
-            .gpu_mut()
-            .expect("the streaming session runs on the GPU executor")
-            .flush_nv12()?
-        {
+        let (nv12_width, nv12_height) = self.nv12_delivery_dims();
+        loop {
+            let Some(exec) = self.core.executor.gpu_mut() else {
+                break;
+            };
+            let Some(nv12_data) = exec.flush_nv12()? else {
+                break;
+            };
             sinks::deliver_frame(
                 &mut self.sinks,
                 nv12_data,
@@ -360,6 +383,6 @@ impl crate::detect::DetectionTarget for StitchSession {
         self.core.source_info()
     }
     fn gpu(&self) -> Option<&crate::gpu::GpuContext> {
-        Some(self.gpu())
+        self.core.executor.gpu().map(|g| g.pipeline.gpu())
     }
 }

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -114,6 +114,12 @@ impl StitchSession {
         interrupted: &AtomicBool,
         mut on_progress: Option<ProgressCallback>,
     ) -> Result<u64, SessionError> {
+        // The CPU arm runs its own synchronous loop: no GPU source
+        // configuration, no staging, no zero-copy.
+        if self.core.executor.gpu().is_none() {
+            return self.run_cpu(source, frame_limit, interrupted, &mut on_progress);
+        }
+
         self.configure_from_source(source);
 
         let result = if self.lookahead_frames > 0 {
@@ -521,6 +527,122 @@ impl StitchSession {
 
             self.process_frame_any(&frame, start.elapsed(), decode_time, frame_t0, &ctx)?;
 
+            if let Some(cb) = on_progress.as_mut() {
+                cb(&FrameProgress {
+                    frames_completed: self.frame_count,
+                    elapsed: start.elapsed(),
+                });
+            }
+        }
+
+        Ok(self.frame_count)
+    }
+
+    /// Batch loop over the CPU executor: synchronous software stitch.
+    ///
+    /// Decode, submit (detection + pose + stitch run inside the
+    /// engine's `submit_frame_*`), convert to NV12 on the CPU, fan out
+    /// to the sinks. No staging ring, no warmup, no zero-copy - the
+    /// engine returns RGBA for the submitted frame immediately.
+    fn run_cpu(
+        &mut self,
+        source: &mut dyn FrameSource,
+        frame_limit: u64,
+        interrupted: &AtomicBool,
+        on_progress: &mut Option<ProgressCallback>,
+    ) -> Result<u64, SessionError> {
+        use crate::source::StereoFrame;
+
+        let start = std::time::Instant::now();
+        if self.lookahead_frames > 0 {
+            log::warn!(
+                "Lookahead ({} frames) is not implemented on the CPU executor; \
+                 running the immediate loop",
+                self.lookahead_frames
+            );
+        }
+        let (nv12_w, nv12_h) = self.nv12_delivery_dims();
+        let render_w = self.core.executor.viewport().width;
+        log::info!(
+            "CPU stitch loop: software render at {}x{}, NV12 delivery {nv12_w}x{nv12_h}",
+            render_w,
+            self.core.executor.viewport().height
+        );
+
+        let mut nv12 = Vec::new();
+        while self.frame_count < frame_limit && !interrupted.load(Ordering::Relaxed) {
+            let frame_t0 = std::time::Instant::now();
+            let frame = {
+                crate::profile_scope!("wait_decode");
+                match source.next_frame()? {
+                    Some(f) => f,
+                    None => break,
+                }
+            };
+            let decode_time = frame_t0.elapsed();
+
+            if let Some(sink) = self.core.event_sink.as_deref_mut() {
+                sink.emit(crate::detect::pipeline_event::PipelineEvent::FrameStart {
+                    frame_index: self.frame_count,
+                    timestamp_ms: start.elapsed().as_secs_f64() * 1000.0,
+                });
+            }
+
+            let stitch_t0 = std::time::Instant::now();
+            let outcome = match &frame {
+                StereoFrame::Yuv420p(pair) => self
+                    .core
+                    .submit_frame_yuv(&pair.left.as_planes(), &pair.right.as_planes())?,
+                StereoFrame::Nv12(pair) => {
+                    let left = crate::render::planes::Nv12Planes {
+                        y: &pair.left.y,
+                        uv: &pair.left.uv,
+                    };
+                    let right = crate::render::planes::Nv12Planes {
+                        y: &pair.right.y,
+                        uv: &pair.right.uv,
+                    };
+                    self.core.submit_frame_nv12(&left, &right)?
+                }
+                _ => {
+                    return Err(SessionError::Config(
+                        "the CPU session consumes CPU-resident frames only (YUV420P / \
+                         NV12); zero-copy sources need the GPU executor"
+                            .into(),
+                    ));
+                }
+            };
+            let crate::core::types::RenderOutcome::Rgba(rgba) = outcome else {
+                unreachable!("the CPU executor stitches synchronously - no warmup");
+            };
+            let stitch_time = stitch_t0.elapsed();
+
+            let convert_t0 = std::time::Instant::now();
+            crate::render::nv12_cpu::rgba_to_nv12_into(rgba, render_w, nv12_w, nv12_h, &mut nv12)?;
+            let convert_time = convert_t0.elapsed();
+
+            let submit_t0 = std::time::Instant::now();
+            super::sinks::deliver_frame(
+                &mut self.sinks,
+                &nv12,
+                nv12_w,
+                nv12_h,
+                self.frame_count as i64,
+            )?;
+            let submit_time = submit_t0.elapsed();
+
+            self.telemetry.record_frame(crate::telemetry::FrameTiming {
+                decode: Some(decode_time),
+                stitch: Some(stitch_time),
+                // The CPU conversion is this arm's counterpart of the
+                // GPU readback slot.
+                readback: Some(convert_time),
+                submit: Some(submit_time),
+                total: Some(frame_t0.elapsed()),
+                ..Default::default()
+            });
+
+            self.frame_count += 1;
             if let Some(cb) = on_progress.as_mut() {
                 cb(&FrameProgress {
                     frames_completed: self.frame_count,

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -623,3 +623,140 @@ fn push_and_pull_share_one_ai_brain() {
         "detector call-count parity"
     );
 }
+
+// ─── CPU-executor session ──────────────────────────────────────────────
+
+/// Build a session over the CPU executor - no GPU anywhere.
+fn build_cpu_session() -> StitchSession {
+    let executor = crate::stitch::CpuExecutor::new(
+        Box::new(crate::projection::LShapeProjection),
+        test_calibration(),
+        ViewportConfig {
+            width: 64,
+            height: 64,
+            fov_degrees: 75.0,
+        },
+        W,
+        H,
+        false,
+    )
+    .expect("cpu executor");
+    StitchSession::with_executor(crate::stitch::Executor::Cpu(Box::new(executor)))
+        .expect("cpu session")
+}
+
+/// Inline sink asserting every delivered frame is a well-formed NV12
+/// buffer at the session's delivery dimensions.
+struct Nv12CheckingSink {
+    frames: Arc<AtomicU64>,
+}
+
+impl OutputSink for Nv12CheckingSink {
+    fn name(&self) -> &str {
+        "nv12-check"
+    }
+    fn wants(&self) -> SinkInput {
+        SinkInput::CpuBytes(crate::sink::PixelFormat::Nv12)
+    }
+    fn consume(&mut self, frame: OutputFrame<'_>) -> Result<(), SinkError> {
+        assert_eq!(frame.format, crate::sink::PixelFormat::Nv12);
+        assert_eq!(
+            frame.data.len(),
+            (frame.width * frame.height * 3 / 2) as usize,
+            "NV12 layout: Y plane + half-size interleaved UV"
+        );
+        self.frames.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+    fn finish(&mut self) -> Result<(), SinkError> {
+        Ok(())
+    }
+}
+
+/// The full batch path over the software stitch: source -> engine
+/// submit (detection + pose + CPU stitch) -> CPU NV12 -> sink fan-out.
+/// Runs in the default suite - the session's first GPU-free
+/// end-to-end test.
+#[test]
+fn cpu_session_runs_end_to_end_without_gpu() {
+    const FRAMES: u64 = 5;
+    let mut session = build_cpu_session();
+
+    let encoded = Arc::new(AtomicU64::new(0));
+    session
+        .add_sink(
+            Box::new(MockEncoder::new(Arc::clone(&encoded))),
+            crate::session::SinkOptions::threaded(2),
+        )
+        .expect("attach threaded sink");
+    let checked = Arc::new(AtomicU64::new(0));
+    session
+        .add_sink(
+            Box::new(Nv12CheckingSink {
+                frames: Arc::clone(&checked),
+            }),
+            crate::session::SinkOptions::inline_lossy(),
+        )
+        .expect("attach inline sink");
+
+    let detections = Arc::new(AtomicU64::new(0));
+    session.set_detector(Box::new(MockDetector::new(vec![], Arc::clone(&detections))));
+    session.set_detection_interval(1);
+
+    let mut source = MockSource::new(FRAMES);
+    let interrupted = AtomicBool::new(false);
+    let frames = session
+        .run(&mut source, u64::MAX, &interrupted, None)
+        .expect("cpu run");
+    session.finish().expect("finish");
+
+    assert_eq!(frames, FRAMES);
+    assert_eq!(
+        encoded.load(Ordering::SeqCst),
+        FRAMES,
+        "every frame reached the threaded sink"
+    );
+    assert_eq!(
+        checked.load(Ordering::SeqCst),
+        FRAMES,
+        "every frame reached the inline sink"
+    );
+    assert!(
+        detections.load(Ordering::SeqCst) >= FRAMES,
+        "detection ran inside the CPU submit path"
+    );
+}
+
+/// Zero-copy frames cannot be consumed by the software stitch; the
+/// loop rejects them with a typed error instead of panicking.
+#[test]
+fn cpu_session_rejects_gpu_resident_frames() {
+    struct ResidentSource;
+    impl FrameSource for ResidentSource {
+        fn info(&self) -> SourceInfo {
+            SourceInfo {
+                width: W,
+                height: H,
+                fps: 30.0,
+                fps_rational: Some((30, 1)),
+                total_frames: None,
+            }
+        }
+        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+            Ok(Some(StereoFrame::GpuResident {
+                left_slot: 0,
+                right_slot: 0,
+            }))
+        }
+    }
+
+    let mut session = build_cpu_session();
+    let interrupted = AtomicBool::new(false);
+    let err = session
+        .run(&mut ResidentSource, u64::MAX, &interrupted, None)
+        .expect_err("resident frames must be rejected on the CPU executor");
+    assert!(
+        matches!(err, SessionError::Config(_)),
+        "expected a typed config error, got: {err}"
+    );
+}

--- a/crates/reco-core/src/session/types.rs
+++ b/crates/reco-core/src/session/types.rs
@@ -136,9 +136,13 @@ pub enum SessionError {
     #[error("core: {0}")]
     Core(#[from] StitchCoreError),
 
-    /// NV12 conversion error.
+    /// NV12 conversion error (GPU converter).
     #[error("NV12 converter: {0}")]
     Nv12(#[from] Nv12Error),
+
+    /// NV12 conversion error (CPU kernel).
+    #[error("CPU NV12 conversion: {0}")]
+    CpuNv12(#[from] crate::render::nv12_cpu::Nv12CpuError),
 
     /// Output sink error.
     #[error("sink: {0}")]
@@ -175,6 +179,7 @@ const _: fn() = || {
     assert_clone_send_sync::<PipelineError>();
     assert_clone_send_sync::<StitchCoreError>();
     assert_clone_send_sync::<Nv12Error>();
+    assert_clone_send_sync::<crate::render::nv12_cpu::Nv12CpuError>();
     assert_clone_send_sync::<SinkError>();
     assert_clone_send_sync::<SourceError>();
     assert_clone_send_sync::<crate::detect::detector::DetectorError>();

--- a/crates/reco-core/src/session/wiring.rs
+++ b/crates/reco-core/src/session/wiring.rs
@@ -30,7 +30,7 @@ impl StitchSession {
         options: SinkOptions,
     ) -> Result<(), SessionError> {
         validate_sink_input(sink.wants(), sink.name()).map_err(SessionError::Config)?;
-        let (width, height) = self.gpu_exec_ref().nv12_dims();
+        let (width, height) = self.nv12_delivery_dims();
         self.sinks
             .push(AttachedSink::new(sink, options, width, height));
         Ok(())

--- a/crates/reco-core/src/shaders/rgba_to_nv12.wgsl
+++ b/crates/reco-core/src/shaders/rgba_to_nv12.wgsl
@@ -17,6 +17,10 @@
 // Color space: BT.709 sRGB → limited-range YCbCr
 // This is the inverse of the sample_yuv() function in fisheye.wgsl.
 // Input texture is Rgba8Unorm (sRGB values stored as-is, no hardware decode).
+//
+// SYNC_WITH: src/render/nv12_cpu.rs - the CPU delivery path mirrors the
+// coefficients, chroma averaging order, and rounding; an oracle test
+// pins the two to 1 LSB agreement.
 
 @group(0) @binding(0) var input: texture_2d<f32>;
 @group(0) @binding(1) var<storage, read_write> output: array<u32>;

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -862,10 +862,10 @@ impl GpuExecutor {
     // -----------------------------------------------------------------
 
     /// NV12 output dimensions: the viewport rounded down to NV12-safe
-    /// values (width to a multiple of 4, height to even).
+    /// values (shared rounding rule with the CPU delivery path).
     pub(crate) fn nv12_dims(&self) -> (u32, u32) {
         let vp = self.pipeline.viewport();
-        (vp.width & !3, vp.height & !1)
+        crate::render::nv12_cpu::nv12_dims(vp.width, vp.height)
     }
 
     /// Submit `render_commands` and convert the render target to NV12.

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -144,7 +144,8 @@ pub fn run_export(
     post_status("Probing source...".into());
 
     use reco_core::source::FrameSource;
-    if let Ok(source) = reco_io::adapters::FfmpegFileSource::open_from_inputs(&left, &right, 0)
+    if let Ok(source) =
+        reco_io::adapters::FfmpegFileSource::open_from_inputs(&left, &right, 0, false)
         && let Some(full_total) = source.total_frames()
     {
         let fps = reco_io::adapters::FfmpegFileSource::frame_rate(left.first_path())

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -75,7 +75,7 @@ impl Playback {
         right: &InputPath,
         sync_offset: i64,
     ) -> Result<(), SourceError> {
-        let source = FfmpegFileSource::open_from_inputs(left, right, sync_offset)?;
+        let source = FfmpegFileSource::open_from_inputs(left, right, sync_offset, false)?;
         let info = source.info();
         let fps = info.fps;
         self.total_frames = source.total_frames();

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -73,6 +73,8 @@ pub struct FfmpegFileSource {
     left_input: crate::stitch_job::InputPath,
     right_input: crate::stitch_job::InputPath,
     sync_offset: i64,
+    /// Software decode forced at open; seek respawns must reuse it.
+    software_decode: bool,
     /// Total frame count (estimated from duration * fps).
     total_frame_count: Option<u64>,
     /// Current frame position (incremented on each next_frame).
@@ -105,6 +107,7 @@ impl FfmpegFileSource {
             &crate::stitch_job::InputPath::Single(left_path.to_path_buf()),
             &crate::stitch_job::InputPath::Single(right_path.to_path_buf()),
             sync_offset,
+            false,
         )
     }
 
@@ -116,6 +119,7 @@ impl FfmpegFileSource {
         left: &crate::stitch_job::InputPath,
         right: &crate::stitch_job::InputPath,
         sync_offset: i64,
+        software_decode: bool,
     ) -> Result<Self, SourceError> {
         let left_probe_path = left.first_path();
         let right_probe_path = right.first_path();
@@ -173,6 +177,7 @@ impl FfmpegFileSource {
             right_owned.clone(),
             sync_offset,
             None,
+            software_decode,
         );
 
         Ok(Self {
@@ -185,6 +190,7 @@ impl FfmpegFileSource {
             left_input: left_owned,
             right_input: right_owned,
             sync_offset,
+            software_decode,
             total_frame_count,
             current_frame: 0,
             exhausted: false,
@@ -250,13 +256,19 @@ impl FfmpegFileSource {
         input: crate::stitch_job::InputPath,
         label: &'static str,
         seek_secs: Option<f64>,
+        software_decode: bool,
     ) -> std::sync::mpsc::Receiver<YuvData> {
         let (tx, rx) = std::sync::mpsc::sync_channel::<YuvData>(4);
 
         std::thread::Builder::new()
             .name(format!("decode_{label}"))
             .spawn(move || {
-                let mut dec = match ffmpeg::decoder::VideoDecoder::open_input(&input) {
+                let open = if software_decode {
+                    ffmpeg::decoder::VideoDecoder::open_input_software
+                } else {
+                    ffmpeg::decoder::VideoDecoder::open_input
+                };
+                let mut dec = match open(&input) {
                     Ok(d) => {
                         log::info!(
                             "{label} decoder: {} ({}x{})",
@@ -333,9 +345,10 @@ impl FfmpegFileSource {
         right: crate::stitch_job::InputPath,
         sync_offset: i64,
         seek_secs: Option<f64>,
+        software_decode: bool,
     ) -> std::sync::mpsc::Receiver<FramePair> {
-        let left_rx = Self::spawn_single_decoder_at(left, "left", seek_secs);
-        let right_rx = Self::spawn_single_decoder_at(right, "right", seek_secs);
+        let left_rx = Self::spawn_single_decoder_at(left, "left", seek_secs, software_decode);
+        let right_rx = Self::spawn_single_decoder_at(right, "right", seek_secs, software_decode);
 
         let (tx, rx) = std::sync::mpsc::sync_channel::<FramePair>(4);
 
@@ -461,6 +474,7 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
             self.right_input.clone(),
             self.sync_offset,
             Some(secs),
+            self.software_decode,
         );
         self.current_frame = frame;
         self.exhausted = false;

--- a/crates/reco-io/src/ffmpeg/decoder.rs
+++ b/crates/reco-io/src/ffmpeg/decoder.rs
@@ -255,6 +255,28 @@ impl VideoDecoder {
         Self::from_input_context(ictx)
     }
 
+    /// Open with software decode, skipping the hardware-acceleration
+    /// probe entirely. The typed form of `RECO_NO_HWACCEL` for callers
+    /// that must not touch a GPU (e.g. `reco stitch --cpu`).
+    pub fn open_software(path: &Path) -> Result<Self, DecodeError> {
+        crate::init();
+        let ictx = input(path)?;
+        Self::from_input_context_inner(ictx, None, true)
+    }
+
+    /// [`Self::open_input`] with software decode forced (see
+    /// [`Self::open_software`]).
+    pub fn open_input_software(
+        input_path: &crate::stitch_job::InputPath,
+    ) -> Result<Self, DecodeError> {
+        match input_path {
+            crate::stitch_job::InputPath::Single(p) => Self::open_software(p),
+            crate::stitch_job::InputPath::Chained(paths) => {
+                Self::open_chained_impl(paths, None, true)
+            }
+        }
+    }
+
     /// Open from an `InputPath` (single file or chained segments).
     pub fn open_input(input_path: &crate::stitch_job::InputPath) -> Result<Self, DecodeError> {
         match input_path {
@@ -283,25 +305,26 @@ impl VideoDecoder {
             // other device's texture -> cross-device fault (DEVICE_REMOVED on
             // desktop NVIDIA, driver hang on laptops). See open_chained_impl.
             crate::stitch_job::InputPath::Chained(paths) => {
-                Self::open_chained_impl(paths, Some(shared))
+                Self::open_chained_impl(paths, Some(shared), false)
             }
         }
     }
 
     fn from_input_context(ictx: ffmpeg::format::context::Input) -> Result<Self, DecodeError> {
-        Self::from_input_context_inner(ictx, None)
+        Self::from_input_context_inner(ictx, None, false)
     }
 
     fn from_input_context_with_shared(
         ictx: ffmpeg::format::context::Input,
         shared: &SharedHwDevice,
     ) -> Result<Self, DecodeError> {
-        Self::from_input_context_inner(ictx, Some(shared))
+        Self::from_input_context_inner(ictx, Some(shared), false)
     }
 
     fn from_input_context_inner(
         ictx: ffmpeg::format::context::Input,
         shared_device: Option<&SharedHwDevice>,
+        force_software: bool,
     ) -> Result<Self, DecodeError> {
         let stream = ictx
             .streams()
@@ -315,7 +338,10 @@ impl VideoDecoder {
         threading.count = 0;
         context.set_threading(threading);
 
-        let (backend, hw_device_ref) = if std::env::var("RECO_NO_HWACCEL").is_ok() {
+        let (backend, hw_device_ref) = if force_software {
+            log::info!("Software decode: forced by the caller");
+            (DecodeBackend::Software, ptr::null_mut())
+        } else if std::env::var("RECO_NO_HWACCEL").is_ok() {
             log::info!("Hardware acceleration disabled via RECO_NO_HWACCEL");
             (DecodeBackend::Software, ptr::null_mut())
         } else if let Some(shared) = shared_device {
@@ -450,7 +476,7 @@ impl VideoDecoder {
     /// Timestamps are rebased, hardware acceleration works across
     /// segment boundaries, and seeking spans the full duration.
     pub fn open_chained(paths: &[std::path::PathBuf]) -> Result<Self, DecodeError> {
-        Self::open_chained_impl(paths, None)
+        Self::open_chained_impl(paths, None, false)
     }
 
     /// Chained open that optionally attaches a pre-created shared hw device.
@@ -463,6 +489,7 @@ impl VideoDecoder {
     fn open_chained_impl(
         paths: &[std::path::PathBuf],
         shared: Option<&SharedHwDevice>,
+        force_software: bool,
     ) -> Result<Self, DecodeError> {
         use std::io::Write;
 
@@ -472,6 +499,7 @@ impl VideoDecoder {
             let p = paths.first().map(|p| p.as_path()).unwrap_or(Path::new(""));
             return match shared {
                 Some(s) => Self::from_input_context_with_shared(input(p)?, s),
+                None if force_software => Self::open_software(p),
                 None => Self::open(p),
             };
         }
@@ -515,7 +543,7 @@ impl VideoDecoder {
             _ => return Err(DecodeError::Ffmpeg("expected input context".into())),
         };
 
-        let mut dec = Self::from_input_context_inner(ictx, shared)?;
+        let mut dec = Self::from_input_context_inner(ictx, shared, force_software)?;
         dec._manifest = Some(manifest);
         Ok(dec)
     }

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -209,6 +209,7 @@ impl SmartFileSource {
                 left,
                 right,
                 sync_offset,
+                false,
                 info,
                 pixel_format,
                 full_range,
@@ -222,6 +223,7 @@ impl SmartFileSource {
         left: &crate::stitch_job::InputPath,
         right: &crate::stitch_job::InputPath,
         sync_offset: i64,
+        software_decode: bool,
     ) -> Result<Self, SourceError> {
         let left_probe_path = left.first_path();
 
@@ -255,6 +257,7 @@ impl SmartFileSource {
             left,
             right,
             sync_offset,
+            software_decode,
             info,
             pixel_format,
             full_range,
@@ -263,17 +266,24 @@ impl SmartFileSource {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn open_cpu(
         left: &crate::stitch_job::InputPath,
         right: &crate::stitch_job::InputPath,
         sync_offset: i64,
+        software_decode: bool,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
         full_range: bool,
         left_rotation: i32,
         right_rotation: i32,
     ) -> Result<Self, SourceError> {
-        let source = crate::adapters::FfmpegFileSource::open_from_inputs(left, right, sync_offset)?;
+        let source = crate::adapters::FfmpegFileSource::open_from_inputs(
+            left,
+            right,
+            sync_offset,
+            software_decode,
+        )?;
         log::info!(
             "SmartFileSource: CPU decode ({}x{}, {pixel_format:?}{})",
             info.width,

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -75,6 +75,11 @@ pub struct StitchJob {
     /// CPU detection is wanted but TensorRT is not available.
     force_cpu_decode: bool,
 
+    /// Stitch on the CPU executor: software render, CPU decode, no
+    /// GPU touched at all. The GPU-less path (headless boxes, CI,
+    /// X5-class boards).
+    cpu_stitch: bool,
+
     /// Lookahead buffer depth in seconds. When > 0, the session
     /// decodes N frames ahead to give the panner future context.
     lookahead_secs: f64,
@@ -255,6 +260,7 @@ impl StitchJob {
             #[cfg(feature = "stacked-output")]
             replay_recording: None,
             force_cpu_decode: false,
+            cpu_stitch: false,
             lookahead_secs: 0.0,
             events_path: None,
         }
@@ -455,6 +461,14 @@ impl StitchJob {
         self
     }
 
+    /// Stitch on the CPU executor: software render + CPU decode, no
+    /// GPU initialized. Implies [`Self::force_cpu_decode`] (there is
+    /// no GPU to decode into).
+    pub fn cpu(mut self) -> Self {
+        self.cpu_stitch = true;
+        self
+    }
+
     /// Set the lookahead buffer depth in seconds.
     pub fn lookahead(mut self, seconds: f64) -> Self {
         self.lookahead_secs = seconds;
@@ -560,16 +574,39 @@ impl StitchJob {
             log::info!("Sync offset: {} frames (from calibration)", effective_sync);
         }
 
-        // Initialize GPU
-        let gpu = reco_core::gpu::GpuContext::new_blocking()?;
-        let gpu_name = gpu.gpu_name().to_string();
-
-        log::debug!("StitchJob::run: force_cpu_decode={}", self.force_cpu_decode);
-        let mut source = if self.force_cpu_decode {
-            log::info!("Force CPU decode: zero-copy disabled by --no-zero-copy");
-            crate::SmartFileSource::open_cpu_only(&self.left, &self.right, effective_sync)?
+        // Decode + render strategy. --cpu never touches the GPU;
+        // otherwise the GPU renders and decode is zero-copy unless
+        // forced off.
+        log::debug!(
+            "StitchJob::run: cpu_stitch={} force_cpu_decode={}",
+            self.cpu_stitch,
+            self.force_cpu_decode
+        );
+        let (gpu, mut source) = if self.cpu_stitch {
+            log::info!("CPU stitch: software render + software decode, no GPU touched (--cpu)");
+            (
+                None,
+                crate::SmartFileSource::open_cpu_only(
+                    &self.left,
+                    &self.right,
+                    effective_sync,
+                    true,
+                )?,
+            )
         } else {
-            crate::SmartFileSource::open(&self.left, &self.right, &gpu, effective_sync)?
+            let gpu = reco_core::gpu::GpuContext::new_blocking()?;
+            let source = if self.force_cpu_decode {
+                log::info!("Force CPU decode: zero-copy disabled by --no-zero-copy");
+                crate::SmartFileSource::open_cpu_only(
+                    &self.left,
+                    &self.right,
+                    effective_sync,
+                    false,
+                )?
+            } else {
+                crate::SmartFileSource::open(&self.left, &self.right, &gpu, effective_sync)?
+            };
+            (Some(gpu), source)
         };
         let info = source.info();
         let (out_w, out_h) = self.resolution.unwrap_or((1920, 1080));
@@ -577,13 +614,6 @@ impl StitchJob {
             log::info!("Output resolution not specified, defaulting to {out_w}x{out_h}");
         }
         let decode_mode = source.decode_mode().to_string();
-
-        // Determine input format from source capabilities
-        let input_format = if source.is_gpu_resident() {
-            reco_core::render::renderer::InputFormat::Nv12
-        } else {
-            reco_core::render::renderer::InputFormat::Yuv420p
-        };
 
         // Build session. Blend lives on the calibration; an explicit job
         // override replaces it, otherwise the saved value renders as-is.
@@ -604,17 +634,45 @@ impl StitchJob {
             height: out_h,
             ..Default::default()
         };
-        let session_config = reco_core::session::types::SessionConfig {
-            calibration: cal,
-            viewport,
-            input_width: info.width,
-            input_height: info.height,
-            output_format: reco_core::gpu::OutputFormat::Rgba8Unorm,
-            input_format,
-            left_rotation: source.left_rotation(),
-            right_rotation: source.right_rotation(),
+        let gpu_name;
+        let mut session = match gpu {
+            Some(gpu) => {
+                gpu_name = gpu.gpu_name().to_string();
+                // Input format follows source capabilities: zero-copy
+                // decoders hand the pipeline NV12 textures.
+                let input_format = if source.is_gpu_resident() {
+                    reco_core::render::renderer::InputFormat::Nv12
+                } else {
+                    reco_core::render::renderer::InputFormat::Yuv420p
+                };
+                let session_config = reco_core::session::types::SessionConfig {
+                    calibration: cal,
+                    viewport,
+                    input_width: info.width,
+                    input_height: info.height,
+                    output_format: reco_core::gpu::OutputFormat::Rgba8Unorm,
+                    input_format,
+                    left_rotation: source.left_rotation(),
+                    right_rotation: source.right_rotation(),
+                };
+                reco_core::session::StitchSession::with_gpu(gpu, session_config)?
+            }
+            None => {
+                gpu_name = "software (CPU)".to_string();
+                let executor = reco_core::stitch::CpuExecutor::new(
+                    Box::new(reco_core::projection::LShapeProjection),
+                    cal,
+                    viewport,
+                    info.width,
+                    info.height,
+                    false,
+                )
+                .map_err(|e| StitchError::Other(format!("CPU executor: {e}")))?;
+                reco_core::session::StitchSession::with_executor(reco_core::stitch::Executor::Cpu(
+                    Box::new(executor),
+                ))?
+            }
         };
-        let mut session = reco_core::session::StitchSession::with_gpu(gpu, session_config)?;
 
         session.telemetry_mut().set_gpu_name(gpu_name.clone());
         session.telemetry_mut().set_decode_mode(decode_mode.clone());
@@ -663,11 +721,7 @@ impl StitchJob {
             Bitrate::Quality(q) => crate::ffmpeg::encoder::Quality::from(*q),
             Bitrate::Crf(_) => crate::ffmpeg::encoder::Quality::Balanced,
         };
-        let fps = if info.fps > 0.0 {
-            info.fps as f64
-        } else {
-            30.0
-        };
+        let fps = if info.fps > 0.0 { info.fps } else { 30.0 };
         let start_secs = self
             .start_time
             .filter(|secs| secs.is_finite() && *secs > 0.0)
@@ -685,8 +739,17 @@ impl StitchJob {
             AudioMode::Disabled => None,
         };
 
+        // --cpu defaults the encoder to software so the whole run keeps
+        // its no-GPU promise; an explicit encoder choice still wins.
+        let encoder_name = match (&self.encoder_name, self.cpu_stitch) {
+            (None, true) => {
+                log::info!("CPU stitch: defaulting to the libx264 software encoder");
+                Some("libx264".to_string())
+            }
+            (name, _) => name.clone(),
+        };
         let enc_config = crate::ffmpeg::encoder::EncoderConfig {
-            encoder_name: self.encoder_name.clone(),
+            encoder_name,
             codec: self.codec.into(),
             quality_preset: quality,
             quality: self.quality_value,

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -2,8 +2,9 @@
 //!
 //! [`StitchJob`] is the simplest way to stitch two video files into a
 //! panoramic output. It handles all orchestration internally: GPU
-//! initialization, zero-copy detection, encoder creation, decode thread
-//! management, and audio passthrough.
+//! initialization (or the all-software path via [`StitchJob::cpu`]),
+//! zero-copy detection, encoder creation, decode thread management,
+//! and audio passthrough.
 //!
 //! # Example
 //!


### PR DESCRIPTION
## What

Steps 12d + 12e of the stitch unification: the batch path runs end to end without a GPU.

- **CPU NV12 kernel** (`render/nv12_cpu.rs`, wgpu-free): BT.709 limited-range RGBA->NV12 mirroring the GPU compute shader's exact coefficients, chroma averaging order, and rounding (`SYNC_WITH` markers on both sides). A GPU-vs-CPU oracle test pins agreement to 1 LSB on every byte. The NV12 dimension rounding rule now has one shared home; the GPU executor delegates to it.
- **`StitchSession::with_executor(Executor)`** becomes the primitive constructor (`with_gpu` is the GPU convenience over it). `run()` dispatches per arm: the CPU arm gets a synchronous loop - decode, engine submit (detection + pose + software stitch inside `submit_frame_*`), CPU NV12, sink fan-out. Resident frames are rejected with a typed error; lookahead logs that it is ignored. Sink attach/finish are executor-agnostic. `DetectionTarget::gpu` returns `None` on the CPU arm, so autocam falls back to CPU inference EPs.
- **`reco stitch --cpu`**: software render, software decode, and libx264 by default - no GPU touched anywhere (an explicit `--encoder` still wins). Software decode is now a typed option threaded down to `VideoDecoder::open_input_software`; without it the flag silently picked NVDEC-with-download and NVENC and left CUDA teardown errors at exit. `RECO_NO_HWACCEL` stays as the global diagnostic override (RECO_* rider disposition: `RECO_REQUIRE_GPU` is a justified test-harness knob; no other RECO_* reads exist on the touched surfaces).

## Testing

- `cpu_session_runs_end_to_end_without_gpu` - the session's first end-to-end test in the default suite (every prior one needs a GPU): mock source -> CPU stitch -> NV12 -> threaded + inline sinks, with detection running inside the submit path.
- NV12 oracle green on NVIDIA hardware (max diff 1 LSB).
- Real runs: `reco stitch --cpu` renders 30/30 frames at ~3.9 fps (1080p, software everything, clean exit); the same clip on the GPU path is unchanged.
- Gates: fmt, clippy (default, `profiling`, `snapshot`, `--no-default-features`), workspace tests, `cargo doc -D warnings`.

## Non-goals

The session module stays gpu-feature-gated (wgpu linked but unused under `--cpu`); ungating it for wgpu-free builds is the fieldkit/X5 integration step, not this one.