### PR TITLE
feat: cylinder projection - pre-stitched panorama import (Step 13, CPU path)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/reco-autocam/src/panners/field.rs
+++ b/crates/reco-autocam/src/panners/field.rs
@@ -1139,11 +1139,11 @@ mod tests {
     }
 
     fn cal() -> reco_core::calibration::Calibration {
-        use reco_core::calibration::{Calibration, Framing, Lens, Topology};
+        use reco_core::calibration::{Calibration, Framing, LShapeTopology, Lens};
         let cam = || Lens::fisheye(1920, 1080, 900.0, 900.0, 960.0, 540.0, [0.0; 4]);
         Calibration::new(
             vec![cam(), cam()],
-            Topology {
+            LShapeTopology {
                 intersect: 0.54,
                 x_ty: 0.0,
                 x_rz: 0.0,

--- a/crates/reco-autocam/src/panners/sweep.rs
+++ b/crates/reco-autocam/src/panners/sweep.rs
@@ -94,13 +94,13 @@ impl Panner for SweepPanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reco_core::calibration::{Calibration, Framing, Lens, Topology};
+    use reco_core::calibration::{Calibration, Framing, LShapeTopology, Lens};
 
     fn test_cal() -> Calibration {
         let cam = || Lens::fisheye(1920, 1080, 900.0, 900.0, 960.0, 540.0, [0.0; 4]);
         Calibration::new(
             vec![cam(), cam()],
-            Topology {
+            LShapeTopology {
                 intersect: 0.54,
                 x_ty: 0.0,
                 x_rz: 0.0,

--- a/crates/reco-calibrate/src/optimizer.rs
+++ b/crates/reco-calibrate/src/optimizer.rs
@@ -19,7 +19,7 @@
 
 use argmin::core::{CostFunction, Error, Executor, State};
 use argmin::solver::neldermead::NelderMead;
-use reco_core::calibration::{Framing, Topology};
+use reco_core::calibration::{Framing, LShapeTopology};
 
 use crate::error::CalibrateError;
 use crate::geometry::{self, OptParams};
@@ -32,7 +32,7 @@ use crate::types::{CalibrationConfig, MatchedPoint};
 /// Trait for calibration parameter optimizers.
 ///
 /// Implementations take a set of matched points and configuration, and
-/// return the optimal [`Topology`] with its residual error. This
+/// return the optimal [`LShapeTopology`] with its residual error. This
 /// abstraction allows swapping optimization backends without changing
 /// the calibration pipeline.
 pub trait Optimizer {
@@ -41,7 +41,7 @@ pub trait Optimizer {
         &self,
         points: &[MatchedPoint],
         config: &CalibrationConfig,
-    ) -> Result<(Topology, Framing, f64), CalibrateError>;
+    ) -> Result<(LShapeTopology, Framing, f64), CalibrateError>;
 }
 
 // ---------------------------------------------------------------------------
@@ -309,7 +309,7 @@ impl Optimizer for NelderMeadOptimizer {
         &self,
         points: &[MatchedPoint],
         config: &CalibrationConfig,
-    ) -> Result<(Topology, Framing, f64), CalibrateError> {
+    ) -> Result<(LShapeTopology, Framing, f64), CalibrateError> {
         let lock = config.optimizer.lock_cam_d;
         let lock_zrx = config.optimizer.lock_z_rx;
         let enable_xrx = config.optimizer.enable_x_rx;
@@ -404,7 +404,7 @@ impl Optimizer for NelderMeadOptimizer {
             (false, true) => params_from_vec_no_zrx(&best_p),
             (false, false) => params_from_vec(&best_p),
         };
-        let topology = Topology {
+        let topology = LShapeTopology {
             intersect: params.intersect,
             x_ty: params.x_ty,
             x_rz: params.x_rz,
@@ -448,7 +448,7 @@ impl Clone for CalibrationCost<'_> {
 pub fn optimize(
     points: &[MatchedPoint],
     config: &CalibrationConfig,
-) -> Result<(Topology, Framing, f64), CalibrateError> {
+) -> Result<(LShapeTopology, Framing, f64), CalibrateError> {
     NelderMeadOptimizer.optimize(points, config)
 }
 

--- a/crates/reco-calibrate/tests/calibrate_videos.rs
+++ b/crates/reco-calibrate/tests/calibrate_videos.rs
@@ -60,28 +60,30 @@ fn calibrate_videos_matches_known_good() {
         exp.framing.axis_offset,
     );
     assert!(
-        (got.topology.intersect - exp.topology.intersect).abs() < tol,
+        (got.topology.l_shape().unwrap().intersect - exp.topology.l_shape().unwrap().intersect)
+            .abs()
+            < tol,
         "intersect: got {}, expected {} (tol {tol})",
-        got.topology.intersect,
-        exp.topology.intersect,
+        got.topology.l_shape().unwrap().intersect,
+        exp.topology.l_shape().unwrap().intersect,
     );
     assert!(
-        (got.topology.x_ty - exp.topology.x_ty).abs() < tol,
+        (got.topology.l_shape().unwrap().x_ty - exp.topology.l_shape().unwrap().x_ty).abs() < tol,
         "x_ty: got {}, expected {} (tol {tol})",
-        got.topology.x_ty,
-        exp.topology.x_ty,
+        got.topology.l_shape().unwrap().x_ty,
+        exp.topology.l_shape().unwrap().x_ty,
     );
     assert!(
-        (got.topology.x_rz - exp.topology.x_rz).abs() < tol,
+        (got.topology.l_shape().unwrap().x_rz - exp.topology.l_shape().unwrap().x_rz).abs() < tol,
         "x_rz: got {}, expected {} (tol {tol})",
-        got.topology.x_rz,
-        exp.topology.x_rz,
+        got.topology.l_shape().unwrap().x_rz,
+        exp.topology.l_shape().unwrap().x_rz,
     );
     assert!(
-        (got.topology.z_rx - exp.topology.z_rx).abs() < tol,
+        (got.topology.l_shape().unwrap().z_rx - exp.topology.l_shape().unwrap().z_rx).abs() < tol,
         "z_rx: got {}, expected {} (tol {tol})",
-        got.topology.z_rx,
-        exp.topology.z_rx,
+        got.topology.l_shape().unwrap().z_rx,
+        exp.topology.l_shape().unwrap().z_rx,
     );
 
     // Quality metrics
@@ -103,5 +105,8 @@ fn calibrate_videos_matches_known_good() {
     println!("  frames_used: {}", result.frames_used);
     println!("  matches: {}", result.total_matches);
     println!("  cam_d: {:.4}", got.framing.axis_offset);
-    println!("  intersect: {:.4}", got.topology.intersect);
+    println!(
+        "  intersect: {:.4}",
+        got.topology.l_shape().unwrap().intersect
+    );
 }

--- a/crates/reco-cli/src/calibrate.rs
+++ b/crates/reco-cli/src/calibrate.rs
@@ -284,7 +284,11 @@ fn print_results(result: &reco_calibrate::CalibrationResult, output: &str, total
     eprintln!("  Confidence:      {:.1}%", result.confidence * 100.0);
     eprintln!("  Residual error:  {:.6}", result.residual_error);
     eprintln!("\nPlacement parameters:");
-    let l = &result.calibration.topology;
+    let l = result
+        .calibration
+        .topology
+        .l_shape()
+        .expect("stereo calibration always produces the L-shape topology");
     eprintln!(
         "  cameraAxisOffset: {:.4}",
         result.calibration.framing.axis_offset

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -125,12 +125,18 @@ pub fn run_camera(
     );
 
     let mut cal = reco_core::calibration::Calibration::from_file(Path::new(calibration))?;
-    if let Some(b) = blend {
-        eprintln!(
-            "Seam blend: --blend {b} overrides the calibration's {}",
-            cal.topology.blend_width
-        );
-        cal.topology.blend_width = b;
+    match (blend, cal.topology.l_shape_mut()) {
+        (Some(b), Some(topology)) => {
+            eprintln!(
+                "Seam blend: --blend {b} overrides the calibration's {}",
+                topology.blend_width
+            );
+            topology.blend_width = b;
+        }
+        (Some(b), None) => {
+            eprintln!("Seam blend: --blend {b} ignored - this topology has no seam");
+        }
+        (None, _) => {}
     }
     let field_roi = cal.field_roi.clone();
 

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -118,13 +118,15 @@ struct Cli {
 // is irrelevant.
 #[allow(clippy::large_enum_variant)]
 enum Commands {
-    /// Stitch two video files into a panoramic output.
+    /// Stitch camera video files into a panoramic output.
     Stitch {
-        /// Path to the left camera video file.
+        /// Path to the left camera video file (or the single
+        /// pre-stitched panorama for cylinder calibrations).
         left: String,
 
-        /// Path to the right camera video file.
-        right: String,
+        /// Path to the right camera video file. Omit for single-input
+        /// (cylinder) calibrations.
+        right: Option<String>,
 
         /// Path to the calibration JSON file.
         #[arg(short, long)]
@@ -808,7 +810,7 @@ fn main() -> anyhow::Result<()> {
         } => stitch::run_stitch(
             stitch::StitchArgs {
                 left: &left,
-                right: &right,
+                right: right.as_deref(),
                 calibration: &calibration,
                 output: &output,
                 width,

--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -95,12 +95,18 @@ pub fn run_preview(
     // Blend lives on the calibration document; --blend is an explicit
     // override, otherwise the saved value is used (and hotkey edits
     // mutate the document directly - no shadow copy).
+    let Some(l_shape) = cal.topology.l_shape() else {
+        anyhow::bail!(
+            "reco preview tunes the L-shape stereo rig; this calibration's topology has \
+             no seam parameters to tune"
+        );
+    };
     if let Some(b) = blend_width {
         eprintln!(
             "Seam blend: --blend {b} overrides the calibration's {}",
-            cal.topology.blend_width
+            l_shape.blend_width
         );
-        cal.topology.blend_width = b;
+        cal.topology.l_shape_mut().unwrap().blend_width = b;
     }
 
     // Use calibration's sync offset unless the user explicitly overrode it
@@ -143,8 +149,7 @@ pub fn run_preview(
     // The actual CoverageBoundary is computed inside StitchCore::new().
     let max_fov = {
         let aspect = info.width as f32 / info.height as f32;
-        let scene =
-            reco_core::render::scene::SceneGeometry::new(&cal.topology, &cal.framing, aspect);
+        let scene = reco_core::render::scene::SceneGeometry::for_calibration(&cal, aspect);
         let coverage = reco_core::projection::CoverageBoundary::from_calibration(&cal, &scene);
         coverage.max_fov_degrees().min(FOV_MAX)
     };
@@ -649,16 +654,50 @@ impl ApplicationHandler for App {
                         }
                         // Calibration adjustment keys
                         PhysicalKey::Code(KeyCode::Digit1) => {
-                            self.cal.topology.intersect =
-                                (self.cal.topology.intersect + 0.01).min(1.0);
+                            self.cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .intersect = (self
+                                .cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .intersect
+                                + 0.01)
+                                .min(1.0);
                             self.apply_calibration_change();
-                            println!("intersect: {:.4}", self.cal.topology.intersect);
+                            println!(
+                                "intersect: {:.4}",
+                                self.cal
+                                    .topology
+                                    .l_shape_mut()
+                                    .expect("guarded at startup")
+                                    .intersect
+                            );
                         }
                         PhysicalKey::Code(KeyCode::Digit2) => {
-                            self.cal.topology.intersect =
-                                (self.cal.topology.intersect - 0.01).max(0.0);
+                            self.cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .intersect = (self
+                                .cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .intersect
+                                - 0.01)
+                                .max(0.0);
                             self.apply_calibration_change();
-                            println!("intersect: {:.4}", self.cal.topology.intersect);
+                            println!(
+                                "intersect: {:.4}",
+                                self.cal
+                                    .topology
+                                    .l_shape_mut()
+                                    .expect("guarded at startup")
+                                    .intersect
+                            );
                         }
                         PhysicalKey::Code(KeyCode::Digit3) => {
                             self.cal.framing.axis_offset += 0.005;
@@ -671,25 +710,69 @@ impl ApplicationHandler for App {
                             println!("camera_axis_offset: {:.4}", self.cal.framing.axis_offset);
                         }
                         PhysicalKey::Code(KeyCode::Digit5) => {
-                            self.cal.topology.x_ty += 0.005;
+                            self.cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .x_ty += 0.005;
                             self.apply_calibration_change();
-                            println!("x_ty: {:.4}", self.cal.topology.x_ty);
+                            println!(
+                                "x_ty: {:.4}",
+                                self.cal
+                                    .topology
+                                    .l_shape_mut()
+                                    .expect("guarded at startup")
+                                    .x_ty
+                            );
                         }
                         PhysicalKey::Code(KeyCode::Digit6) => {
-                            self.cal.topology.x_ty -= 0.005;
+                            self.cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .x_ty -= 0.005;
                             self.apply_calibration_change();
-                            println!("x_ty: {:.4}", self.cal.topology.x_ty);
+                            println!(
+                                "x_ty: {:.4}",
+                                self.cal
+                                    .topology
+                                    .l_shape_mut()
+                                    .expect("guarded at startup")
+                                    .x_ty
+                            );
                         }
                         PhysicalKey::Code(KeyCode::KeyB) => {
                             // Cycle blend width: 0.0 -> 0.05 -> 0.10 -> 0.15 -> 0.20 -> 0.0.
                             // Mutate the calibration document (single home) so
                             // other hotkeys' update_calibration cannot revert it.
-                            let b = self.cal.topology.blend_width;
-                            self.cal.topology.blend_width = if b >= 0.19 { 0.0 } else { b + 0.05 };
+                            let b = self
+                                .cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .blend_width;
+                            self.cal
+                                .topology
+                                .l_shape_mut()
+                                .expect("guarded at startup")
+                                .blend_width = if b >= 0.19 { 0.0 } else { b + 0.05 };
                             if let Some(ref mut r) = self.renderer {
-                                r.set_blend_width(self.cal.topology.blend_width);
+                                r.set_blend_width(
+                                    self.cal
+                                        .topology
+                                        .l_shape_mut()
+                                        .expect("guarded at startup")
+                                        .blend_width,
+                                );
                             }
-                            println!("blend_width: {:.2}", self.cal.topology.blend_width);
+                            println!(
+                                "blend_width: {:.2}",
+                                self.cal
+                                    .topology
+                                    .l_shape_mut()
+                                    .expect("guarded at startup")
+                                    .blend_width
+                            );
                             self.needs_redraw = true;
                         }
                         PhysicalKey::Code(KeyCode::Digit7) => {

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -18,7 +18,7 @@ use std::sync::atomic::AtomicBool;
 #[allow(dead_code)]
 pub struct StitchArgs<'a> {
     pub left: &'a str,
-    pub right: &'a str,
+    pub right: Option<&'a str>,
     pub calibration: &'a str,
     pub output: &'a str,
     pub width: u32,
@@ -107,21 +107,27 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
             reco_io::stitch_job::InputPath::Single(std::path::PathBuf::from(s))
         }
     };
-    let mut job = reco_io::StitchJob::with_calibration(
-        to_input(args.left),
-        to_input(args.right),
-        cal,
-        args.output,
-    )
-    .codec(parse_codec(args.codec))
-    .quality(parse_quality(args.quality))
-    .resolution(args.width, args.height)
-    .on_progress(move |p: &reco_core::session::types::FrameProgress| {
-        // Use the session's own elapsed clock so the reported
-        // rate excludes one-time GPU / encoder / ORT init and
-        // reflects only the decode → stitch → encode loop.
-        progress.report_with_elapsed(p.frames_completed, p.elapsed);
-    });
+    let mut job = match args.right {
+        Some(right) => reco_io::StitchJob::with_calibration(
+            to_input(args.left),
+            to_input(right),
+            cal,
+            args.output,
+        ),
+        // One input: the calibration must carry a mono topology
+        // (StitchJob::run rejects the mismatch with a typed error).
+        None => reco_io::StitchJob::mono_with_calibration(to_input(args.left), cal, args.output),
+    };
+    job = job
+        .codec(parse_codec(args.codec))
+        .quality(parse_quality(args.quality))
+        .resolution(args.width, args.height)
+        .on_progress(move |p: &reco_core::session::types::FrameProgress| {
+            // Use the session's own elapsed clock so the reported
+            // rate excludes one-time GPU / encoder / ORT init and
+            // reflects only the decode → stitch → encode loop.
+            progress.report_with_elapsed(p.frames_completed, p.elapsed);
+        });
 
     if let Some(b) = args.blend {
         job = job.blend_width(b);

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -357,10 +357,6 @@ pub struct CylinderTopology {
     /// pre-stitched action-camera case; 360 is a full cylinder.
     #[serde(default = "default_sweep_deg")]
     pub sweep_deg: f64,
-    /// Screen tilt around the view axis in degrees (typically within
-    /// ±30), correcting a rig that is not level side-to-side.
-    #[serde(default)]
-    pub screen_rotation_deg: f64,
     /// Painted height in the same units as `focal_length` (source
     /// pixels). Omitted = the source video's pixel height, which is
     /// the convention's default.
@@ -373,7 +369,6 @@ impl Default for CylinderTopology {
         Self {
             focal_length: default_focal_length(),
             sweep_deg: default_sweep_deg(),
-            screen_rotation_deg: 0.0,
             video_height: None,
         }
     }
@@ -736,12 +731,6 @@ fn validate_cylinder(t: &CylinderTopology) -> Result<(), CalibrationError> {
             f64::MAX,
         ),
         ("topology.sweep_deg", t.sweep_deg, f64::MIN_POSITIVE, 360.0),
-        (
-            "topology.screen_rotation_deg",
-            t.screen_rotation_deg,
-            -360.0,
-            360.0,
-        ),
         (
             "topology.video_height",
             // Omitted = the source pixel height, always valid.

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -361,9 +361,11 @@ pub struct CylinderTopology {
     /// ±30), correcting a rig that is not level side-to-side.
     #[serde(default)]
     pub screen_rotation_deg: f64,
-    /// Video height in world units (`1.0` = normalized).
-    #[serde(default = "default_video_height")]
-    pub video_height: f64,
+    /// Painted height in the same units as `focal_length` (source
+    /// pixels). Omitted = the source video's pixel height, which is
+    /// the convention's default.
+    #[serde(default)]
+    pub video_height: Option<f64>,
 }
 
 impl Default for CylinderTopology {
@@ -372,7 +374,7 @@ impl Default for CylinderTopology {
             focal_length: default_focal_length(),
             sweep_deg: default_sweep_deg(),
             screen_rotation_deg: 0.0,
-            video_height: default_video_height(),
+            video_height: None,
         }
     }
 }
@@ -383,10 +385,6 @@ fn default_focal_length() -> f64 {
 
 fn default_sweep_deg() -> f64 {
     180.0
-}
-
-fn default_video_height() -> f64 {
-    1.0
 }
 
 /// Default seam blend width for calibrations that do not specify one.
@@ -746,7 +744,8 @@ fn validate_cylinder(t: &CylinderTopology) -> Result<(), CalibrationError> {
         ),
         (
             "topology.video_height",
-            t.video_height,
+            // Omitted = the source pixel height, always valid.
+            t.video_height.unwrap_or(1.0),
             f64::MIN_POSITIVE,
             f64::MAX,
         ),
@@ -1031,7 +1030,7 @@ mod tests {
         assert!(bad(|t| t.focal_length = 0.0).is_err());
         assert!(bad(|t| t.sweep_deg = 361.0).is_err());
         assert!(bad(|t| t.sweep_deg = 0.0).is_err());
-        assert!(bad(|t| t.video_height = f64::NAN).is_err());
+        assert!(bad(|t| t.video_height = Some(f64::NAN)).is_err());
     }
 
     #[test]

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -204,6 +204,11 @@ impl Lens {
     /// A distortion-free source: a pre-stitched flat panorama frame.
     /// Only the dimensions are load-bearing (cylinder sampling never
     /// undistorts); the intrinsics are centered identity values.
+    ///
+    /// The programmatic route to a mono lens - consumers building a
+    /// cylinder [`Calibration`] in code use this; JSON documents spell
+    /// the fields out. Exercised by the mono session and projection
+    /// tests.
     pub fn flat(width: u32, height: u32) -> Self {
         Self {
             width,
@@ -220,12 +225,11 @@ impl Lens {
 
 /// Scene geometry parameters: which shape the sources are painted on.
 ///
-/// Serialized with a `type` tag (`"l-shape"` / `"cylinder"`); documents
-/// written before the tag existed deserialize as L-shape. The matching
-/// [`Projection`](crate::projection::Projection) dispatches the actual
-/// geometry; this carries its parameters. The virtual-camera position
-/// lives in [`Framing`], not here.
-#[derive(Debug, Clone, Serialize)]
+/// Serialized with a mandatory `type` tag (`"l-shape"` / `"cylinder"`).
+/// The matching [`Projection`](crate::projection::Projection) dispatches
+/// the actual geometry; this carries its parameters. The virtual-camera
+/// position lives in [`Framing`], not here.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub enum Topology {
     /// Two fisheye cameras on perpendicular planes (the stereo rig).
@@ -289,33 +293,6 @@ impl From<CylinderTopology> for Topology {
     }
 }
 
-// Deserialize accepts both the tagged form and the legacy untagged
-// L-shape document (no `type` field): tagged wins when present.
-impl<'de> Deserialize<'de> for Topology {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        #[serde(tag = "type", rename_all = "kebab-case")]
-        enum Tagged {
-            LShape(LShapeTopology),
-            Cylinder(CylinderTopology),
-        }
-        #[derive(Deserialize)]
-        #[serde(untagged)]
-        enum Repr {
-            Tagged(Tagged),
-            Legacy(LShapeTopology),
-        }
-        Ok(match Repr::deserialize(deserializer)? {
-            Repr::Tagged(Tagged::LShape(t)) => Topology::LShape(t),
-            Repr::Tagged(Tagged::Cylinder(t)) => Topology::Cylinder(t),
-            Repr::Legacy(t) => Topology::LShape(t),
-        })
-    }
-}
-
 /// 3D placement of the two L-shape source planes plus the overlap seam.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LShapeTopology {
@@ -374,6 +351,8 @@ impl Default for CylinderTopology {
     }
 }
 
+// Functions, not constants: serde's `default = "..."` attribute takes
+// a function path, never a value expression.
 fn default_focal_length() -> f64 {
     2400.0
 }
@@ -847,7 +826,8 @@ mod tests {
                   "fx": 1796.32, "fy": 1797.22, "cx": 1919.37, "cy": 1063.17,
                   "distortion": [0.0342, 0.0677, -0.0741, 0.0299], "correction": 1.0 }
             ],
-            "topology": { "intersect": 0.5446, "x_ty": 0.00476, "x_rz": 0.00753,
+            "topology": { "type": "l-shape",
+                          "intersect": 0.5446, "x_ty": 0.00476, "x_rz": 0.00753,
                           "z_rx": -0.00431, "blend_width": 0.05 },
             "framing": { "axis_offset": 0.2398, "tilt": 0.0, "roll": 0.0 }
         }"#
@@ -947,16 +927,13 @@ mod tests {
     }
 
     #[test]
-    fn legacy_untagged_topology_parses_as_l_shape() {
-        // Documents written before the `type` tag existed carry a bare
-        // L-shape object; they must keep parsing unchanged.
+    fn untagged_topology_document_is_rejected() {
+        // The `type` tag is mandatory: a topology object without it
+        // must fail to parse rather than silently default to L-shape.
         let mut v: serde_json::Value = serde_json::from_str(&valid_cal().to_json_pretty()).unwrap();
         let topo = v["topology"].as_object_mut().unwrap();
         assert_eq!(topo.remove("type").unwrap(), "l-shape");
-        let cal: Calibration = serde_json::from_value(v).unwrap();
-        let t = cal.topology.l_shape().expect("untagged doc is L-shape");
-        assert!((t.intersect - 0.5).abs() < 1e-9);
-        cal.validate().unwrap();
+        assert!(serde_json::from_value::<Calibration>(v).is_err());
     }
 
     #[test]

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -116,13 +116,16 @@ pub enum CalibrationError {
     #[error("calibration must have at least one lens")]
     NoLenses,
 
-    /// The lens count does not match what the topology can render.
+    /// The lens count does not match what the topology consumes.
     ///
-    /// The L-shape topology (the only one today) indexes exactly two
-    /// lenses; any other count would panic at render time. This becomes
-    /// topology-aware once projections carry their own arity.
-    #[error("L-shape calibration needs exactly 2 lenses, got {found}")]
-    ExpectedTwoLenses {
+    /// Topologies index their lenses at render time; any other count
+    /// would panic out-of-bounds downstream.
+    #[error("{topology} calibration needs exactly {expected} lens(es), got {found}")]
+    LensCountMismatch {
+        /// Topology name for the message.
+        topology: &'static str,
+        /// Lens count the topology consumes.
+        expected: usize,
         /// Number of lenses actually present.
         found: usize,
     },
@@ -197,15 +200,125 @@ impl Lens {
             correction: 1.0,
         }
     }
+
+    /// A distortion-free source: a pre-stitched flat panorama frame.
+    /// Only the dimensions are load-bearing (cylinder sampling never
+    /// undistorts); the intrinsics are centered identity values.
+    pub fn flat(width: u32, height: u32) -> Self {
+        Self {
+            width,
+            height,
+            fx: width as f64 * 0.5,
+            fy: width as f64 * 0.5,
+            cx: width as f64 * 0.5,
+            cy: height as f64 * 0.5,
+            distortion: [0.0; 4],
+            correction: 1.0,
+        }
+    }
 }
 
-/// 3D placement of the source planes plus the overlap seam.
+/// Scene geometry parameters: which shape the sources are painted on.
 ///
-/// The geometry kind (L-shape today, cylinder/N-camera later) is dispatched by
-/// the [`Projection`](crate::projection::Projection) trait; this carries its
-/// parameters. The virtual-camera position lives in [`Framing`], not here.
+/// Serialized with a `type` tag (`"l-shape"` / `"cylinder"`); documents
+/// written before the tag existed deserialize as L-shape. The matching
+/// [`Projection`](crate::projection::Projection) dispatches the actual
+/// geometry; this carries its parameters. The virtual-camera position
+/// lives in [`Framing`], not here.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub enum Topology {
+    /// Two fisheye cameras on perpendicular planes (the stereo rig).
+    LShape(LShapeTopology),
+    /// One pre-stitched panorama painted on the inside of a cylinder.
+    Cylinder(CylinderTopology),
+}
+
+impl Topology {
+    /// L-shape parameters, when this is the L-shape topology.
+    pub fn l_shape(&self) -> Option<&LShapeTopology> {
+        match self {
+            Topology::LShape(t) => Some(t),
+            Topology::Cylinder(_) => None,
+        }
+    }
+
+    /// Mutable [`Self::l_shape`].
+    pub fn l_shape_mut(&mut self) -> Option<&mut LShapeTopology> {
+        match self {
+            Topology::LShape(t) => Some(t),
+            Topology::Cylinder(_) => None,
+        }
+    }
+
+    /// Cylinder parameters, when this is the cylinder topology.
+    pub fn cylinder(&self) -> Option<&CylinderTopology> {
+        match self {
+            Topology::LShape(_) => None,
+            Topology::Cylinder(t) => Some(t),
+        }
+    }
+
+    /// Number of source cameras this topology consumes.
+    pub fn camera_count(&self) -> usize {
+        match self {
+            Topology::LShape(_) => 2,
+            Topology::Cylinder(_) => 1,
+        }
+    }
+
+    /// Seam blend width. The cylinder has a single surface and no seam,
+    /// so it reports `0.0`.
+    pub fn blend_width(&self) -> f32 {
+        match self {
+            Topology::LShape(t) => t.blend_width,
+            Topology::Cylinder(_) => 0.0,
+        }
+    }
+}
+
+impl From<LShapeTopology> for Topology {
+    fn from(t: LShapeTopology) -> Self {
+        Topology::LShape(t)
+    }
+}
+
+impl From<CylinderTopology> for Topology {
+    fn from(t: CylinderTopology) -> Self {
+        Topology::Cylinder(t)
+    }
+}
+
+// Deserialize accepts both the tagged form and the legacy untagged
+// L-shape document (no `type` field): tagged wins when present.
+impl<'de> Deserialize<'de> for Topology {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(tag = "type", rename_all = "kebab-case")]
+        enum Tagged {
+            LShape(LShapeTopology),
+            Cylinder(CylinderTopology),
+        }
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Repr {
+            Tagged(Tagged),
+            Legacy(LShapeTopology),
+        }
+        Ok(match Repr::deserialize(deserializer)? {
+            Repr::Tagged(Tagged::LShape(t)) => Topology::LShape(t),
+            Repr::Tagged(Tagged::Cylinder(t)) => Topology::Cylinder(t),
+            Repr::Legacy(t) => Topology::LShape(t),
+        })
+    }
+}
+
+/// 3D placement of the two L-shape source planes plus the overlap seam.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Topology {
+pub struct LShapeTopology {
     /// Overlap ratio between the two planes (`0.0` none .. `1.0` full).
     /// Each plane is translated by `(plane_width / 2) × (1 - intersect)`.
     pub intersect: f64,
@@ -227,6 +340,53 @@ pub struct Topology {
     /// Seam blend width as a fraction of the plane overlap. `0.0` = hard seam.
     #[serde(default = "default_blend_width")]
     pub blend_width: f32,
+}
+
+/// Cylinder placement for a single pre-stitched panorama: the video is
+/// painted on the inside of a cylinder and the virtual camera sits on
+/// its axis. Defaults match the established 180-degree
+/// cylindrical-player convention.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CylinderTopology {
+    /// Cylinder radius in world units. Larger values = narrower
+    /// cylindrical wrap per pixel, so the panorama feels flatter.
+    /// Conventional range is 1000-5000.
+    #[serde(default = "default_focal_length")]
+    pub focal_length: f64,
+    /// Full horizontal angular sweep in degrees. 180 is the canonical
+    /// pre-stitched action-camera case; 360 is a full cylinder.
+    #[serde(default = "default_sweep_deg")]
+    pub sweep_deg: f64,
+    /// Screen tilt around the view axis in degrees (typically within
+    /// ±30), correcting a rig that is not level side-to-side.
+    #[serde(default)]
+    pub screen_rotation_deg: f64,
+    /// Video height in world units (`1.0` = normalized).
+    #[serde(default = "default_video_height")]
+    pub video_height: f64,
+}
+
+impl Default for CylinderTopology {
+    fn default() -> Self {
+        Self {
+            focal_length: default_focal_length(),
+            sweep_deg: default_sweep_deg(),
+            screen_rotation_deg: 0.0,
+            video_height: default_video_height(),
+        }
+    }
+}
+
+fn default_focal_length() -> f64 {
+    2400.0
+}
+
+fn default_sweep_deg() -> f64 {
+    180.0
+}
+
+fn default_video_height() -> f64 {
+    1.0
 }
 
 /// Default seam blend width for calibrations that do not specify one.
@@ -300,11 +460,11 @@ const MAX_CALIBRATION_FILE_SIZE: u64 = 1_048_576;
 impl Calibration {
     /// Assemble a calibration from its parts (current schema version, no sync
     /// offset, no ROI).
-    pub fn new(lenses: Vec<Lens>, topology: Topology, framing: Framing) -> Self {
+    pub fn new(lenses: Vec<Lens>, topology: impl Into<Topology>, framing: Framing) -> Self {
         Self {
             schema_version: SCHEMA_VERSION,
             lenses,
-            topology,
+            topology: topology.into(),
             framing,
             sync_offset: 0,
             field_roi: None,
@@ -395,11 +555,16 @@ impl Calibration {
         if self.lenses.is_empty() {
             return Err(CalibrationError::NoLenses);
         }
-        // The L-shape topology hard-indexes lenses[0] and lenses[1] at
-        // render time; reject any other count here with a typed error
-        // rather than panicking out-of-bounds downstream.
-        if self.lenses.len() != 2 {
-            return Err(CalibrationError::ExpectedTwoLenses {
+        // Topologies hard-index their lenses at render time; reject a
+        // mismatched count here with a typed error rather than
+        // panicking out-of-bounds downstream.
+        if self.lenses.len() != self.topology.camera_count() {
+            return Err(CalibrationError::LensCountMismatch {
+                topology: match self.topology {
+                    Topology::LShape(_) => "L-shape",
+                    Topology::Cylinder(_) => "cylinder",
+                },
+                expected: self.topology.camera_count(),
                 found: self.lenses.len(),
             });
         }
@@ -407,7 +572,7 @@ impl Calibration {
             validate_lens(lens, i)?;
         }
         validate_topology(&self.topology)?;
-        validate_framing(&self.framing)?;
+        validate_framing(&self.framing, &self.topology)?;
         if self.sync_offset < -MAX_SYNC_OFFSET_FRAMES || self.sync_offset > MAX_SYNC_OFFSET_FRAMES {
             return Err(CalibrationError::SyncOffsetOutOfRange {
                 value: self.sync_offset,
@@ -556,6 +721,55 @@ fn validate_lens(lens: &Lens, index: usize) -> Result<(), CalibrationError> {
 
 /// Validate the topology parameters.
 fn validate_topology(t: &Topology) -> Result<(), CalibrationError> {
+    match t {
+        Topology::LShape(t) => validate_l_shape(t),
+        Topology::Cylinder(t) => validate_cylinder(t),
+    }
+}
+
+/// Cylinder parameter ranges: positive finite radius/height, sweep in
+/// `(0, 360]` degrees, finite screen rotation.
+fn validate_cylinder(t: &CylinderTopology) -> Result<(), CalibrationError> {
+    for (name, val, lo, hi) in [
+        (
+            "topology.focal_length",
+            t.focal_length,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+        ),
+        ("topology.sweep_deg", t.sweep_deg, f64::MIN_POSITIVE, 360.0),
+        (
+            "topology.screen_rotation_deg",
+            t.screen_rotation_deg,
+            -360.0,
+            360.0,
+        ),
+        (
+            "topology.video_height",
+            t.video_height,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+        ),
+    ] {
+        if !val.is_finite() {
+            return Err(CalibrationError::NonFiniteFloat {
+                field: name.to_owned(),
+                value: format!("{val}"),
+            });
+        }
+        if val < lo || val > hi {
+            return Err(CalibrationError::OutOfRange {
+                field: name.to_owned(),
+                value: val,
+                min: lo,
+                max: hi,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_l_shape(t: &LShapeTopology) -> Result<(), CalibrationError> {
     if !t.intersect.is_finite() {
         return Err(CalibrationError::NonFiniteFloat {
             field: "topology.intersect".to_owned(),
@@ -602,14 +816,16 @@ fn validate_topology(t: &Topology) -> Result<(), CalibrationError> {
 }
 
 /// Validate the framing parameters.
-fn validate_framing(f: &Framing) -> Result<(), CalibrationError> {
+fn validate_framing(f: &Framing, topology: &Topology) -> Result<(), CalibrationError> {
     if !f.axis_offset.is_finite() {
         return Err(CalibrationError::NonFiniteFloat {
             field: "framing.axis_offset".to_owned(),
             value: format!("{}", f.axis_offset),
         });
     }
-    if f.axis_offset <= EPSILON {
+    // The off-axis camera placement is an L-shape concept; the mono
+    // cylinder's camera sits on the axis (offset 0 is its natural value).
+    if matches!(topology, Topology::LShape(_)) && f.axis_offset <= EPSILON {
         return Err(CalibrationError::AxisOffsetTooSmall {
             value: f.axis_offset,
             epsilon: EPSILON,
@@ -656,7 +872,7 @@ mod tests {
         assert_eq!(cal.lenses[0].width, 3840);
         assert_eq!(cal.lenses[0].distortion.len(), 4);
         assert!((cal.framing.axis_offset - 0.2398).abs() < 1e-4);
-        assert!((cal.topology.intersect - 0.5446).abs() < 1e-4);
+        assert!((cal.topology.l_shape().unwrap().intersect - 0.5446).abs() < 1e-4);
         assert!(cal.field_roi.is_none());
         cal.validate().unwrap();
     }
@@ -668,7 +884,7 @@ mod tests {
         // default-valued field survives even if serialization drops it).
         let mut cal = valid_cal();
         cal.lenses[0].correction = 0.0;
-        cal.topology.blend_width = 0.123;
+        cal.topology.l_shape_mut().unwrap().blend_width = 0.123;
         cal.framing.tilt = 0.3;
         cal.framing.roll = -0.12;
         cal.sync_offset = 67;
@@ -677,8 +893,13 @@ mod tests {
         let back: Calibration = serde_json::from_str(&json).unwrap();
         assert_eq!(back.lenses.len(), cal.lenses.len());
         assert!((back.lenses[0].correction - 0.0).abs() < 1e-6);
-        assert!((back.topology.blend_width - 0.123).abs() < 1e-6);
-        assert!((back.topology.intersect - cal.topology.intersect).abs() < 1e-9);
+        assert!((back.topology.l_shape().unwrap().blend_width - 0.123).abs() < 1e-6);
+        assert!(
+            (back.topology.l_shape().unwrap().intersect
+                - cal.topology.l_shape().unwrap().intersect)
+                .abs()
+                < 1e-9
+        );
         assert!((back.framing.axis_offset - cal.framing.axis_offset).abs() < 1e-9);
         assert!((back.framing.tilt - 0.3).abs() < 1e-9);
         assert!((back.framing.roll + 0.12).abs() < 1e-9);
@@ -713,7 +934,7 @@ mod tests {
         Calibration {
             schema_version: SCHEMA_VERSION,
             lenses: vec![lens(), lens()],
-            topology: Topology {
+            topology: Topology::LShape(LShapeTopology {
                 intersect: 0.5,
                 x_ty: 0.0,
                 x_rz: 0.0,
@@ -721,7 +942,7 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
-            },
+            }),
             framing: Framing {
                 axis_offset: 0.25,
                 tilt: 0.0,
@@ -735,6 +956,82 @@ mod tests {
     #[test]
     fn valid_calibration_passes() {
         valid_cal().validate().unwrap();
+    }
+
+    #[test]
+    fn legacy_untagged_topology_parses_as_l_shape() {
+        // Documents written before the `type` tag existed carry a bare
+        // L-shape object; they must keep parsing unchanged.
+        let mut v: serde_json::Value = serde_json::from_str(&valid_cal().to_json_pretty()).unwrap();
+        let topo = v["topology"].as_object_mut().unwrap();
+        assert_eq!(topo.remove("type").unwrap(), "l-shape");
+        let cal: Calibration = serde_json::from_value(v).unwrap();
+        let t = cal.topology.l_shape().expect("untagged doc is L-shape");
+        assert!((t.intersect - 0.5).abs() < 1e-9);
+        cal.validate().unwrap();
+    }
+
+    #[test]
+    fn tagged_cylinder_document_round_trips() {
+        let cal = Calibration::new(
+            vec![Lens::flat(3840, 1080)],
+            CylinderTopology::default(),
+            Framing {
+                axis_offset: 0.0,
+                tilt: 0.0,
+                roll: 0.0,
+            },
+        );
+        cal.validate().unwrap();
+        let json = cal.to_json_pretty();
+        assert!(
+            json.contains("\"type\": \"cylinder\""),
+            "tagged serialization: {json}"
+        );
+        let back: Calibration = serde_json::from_str(&json).unwrap();
+        let t = back.topology.cylinder().expect("cylinder round-trip");
+        assert!((t.focal_length - 2400.0).abs() < 1e-9);
+        assert!((t.sweep_deg - 180.0).abs() < 1e-9);
+        back.validate().unwrap();
+    }
+
+    #[test]
+    fn cylinder_lens_count_is_enforced() {
+        let mut cal = valid_cal();
+        cal.topology = Topology::Cylinder(CylinderTopology::default());
+        assert!(
+            matches!(
+                cal.validate(),
+                Err(CalibrationError::LensCountMismatch {
+                    expected: 1,
+                    found: 2,
+                    ..
+                })
+            ),
+            "two lenses on a mono topology must be rejected"
+        );
+    }
+
+    #[test]
+    fn cylinder_parameters_are_validated() {
+        let bad = |f: fn(&mut CylinderTopology)| {
+            let mut t = CylinderTopology::default();
+            f(&mut t);
+            let cal = Calibration::new(
+                vec![Lens::flat(3840, 1080)],
+                t,
+                Framing {
+                    axis_offset: 0.0,
+                    tilt: 0.0,
+                    roll: 0.0,
+                },
+            );
+            cal.validate()
+        };
+        assert!(bad(|t| t.focal_length = 0.0).is_err());
+        assert!(bad(|t| t.sweep_deg = 361.0).is_err());
+        assert!(bad(|t| t.sweep_deg = 0.0).is_err());
+        assert!(bad(|t| t.video_height = f64::NAN).is_err());
     }
 
     #[test]
@@ -790,7 +1087,7 @@ mod tests {
     #[test]
     fn rejects_intersect_out_of_range() {
         let mut c = valid_cal();
-        c.topology.intersect = 1.5;
+        c.topology.l_shape_mut().unwrap().intersect = 1.5;
         assert!(matches!(
             c.validate(),
             Err(CalibrationError::IntersectOutOfRange { .. })
@@ -810,7 +1107,7 @@ mod tests {
         c.lenses.pop();
         assert!(matches!(
             c.validate(),
-            Err(CalibrationError::ExpectedTwoLenses { found: 1 })
+            Err(CalibrationError::LensCountMismatch { found: 1, .. })
         ));
     }
 
@@ -821,7 +1118,7 @@ mod tests {
         c.lenses.push(extra);
         assert!(matches!(
             c.validate(),
-            Err(CalibrationError::ExpectedTwoLenses { found: 3 })
+            Err(CalibrationError::LensCountMismatch { found: 3, .. })
         ));
     }
 
@@ -842,7 +1139,7 @@ mod tests {
         // A hand-migrated file keeping old camelCase keys must not load
         // with the seam alignment silently zeroed.
         let mut cal = valid_cal();
-        cal.topology.x_ty = 0.0048;
+        cal.topology.l_shape_mut().unwrap().x_ty = 0.0048;
         let mut v: serde_json::Value = serde_json::from_str(&cal.to_json_pretty()).unwrap();
         let topo = v["topology"].as_object_mut().unwrap();
         topo.remove("x_ty");

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -93,6 +93,7 @@ pub struct StitchCore {
     pub(crate) cpu_frame: Vec<u8>,
     /// One-shot guard for the mono-detection warning (detection is
     /// L-shape-only until the mono mapping lands).
+    // TODO: remove once mono detection lands (Step 13 PR B).
     mono_detection_warned: bool,
     pub(crate) output_width: u32,
     pub(crate) output_height: u32,

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -91,6 +91,9 @@ pub struct StitchCore {
     /// staging ring. [`RenderOutcome::Rgba`](self::types::RenderOutcome)
     /// borrows from it on the CPU arm; empty on GPU engines.
     pub(crate) cpu_frame: Vec<u8>,
+    /// One-shot guard for the mono-detection warning (detection is
+    /// L-shape-only until the mono mapping lands).
+    mono_detection_warned: bool,
     pub(crate) output_width: u32,
     pub(crate) output_height: u32,
 
@@ -215,6 +218,7 @@ impl StitchCore {
             #[cfg(feature = "gpu")]
             readback,
             cpu_frame: Vec::new(),
+            mono_detection_warned: false,
             output_width,
             output_height,
             coverage: Some(coverage),

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -896,7 +896,7 @@ mod tests {
         );
         core.set_fov(50.0);
         core.set_blend_width(0.1);
-        assert!((core.calibration().topology.blend_width - 0.1).abs() < 1e-6);
+        assert!((core.calibration().topology.blend_width() - 0.1).abs() < 1e-6);
         core.set_rig_tilt(0.2);
         assert!((core.calibration().framing.tilt - 0.2).abs() < 1e-6);
         assert_eq!(core.resize(48, 26), Some((48, 26)));

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -375,6 +375,7 @@ impl super::StitchCore {
     /// detector logs once and idles, and the panner runs without
     /// detections. The stacked replay recorder (2-tile format) is
     /// likewise skipped.
+    // TODO: wire mono detection + replay (Step 13 PR B).
     pub fn submit_frame_mono_yuv(
         &mut self,
         frame: &YuvPlanes<'_>,

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -74,7 +74,7 @@ impl super::StitchCore {
             #[cfg(feature = "gpu")]
             Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
         };
-        let rgba = cpu.stitch_yuv(left, right, pose.yaw, pose.pitch)?;
+        let rgba = cpu.stitch_yuv(&[*left, *right], pose.yaw, pose.pitch)?;
         Ok(self.deliver_cpu_frame(rgba, pose))
     }
 
@@ -320,7 +320,7 @@ impl super::StitchCore {
                     #[cfg(feature = "gpu")]
                     Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
                 };
-                let rgba = cpu.stitch_nv12(left, right, pose.yaw, pose.pitch)?;
+                let rgba = cpu.stitch_nv12(&[*left, *right], pose.yaw, pose.pitch)?;
                 Ok(self.deliver_cpu_frame(rgba, pose))
             }
             #[cfg(feature = "gpu")]

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -366,6 +366,50 @@ impl super::StitchCore {
         })
     }
 
+    /// Submit a mono frame - a single pre-stitched panorama - and
+    /// render the current pose. The single-camera counterpart of
+    /// [`Self::submit_frame_yuv`] for mono topologies (the cylinder).
+    ///
+    /// Detection is not wired for mono topologies yet (the
+    /// detection-to-panorama mapping is L-shape-only); an attached
+    /// detector logs once and idles, and the panner runs without
+    /// detections. The stacked replay recorder (2-tile format) is
+    /// likewise skipped.
+    pub fn submit_frame_mono_yuv(
+        &mut self,
+        frame: &YuvPlanes<'_>,
+    ) -> Result<RenderOutcome<'_>, StitchCoreError> {
+        self.anchor_session_start();
+
+        if self.detection_due(self.frame_count) && !self.mono_detection_warned {
+            self.mono_detection_warned = true;
+            log::warn!("detection is not supported on mono topologies yet; the detector idles");
+        }
+
+        let pose = self.resolve_current_pose(false);
+        match &self.executor {
+            Executor::Cpu(_) => {
+                // See submit_cpu_yuv for the wgpu-free lint note.
+                #[allow(clippy::infallible_destructuring_match)]
+                let cpu = match &self.executor {
+                    Executor::Cpu(cpu) => cpu,
+                    #[cfg(feature = "gpu")]
+                    Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
+                };
+                let rgba = cpu.stitch_yuv(&[*frame], pose.yaw, pose.pitch)?;
+                Ok(self.deliver_cpu_frame(rgba, pose))
+            }
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(_) => Err(StitchCoreError::Executor(
+                crate::stitch::StitchError::InvalidConfig(
+                    "the mono GPU pass is not wired yet; run mono topologies on the \
+                     CPU executor"
+                        .into(),
+                ),
+            )),
+        }
+    }
+
     /// Store a CPU-stitched frame and hand out the borrowed outcome -
     /// the synchronous dual of the GPU readback tail (replay push +
     /// frame accounting).

--- a/crates/reco-core/src/detect/panner.rs
+++ b/crates/reco-core/src/detect/panner.rs
@@ -229,7 +229,7 @@ pub(crate) fn dispatch(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calibration::{Calibration, Framing, Lens, Topology};
+    use crate::calibration::{Calibration, Framing, LShapeTopology, Lens};
     use crate::detect::tracker::{TrackState, TrackedEntity, WorldState};
     use crate::geometry::CameraId;
 
@@ -239,7 +239,7 @@ mod tests {
         let cam = || Lens::fisheye(1920, 1080, 900.0, 900.0, 960.0, 540.0, [0.0; 4]);
         Calibration::new(
             vec![cam(), cam()],
-            Topology {
+            LShapeTopology {
                 intersect: 0.54,
                 x_ty: 0.0,
                 x_rz: 0.0,

--- a/crates/reco-core/src/geometry/mod.rs
+++ b/crates/reco-core/src/geometry/mod.rs
@@ -20,7 +20,7 @@ mod virtual_camera;
 pub use matrices::{FAR_PLANE, NEAR_PLANE, view_matrix};
 pub use rig_correction::{resolve_render_pose, world_to_render_pose};
 pub use types::{CameraId, ViewportPosition};
-pub use virtual_camera::VirtualCamera;
+pub use virtual_camera::{MONO_CAMERA_POSITION, VirtualCamera};
 
 #[cfg(feature = "gpu")]
 pub(crate) use matrices::matrix4_to_columns;

--- a/crates/reco-core/src/geometry/virtual_camera.rs
+++ b/crates/reco-core/src/geometry/virtual_camera.rs
@@ -27,6 +27,12 @@ use nalgebra::Vector3;
 /// Rig tilt and rig roll are NOT part of this type: `rig_frame` layers
 /// them on top, and `view_matrix` + `world_to_render_pose` both compose
 /// through that one construction.
+/// World-space eye position of the mono (single-camera) rig: on the
+/// projection axis, one unit back along `+Z`. The single home for the
+/// convention shared by [`VirtualCamera::mono`], the mono scene
+/// geometry, and the cylinder map.
+pub const MONO_CAMERA_POSITION: [f32; 3] = [0.0, 0.0, 1.0];
+
 #[derive(Debug, Clone, Copy)]
 pub struct VirtualCamera {
     /// World-space camera eye position (copy of `camera_position`).
@@ -44,6 +50,15 @@ impl VirtualCamera {
     /// rather than a field because every VirtualCamera agrees on it.
     pub fn world_up() -> Vector3<f32> {
         Vector3::new(0.0, 1.0, 0.0)
+    }
+
+    /// The mono (single-camera) basis: the camera sits on the
+    /// projection axis at [`MONO_CAMERA_POSITION`] looking at the
+    /// origin - forward `-Z`, right `+X`, up `+Y`. A unit offset
+    /// rather than the origin itself: `new` normalizes the
+    /// eye-to-origin direction, and a zero eye would produce NaN axes.
+    pub fn mono() -> Self {
+        Self::new(&MONO_CAMERA_POSITION)
     }
 
     /// Build the basis from a world-space camera position.

--- a/crates/reco-core/src/projection/coverage.rs
+++ b/crates/reco-core/src/projection/coverage.rs
@@ -112,11 +112,20 @@ impl CoverageBoundary {
     /// Densely samples both planes' edge loops and a sparse interior grid,
     /// projecting into (yaw, pitch) space and grouping into pitch slices.
     /// Analytic rectangular coverage: the same yaw range at every
-    /// pitch. The mono cylinder's panorama is exactly rectangular in
+    /// pitch. The mono cylinder's panorama is rectangular in
     /// (yaw, pitch) space, so no boundary sampling is needed. The
     /// camera basis is the mono convention (on the cylinder axis,
-    /// forward `-Z`); rig tilt/roll margining does not apply.
-    pub fn rectangular(yaw_min: f32, yaw_max: f32, pitch_min: f32, pitch_max: f32) -> Self {
+    /// forward `-Z`). Rig tilt/roll feed the same viewport-roll
+    /// margining a tilted L-shape gets (panning a tilted rig rolls
+    /// the viewport against the panorama).
+    pub fn rectangular(
+        yaw_min: f32,
+        yaw_max: f32,
+        pitch_min: f32,
+        pitch_max: f32,
+        rig_tilt: f32,
+        rig_roll: f32,
+    ) -> Self {
         let n_slices: usize = 16;
         Self {
             n_slices,
@@ -124,8 +133,8 @@ impl CoverageBoundary {
             pitch_max,
             slices: vec![(yaw_min, yaw_max); n_slices],
             min_pitch_range: pitch_max - pitch_min,
-            rig_tilt: 0.0,
-            rig_roll: 0.0,
+            rig_tilt,
+            rig_roll,
             cam: VirtualCamera::new(&[0.0, 0.0, 1.0]),
         }
     }

--- a/crates/reco-core/src/projection/coverage.rs
+++ b/crates/reco-core/src/projection/coverage.rs
@@ -111,6 +111,25 @@ impl CoverageBoundary {
     ///
     /// Densely samples both planes' edge loops and a sparse interior grid,
     /// projecting into (yaw, pitch) space and grouping into pitch slices.
+    /// Analytic rectangular coverage: the same yaw range at every
+    /// pitch. The mono cylinder's panorama is exactly rectangular in
+    /// (yaw, pitch) space, so no boundary sampling is needed. The
+    /// camera basis is the mono convention (on the cylinder axis,
+    /// forward `-Z`); rig tilt/roll margining does not apply.
+    pub fn rectangular(yaw_min: f32, yaw_max: f32, pitch_min: f32, pitch_max: f32) -> Self {
+        let n_slices: usize = 16;
+        Self {
+            n_slices,
+            pitch_min,
+            pitch_max,
+            slices: vec![(yaw_min, yaw_max); n_slices],
+            min_pitch_range: pitch_max - pitch_min,
+            rig_tilt: 0.0,
+            rig_roll: 0.0,
+            cam: VirtualCamera::new(&[0.0, 0.0, 1.0]),
+        }
+    }
+
     pub fn from_calibration(calibration: &Calibration, scene: &SceneGeometry) -> Self {
         let n_slices: usize = 400;
         let margin = 0.02_f32;

--- a/crates/reco-core/src/projection/coverage.rs
+++ b/crates/reco-core/src/projection/coverage.rs
@@ -135,7 +135,7 @@ impl CoverageBoundary {
             min_pitch_range: pitch_max - pitch_min,
             rig_tilt,
             rig_roll,
-            cam: VirtualCamera::new(&[0.0, 0.0, 1.0]),
+            cam: VirtualCamera::mono(),
         }
     }
 

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -209,8 +209,9 @@ impl Projection for CylindricalProjection {
             fs_entry: "fs_cylindrical_mono",
             // Mono: single surface, nothing to blend over.
             blend: wgpu::BlendState::REPLACE,
-            // Placeholder until the mono GPU pass is wired: its
-            // composite is a fullscreen pass with its own bind layout.
+            // TODO: placeholder until the mono GPU pass is wired
+            // (Step 13 PR B): its composite is a fullscreen pass with
+            // its own bind layout.
             vertex_layout: crate::render::renderer::Vertex::LAYOUT,
         }
     }
@@ -971,10 +972,11 @@ mod tests {
 
     #[test]
     fn projection_dyn_dispatch_round_trip_with_mixed_camera_counts() {
-        // Compile-time: `Box<dyn Projection>` can hold concrete impls
-        // with different `camera_count()` results. Proves the trait
-        // API's claim that consumers can swap projections without a
-        // new type parameter on StitchCore.
+        // Compile-time: the trait is object-safe, so one collection
+        // holds impls with different `camera_count()` results - what
+        // lets `for_topology` pick the projection at calibration-load
+        // time. The assertions pin the per-projection counts and that
+        // the diagnostic names stay distinct.
         let projections: Vec<Box<dyn Projection>> =
             vec![Box::new(LShapeProjection), Box::new(CylindricalProjection)];
         assert_eq!(projections[0].camera_count(), 2);

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -190,6 +190,7 @@ impl Projection for CylindricalProjection {
         vec![(
             Box::new(crate::stitch::cylinder::CylinderMap::new(
                 topology,
+                &calibration.framing,
                 f64::from(calibration.lenses[0].height),
                 config,
                 yaw,
@@ -226,8 +227,19 @@ impl Projection for CylindricalProjection {
         let height = t
             .video_height
             .unwrap_or(f64::from(calibration.lenses[0].height));
-        let pitch_half = ((height * 0.5) / t.focal_length).atan() as f32;
-        CoverageBoundary::rectangular(-yaw_half, yaw_half, -pitch_half, pitch_half)
+        // A tilted rig frame shifts the painted band in pose space by
+        // up to the tilt; shrink conservatively until the sampled
+        // coverage lands with the mono GPU pass.
+        let pitch_half =
+            (((height * 0.5) / t.focal_length).atan() - calibration.framing.tilt.abs()) as f32;
+        CoverageBoundary::rectangular(
+            -yaw_half,
+            yaw_half,
+            -pitch_half.max(0.0),
+            pitch_half.max(0.0),
+            calibration.framing.tilt as f32,
+            calibration.framing.roll as f32,
+        )
     }
 }
 

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -155,78 +155,17 @@ impl Projection for LShapeProjection {
 // ---------------------------------------------------------------------------
 // Cylindrical single-input projection.
 // ---------------------------------------------------------------------------
-//
-// Models a single video as a texture painted on the inside of a
-// cylinder of radius `focal_length`. The virtual camera sits on the
-// cylinder axis and looks outward; pan/tilt/zoom rotate the camera and
-// scale FOV. This is the standard projection for pre-stitched 180-degree
-// action-camera footage, so files from that ecosystem deproject with
-// small adapter code. Defaults (focal_length=2400, sweep=180deg) match
-// the convention such players established.
-//
-// Proves the `Projection` trait supports camera_count() != 2. The
-// inverse map + WGSL wiring into StitchCore land at the cylinder step
-// (needs a mono submit path and a different bind group layout); the
-// shader draft lives at `shaders/cylindrical_mono.wgsl`.
-
-/// Configuration for a [`CylindricalProjection`]. Defaults match the
-/// established 180-degree cylindrical-player convention (2400px focal
-/// length, no screen rotation).
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct CylindricalProjectionConfig {
-    /// Cylinder radius in world units. Larger values = narrower
-    /// cylindrical wrap per pixel, so the panorama feels flatter.
-    /// Conventional range is 1000-5000 with 2400 as the default.
-    pub focal_length: f32,
-    /// Full horizontal angular sweep in radians. `std::f32::consts::PI`
-    /// (180 degrees) is the canonical action-camera case; 2π would be
-    /// a full 360-degree cylinder.
-    pub angular_sweep_rad: f32,
-    /// Screen tilt around the view axis in radians (typically within
-    /// ±30 degrees), correcting a rig that is not level side-to-side.
-    pub screen_rotation_rad: f32,
-    /// Video height in world units. Defaults to `1.0` (normalized);
-    /// consumers with a known camera height can pass the actual value
-    /// so the cylinder has the right aspect.
-    pub video_height: f32,
-}
-
-impl Default for CylindricalProjectionConfig {
-    fn default() -> Self {
-        Self {
-            focal_length: 2400.0,
-            angular_sweep_rad: std::f32::consts::PI,
-            screen_rotation_rad: 0.0,
-            video_height: 1.0,
-        }
-    }
-}
 
 /// Single-input cylindrical projection.
 ///
 /// Consumes one camera (`camera_count() == 1`) and renders it as if
-/// painted on the inside of a cylinder of radius `config.focal_length`.
-/// The virtual camera sits on the cylinder axis.
-///
-#[derive(Debug, Clone, Copy, Default)]
-pub struct CylindricalProjection {
-    /// Projection parameters (see [`CylindricalProjectionConfig::default`]).
-    pub config: CylindricalProjectionConfig,
-}
-
-impl CylindricalProjection {
-    /// Build a new cylindrical projection with the given config.
-    pub fn new(config: CylindricalProjectionConfig) -> Self {
-        Self { config }
-    }
-
-    /// Compute the cylinder's `theta_start` angle in radians:
-    /// `PI/2 - angular_sweep/2` - where the video's left edge lands on
-    /// the cylinder surface (the sweep centers on the +Z view axis).
-    pub fn theta_start_rad(&self) -> f32 {
-        std::f32::consts::FRAC_PI_2 - self.config.angular_sweep_rad * 0.5
-    }
-}
+/// painted on the inside of a cylinder; the virtual camera sits on the
+/// cylinder axis. The parameters live in the calibration document's
+/// [`CylinderTopology`](crate::calibration::CylinderTopology) - like
+/// the L-shape, the struct itself carries no state. This is the
+/// standard projection for pre-stitched 180-degree footage.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CylindricalProjection;
 
 impl Projection for CylindricalProjection {
     fn name(&self) -> &'static str {
@@ -237,18 +176,28 @@ impl Projection for CylindricalProjection {
         1
     }
 
-    /// Not wired yet: the mono cylinder's inverse map lands at the
-    /// cylinder-topology step (its WGSL lives at
-    /// `shaders/cylindrical_mono.wgsl`). Unreachable through StitchCore
-    /// today - construction rejects the camera-count mismatch.
     fn surface_maps(
         &self,
-        _calibration: &Calibration,
-        _config: &crate::render::viewport::ViewportConfig,
-        _yaw: f32,
-        _pitch: f32,
+        calibration: &Calibration,
+        config: &crate::render::viewport::ViewportConfig,
+        yaw: f32,
+        pitch: f32,
     ) -> Vec<(Box<dyn SurfaceMap>, BlendRule)> {
-        Vec::new()
+        let topology = calibration
+            .topology
+            .cylinder()
+            .expect("the cylindrical projection requires the cylinder topology");
+        vec![(
+            Box::new(crate::stitch::cylinder::CylinderMap::new(
+                topology,
+                f64::from(calibration.lenses[0].height),
+                config,
+                yaw,
+                pitch,
+            )),
+            // Single surface: nothing underneath to blend with.
+            BlendRule::Opaque,
+        )]
     }
 
     #[cfg(feature = "gpu")]
@@ -259,11 +208,36 @@ impl Projection for CylindricalProjection {
             fs_entry: "fs_cylindrical_mono",
             // Mono: single surface, nothing to blend over.
             blend: wgpu::BlendState::REPLACE,
-            // Placeholder until the cylinder is wired: its composite is a
-            // fullscreen pass, and its real vertex/bind layout lands with
-            // the cylinder-topology step.
+            // Placeholder until the mono GPU pass is wired: its
+            // composite is a fullscreen pass with its own bind layout.
             vertex_layout: crate::render::renderer::Vertex::LAYOUT,
         }
+    }
+
+    /// The cylinder's panorama is exactly rectangular in (yaw, pitch):
+    /// yaw spans the angular sweep, pitch spans what the painted
+    /// height subtends at the radius.
+    fn coverage(&self, calibration: &Calibration, _scene: &SceneGeometry) -> CoverageBoundary {
+        let t = calibration
+            .topology
+            .cylinder()
+            .expect("the cylindrical projection requires the cylinder topology");
+        let yaw_half = (t.sweep_deg.to_radians() * 0.5) as f32;
+        let height = t
+            .video_height
+            .unwrap_or(f64::from(calibration.lenses[0].height));
+        let pitch_half = ((height * 0.5) / t.focal_length).atan() as f32;
+        CoverageBoundary::rectangular(-yaw_half, yaw_half, -pitch_half, pitch_half)
+    }
+}
+
+/// The projection a calibration document calls for: the topology
+/// variant picks it. Consumers with a custom projection can still
+/// inject their own at executor construction.
+pub fn for_topology(topology: &crate::calibration::Topology) -> Box<dyn Projection> {
+    match topology {
+        crate::calibration::Topology::LShape(_) => Box::new(LShapeProjection),
+        crate::calibration::Topology::Cylinder(_) => Box::new(CylindricalProjection),
     }
 }
 
@@ -915,21 +889,21 @@ mod tests {
 
     // ---- CylindricalProjection ---------------------------------------------
 
-    #[test]
-    fn cylindrical_defaults_match_convention() {
-        // Reference values are the established cylindrical-player
-        // convention (focal length 2400, 180-deg sweep, no screen tilt,
-        // normalized height). Regresses if the defaults silently change.
-        let c = CylindricalProjectionConfig::default();
-        assert_eq!(c.focal_length, 2400.0);
-        assert!((c.angular_sweep_rad - std::f32::consts::PI).abs() < 1e-6);
-        assert_eq!(c.screen_rotation_rad, 0.0);
-        assert_eq!(c.video_height, 1.0);
+    fn cylinder_cal() -> Calibration {
+        Calibration::new(
+            vec![Lens::flat(3840, 1080)],
+            crate::calibration::CylinderTopology::default(),
+            Framing {
+                axis_offset: 0.0,
+                tilt: 0.0,
+                roll: 0.0,
+            },
+        )
     }
 
     #[test]
     fn cylindrical_projection_reports_mono() {
-        let p = CylindricalProjection::default();
+        let p = CylindricalProjection;
         assert_eq!(p.name(), "cylindrical-mono-1camera");
         assert_eq!(
             p.camera_count(),
@@ -939,22 +913,48 @@ mod tests {
     }
 
     #[test]
-    fn cylindrical_theta_start_centers_the_sweep() {
-        // theta_start = PI/2 - s/2 where s is the angular sweep, so the
-        // sweep centers on the view axis. Verify for 180-deg (default)
-        // and for a 90-deg cylinder (quarter sweep).
-        let p180 = CylindricalProjection::default();
+    fn cylindrical_surface_maps_emit_one_opaque_surface() {
+        let cal = cylinder_cal();
+        let config = crate::render::viewport::ViewportConfig::default();
+        let surfaces = CylindricalProjection.surface_maps(&cal, &config, 0.0, 0.0);
+        assert_eq!(surfaces.len(), 1);
+        assert_eq!(surfaces[0].1, crate::stitch::BlendRule::Opaque);
         assert!(
-            (p180.theta_start_rad() - std::f32::consts::FRAC_PI_2 * 0.0).abs() < 1e-6,
-            "180-deg sweep: theta_start = PI/2 - PI/2 = 0"
+            surfaces[0]
+                .0
+                .sample_uv(config.width / 2, config.height / 2)
+                .is_some(),
+            "the straight-ahead pixel is covered"
         );
+    }
 
-        let p90 = CylindricalProjection::new(CylindricalProjectionConfig {
-            angular_sweep_rad: std::f32::consts::FRAC_PI_2,
-            ..Default::default()
-        });
-        // 90-deg: theta_start = PI/2 - PI/4 = PI/4.
-        assert!((p90.theta_start_rad() - std::f32::consts::FRAC_PI_4).abs() < 1e-6);
+    #[test]
+    fn cylindrical_coverage_is_the_analytic_rectangle() {
+        let cal = cylinder_cal();
+        let scene = SceneGeometry::for_calibration(&cal, 3840.0 / 1080.0);
+        let coverage = CylindricalProjection.coverage(&cal, &scene);
+        let (y_lo, y_hi) = coverage.yaw_range();
+        assert!(
+            (y_lo + std::f32::consts::FRAC_PI_2).abs() < 1e-5,
+            "yaw_min {y_lo}"
+        );
+        assert!(
+            (y_hi - std::f32::consts::FRAC_PI_2).abs() < 1e-5,
+            "yaw_max {y_hi}"
+        );
+        // pitch half-extent = atan((h/2)/r) for h = the source's 1080
+        // pixel height (the omitted-video_height default), r = 2400.
+        let expected = ((1080.0f64 * 0.5) / 2400.0).atan() as f32;
+        assert!((coverage.pitch_max - expected).abs() < 1e-6);
+        assert!((coverage.pitch_min + expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn for_topology_resolves_the_matching_projection() {
+        let l = for_topology(&test_calibration().topology);
+        assert_eq!(l.camera_count(), 2);
+        let c = for_topology(&cylinder_cal().topology);
+        assert_eq!(c.camera_count(), 1);
     }
 
     #[test]
@@ -963,10 +963,8 @@ mod tests {
         // with different `camera_count()` results. Proves the trait
         // API's claim that consumers can swap projections without a
         // new type parameter on StitchCore.
-        let projections: Vec<Box<dyn Projection>> = vec![
-            Box::new(LShapeProjection),
-            Box::new(CylindricalProjection::default()),
-        ];
+        let projections: Vec<Box<dyn Projection>> =
+            vec![Box::new(LShapeProjection), Box::new(CylindricalProjection)];
         assert_eq!(projections[0].camera_count(), 2);
         assert_eq!(projections[1].camera_count(), 1);
         assert_ne!(projections[0].name(), projections[1].name());
@@ -976,6 +974,5 @@ mod tests {
     fn cylindrical_projection_is_send_sync() {
         fn assert_send_sync<T: Send + Sync + 'static>() {}
         assert_send_sync::<CylindricalProjection>();
-        assert_send_sync::<CylindricalProjectionConfig>();
     }
 }

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -227,16 +227,16 @@ impl Projection for CylindricalProjection {
         let height = t
             .video_height
             .unwrap_or(f64::from(calibration.lenses[0].height));
-        // A tilted rig frame shifts the painted band in pose space by
-        // up to the tilt; shrink conservatively until the sampled
-        // coverage lands with the mono GPU pass.
-        let pitch_half =
-            (((height * 0.5) / t.focal_length).atan() - calibration.framing.tilt.abs()) as f32;
+        let pitch_half = (((height * 0.5) / t.focal_length).atan()) as f32;
+        // The painted band is world-fixed; rig tilt/roll shape how
+        // panning traverses it, not where it is - the clamp's rotated
+        // viewport margining (the same mechanism a tilted L-shape
+        // uses) accounts for the edge roll.
         CoverageBoundary::rectangular(
             -yaw_half,
             yaw_half,
-            -pitch_half.max(0.0),
-            pitch_half.max(0.0),
+            -pitch_half,
+            pitch_half,
             calibration.framing.tilt as f32,
             calibration.framing.roll as f32,
         )

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -126,7 +126,7 @@ impl Projection for LShapeProjection {
             (Box::new(left), BlendRule::Opaque),
             (
                 Box::new(right),
-                BlendRule::Smoothstep(calibration.topology.blend_width as f64),
+                BlendRule::Smoothstep(calibration.topology.blend_width() as f64),
             ),
         ]
     }
@@ -291,7 +291,7 @@ const CONVERGENCE_EPS: f64 = 1e-10;
 ///
 /// # fn example(cal: &Calibration) {
 /// let aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-/// let scene = SceneGeometry::new(&cal.topology, &cal.framing, aspect);
+/// let scene = SceneGeometry::for_calibration(cal, aspect);
 /// if let Some(pos) = camera_to_panorama(CameraId::Left, 0.5, 0.5, cal, &scene) {
 ///     println!("Center of left camera maps to yaw={:.3}, pitch={:.3}", pos.yaw, pos.pitch);
 /// }
@@ -468,11 +468,11 @@ pub(crate) fn yaw_pitch_to_direction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calibration::{Calibration, Framing, Lens, Topology};
+    use crate::calibration::{Calibration, Framing, LShapeTopology, Lens};
 
     fn test_scene(cal: &Calibration) -> SceneGeometry {
         let aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-        SceneGeometry::new(&cal.topology, &cal.framing, aspect)
+        SceneGeometry::for_calibration(cal, aspect)
     }
 
     fn test_calibration() -> Calibration {
@@ -489,7 +489,7 @@ mod tests {
         };
         Calibration::new(
             vec![cam(), cam()],
-            Topology {
+            LShapeTopology {
                 intersect: 0.5446,
                 x_ty: 0.00476,
                 x_rz: 0.00753,
@@ -909,7 +909,7 @@ mod tests {
         assert_eq!(surfaces[0].1, crate::stitch::BlendRule::Opaque);
         assert_eq!(
             surfaces[1].1,
-            crate::stitch::BlendRule::Smoothstep(cal.topology.blend_width as f64)
+            crate::stitch::BlendRule::Smoothstep(cal.topology.blend_width() as f64)
         );
     }
 

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -123,7 +123,7 @@ impl StitchPipeline {
 
         let output_format = output_format.into();
         let aspect = calibration.lenses[0].width as f32 / calibration.lenses[0].height as f32;
-        let scene = SceneGeometry::new(&calibration.topology, &calibration.framing, aspect);
+        let scene = SceneGeometry::for_calibration(&calibration, aspect);
         let renderer = Renderer::new(
             &gpu,
             program,
@@ -250,7 +250,11 @@ impl StitchPipeline {
 
     /// Set the seam blend width (per-frame uniform; no scene rebuild).
     pub fn set_blend_width(&mut self, width: f32) {
-        self.calibration.topology.blend_width = width;
+        if let Some(t) = self.calibration.topology.l_shape_mut() {
+            t.blend_width = width;
+        } else {
+            log::warn!("set_blend_width({width}) ignored: this topology has no seam");
+        }
     }
 
     /// Update calibration parameters. Recomputes [`SceneGeometry`] from the
@@ -260,7 +264,7 @@ impl StitchPipeline {
     /// No GPU pipeline recreation needed - only the uniform data changes.
     pub fn update_calibration(&mut self, calibration: Calibration) {
         let aspect = calibration.lenses[0].width as f32 / calibration.lenses[0].height as f32;
-        self.scene = SceneGeometry::new(&calibration.topology, &calibration.framing, aspect);
+        self.scene = SceneGeometry::for_calibration(&calibration, aspect);
         self.calibration = calibration;
         log::debug!("Pipeline calibration updated");
     }
@@ -528,7 +532,7 @@ impl StitchPipeline {
             &self.scene,
             &self.calibration,
             &viewport,
-            self.calibration.topology.blend_width,
+            self.calibration.topology.blend_width(),
             target_view,
         );
         Ok(())
@@ -569,7 +573,7 @@ impl StitchPipeline {
             &self.scene,
             &self.calibration,
             &viewport,
-            self.calibration.topology.blend_width,
+            self.calibration.topology.blend_width(),
         ))
     }
 
@@ -607,7 +611,7 @@ impl StitchPipeline {
             &self.scene,
             &self.calibration,
             &viewport,
-            self.calibration.topology.blend_width,
+            self.calibration.topology.blend_width(),
         ))
     }
 
@@ -645,7 +649,7 @@ impl StitchPipeline {
             &self.scene,
             &self.calibration,
             &viewport,
-            self.calibration.topology.blend_width,
+            self.calibration.topology.blend_width(),
         ))
     }
 
@@ -708,7 +712,7 @@ impl StitchPipeline {
             &self.scene,
             &self.calibration,
             &viewport,
-            self.calibration.topology.blend_width,
+            self.calibration.topology.blend_width(),
         )
     }
 

--- a/crates/reco-core/src/render/planes.rs
+++ b/crates/reco-core/src/render/planes.rs
@@ -11,6 +11,7 @@
 /// - `y`: `width * height` bytes
 /// - `u`: `(width/2) * (height/2)` bytes
 /// - `v`: `(width/2) * (height/2)` bytes
+#[derive(Clone, Copy)]
 pub struct YuvPlanes<'a> {
     /// Y (luma) plane, full resolution.
     pub y: &'a [u8],
@@ -124,6 +125,7 @@ pub(crate) fn copy_plane_tight(src: &FramePlaneView<'_>, dst: &mut [u8]) {
 /// Tightly packed (no stride padding):
 /// - `y`: `width * height` bytes
 /// - `uv`: `width * (height/2)` bytes (interleaved U,V)
+#[derive(Clone, Copy)]
 pub struct Nv12Planes<'a> {
     /// Y (luma) plane, full resolution.
     pub y: &'a [u8],

--- a/crates/reco-core/src/render/planes.rs
+++ b/crates/reco-core/src/render/planes.rs
@@ -7,6 +7,10 @@
 
 /// Borrowed YUV420P plane references for pipeline input.
 ///
+/// `Copy` because this is a bundle of slice references: duplicating it
+/// copies pointers, never pixels, which lets the N-ary stitch seam
+/// build per-camera arrays by value.
+///
 /// Tightly packed (no stride padding):
 /// - `y`: `width * height` bytes
 /// - `u`: `(width/2) * (height/2)` bytes
@@ -121,6 +125,9 @@ pub(crate) fn copy_plane_tight(src: &FramePlaneView<'_>, dst: &mut [u8]) {
 }
 
 /// Borrowed NV12 plane references for pipeline input.
+///
+/// `Copy` for the same reason as [`YuvPlanes`]: slice references only,
+/// so per-camera arrays at the stitch seam copy pointers, not pixels.
 ///
 /// Tightly packed (no stride padding):
 /// - `y`: `width * height` bytes

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -20,7 +20,7 @@
 //!   Camera at [d, 0, d] where d = framing.axis_offset
 //! ```
 
-use crate::calibration::{Framing, Topology};
+use crate::calibration::{Calibration, Framing, LShapeTopology, Topology};
 use nalgebra::{Matrix4, Translation3, UnitQuaternion};
 
 /// Computed 3D positions and rotations for the two camera planes.
@@ -53,7 +53,7 @@ impl SceneGeometry {
     /// - Left plane: `position = [0, 0, (w/2)(1 - intersect)]`, `rotation = [z_rx, π/2, z_rz]`
     /// - Right plane: `position = [(w/2)(1 - intersect), x_ty, 0]`, `rotation = [x_rx, 0, x_rz]`
     /// - Virtual camera at `[axis_offset, 0, axis_offset]`.
-    pub fn new(topology: &Topology, framing: &Framing, aspect: f32) -> Self {
+    pub fn new(topology: &LShapeTopology, framing: &Framing, aspect: f32) -> Self {
         let plane_width: f32 = 1.0;
         let half_offset = (plane_width / 2.0) * (1.0 - topology.intersect as f32);
         let axis = framing.axis_offset as f32;
@@ -69,6 +69,34 @@ impl SceneGeometry {
             right_rotation: [topology.x_rx as f32, 0.0, topology.x_rz as f32],
             camera_position: [axis, 0.0, axis],
             plane_width,
+            plane_aspect: aspect,
+        }
+    }
+
+    /// Scene geometry for a calibration document: plane placement for
+    /// the L-shape, the inert identity for plane-less topologies
+    /// (their projections never sample it). `aspect` is the source
+    /// frame `width / height`.
+    pub fn for_calibration(calibration: &Calibration, aspect: f32) -> Self {
+        match &calibration.topology {
+            Topology::LShape(t) => Self::new(t, &calibration.framing, aspect),
+            Topology::Cylinder(_) => Self::mono_identity(aspect),
+        }
+    }
+
+    /// Placeholder scene for topologies without plane placement (the
+    /// mono cylinder): planes at the origin, camera at the origin.
+    /// Mono projections never sample it - they override coverage and
+    /// carry their own geometry - but the engine's scene accessor
+    /// stays total until the scene becomes projection-owned.
+    pub fn mono_identity(aspect: f32) -> Self {
+        Self {
+            left_position: [0.0; 3],
+            left_rotation: [0.0; 3],
+            right_position: [0.0; 3],
+            right_rotation: [0.0; 3],
+            camera_position: [0.0; 3],
+            plane_width: 1.0,
             plane_aspect: aspect,
         }
     }
@@ -120,10 +148,10 @@ impl SceneGeometry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::calibration::{Framing, Topology};
+    use crate::calibration::{Framing, LShapeTopology};
 
-    fn topo(intersect: f64) -> Topology {
-        Topology {
+    fn topo(intersect: f64) -> LShapeTopology {
+        LShapeTopology {
             intersect,
             x_ty: 0.0,
             x_rz: 0.0,
@@ -156,7 +184,7 @@ mod tests {
 
     #[test]
     fn geometry_with_corrections() {
-        let topology = Topology {
+        let topology = LShapeTopology {
             intersect: 0.55,
             x_ty: 0.005,
             x_rz: 0.008,

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -85,17 +85,20 @@ impl SceneGeometry {
     }
 
     /// Placeholder scene for topologies without plane placement (the
-    /// mono cylinder): planes at the origin, camera at the origin.
-    /// Mono projections never sample it - they override coverage and
-    /// carry their own geometry - but the engine's scene accessor
-    /// stays total until the scene becomes projection-owned.
+    /// mono cylinder): planes at the origin. Mono projections never
+    /// sample the planes - they override coverage and carry their own
+    /// geometry - but the camera position must yield a valid
+    /// [`VirtualCamera`](crate::geometry::VirtualCamera) basis
+    /// (`[0, 0, 1]` = the mono convention, forward `-Z`): the pose
+    /// orientation path builds the basis from it, and the origin
+    /// would normalize a zero vector into NaN poses.
     pub fn mono_identity(aspect: f32) -> Self {
         Self {
             left_position: [0.0; 3],
             left_rotation: [0.0; 3],
             right_position: [0.0; 3],
             right_rotation: [0.0; 3],
-            camera_position: [0.0; 3],
+            camera_position: [0.0, 0.0, 1.0],
             plane_width: 1.0,
             plane_aspect: aspect,
         }

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -98,7 +98,7 @@ impl SceneGeometry {
             left_rotation: [0.0; 3],
             right_position: [0.0; 3],
             right_rotation: [0.0; 3],
-            camera_position: [0.0, 0.0, 1.0],
+            camera_position: crate::geometry::MONO_CAMERA_POSITION,
             plane_width: 1.0,
             plane_aspect: aspect,
         }

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -590,6 +590,7 @@ impl StitchSession {
 
             let stitch_t0 = std::time::Instant::now();
             let outcome = match &frame {
+                StereoFrame::Mono(yuv) => self.core.submit_frame_mono_yuv(&yuv.as_planes())?,
                 StereoFrame::Yuv420p(pair) => self
                     .core
                     .submit_frame_yuv(&pair.left.as_planes(), &pair.right.as_planes())?,

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -760,3 +760,82 @@ fn cpu_session_rejects_gpu_resident_frames() {
         "expected a typed config error, got: {err}"
     );
 }
+
+/// The mono cylinder path end to end without a GPU: single-input
+/// source -> engine mono submit (CPU cylinder stitch) -> NV12 -> sink.
+#[test]
+fn mono_cylinder_session_runs_end_to_end_without_gpu() {
+    struct MonoSource(u64);
+    impl FrameSource for MonoSource {
+        fn info(&self) -> SourceInfo {
+            SourceInfo {
+                width: W,
+                height: H,
+                fps: 30.0,
+                fps_rational: Some((30, 1)),
+                total_frames: None,
+            }
+        }
+        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+            if self.0 == 0 {
+                return Ok(None);
+            }
+            self.0 -= 1;
+            let y_size = (W * H) as usize;
+            let uv_size = ((W / 2) * (H / 2)) as usize;
+            Ok(Some(StereoFrame::Mono(YuvData {
+                y: vec![128u8; y_size],
+                u: vec![128u8; uv_size],
+                v: vec![128u8; uv_size],
+            })))
+        }
+    }
+
+    const FRAMES: u64 = 4;
+    let cal = Calibration::new(
+        vec![crate::calibration::Lens::flat(W, H)],
+        crate::calibration::CylinderTopology::default(),
+        Framing {
+            axis_offset: 0.0,
+            tilt: 0.0,
+            roll: 0.0,
+        },
+    );
+    let executor = crate::stitch::CpuExecutor::new(
+        Box::new(crate::projection::CylindricalProjection),
+        cal,
+        ViewportConfig {
+            width: 64,
+            height: 64,
+            fov_degrees: 60.0,
+        },
+        W,
+        H,
+        false,
+    )
+    .expect("mono cpu executor");
+    let mut session =
+        StitchSession::with_executor(crate::stitch::Executor::Cpu(Box::new(executor)))
+            .expect("mono session");
+
+    let encoded = Arc::new(AtomicU64::new(0));
+    session
+        .add_sink(
+            Box::new(MockEncoder::new(Arc::clone(&encoded))),
+            crate::session::SinkOptions::threaded(2),
+        )
+        .expect("attach sink");
+
+    let interrupted = AtomicBool::new(false);
+    let frames = session
+        .run(&mut MonoSource(FRAMES), u64::MAX, &interrupted, None)
+        .expect("mono run");
+    session.finish().expect("finish");
+
+    assert_eq!(frames, FRAMES);
+    assert_eq!(
+        encoded.load(Ordering::SeqCst),
+        FRAMES,
+        "every mono frame reached the sink"
+    );
+}

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -763,6 +763,11 @@ fn cpu_session_rejects_gpu_resident_frames() {
 
 /// The mono cylinder path end to end without a GPU: single-input
 /// source -> engine mono submit (CPU cylinder stitch) -> NV12 -> sink.
+///
+/// Doubles as the minimal mono-consumer example: a calibration built
+/// from `Lens::flat` + `CylinderTopology` + a zero `Framing`, a
+/// `FrameSource` yielding `StereoFrame::Mono`, and a plain session
+/// run on the CPU executor - no GPU context is created on this path.
 #[test]
 fn mono_cylinder_session_runs_end_to_end_without_gpu() {
     struct MonoSource(u64);

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -11,7 +11,7 @@ use std::sync::{Arc, Mutex};
 
 use super::StitchSession;
 use super::types::*;
-use crate::calibration::{Calibration, Framing, Lens, Topology};
+use crate::calibration::{Calibration, Framing, LShapeTopology, Lens};
 use crate::detect::detector::{Detection, DetectorError, DetectorFrame, UnifiedDetector};
 use crate::detect::director::MappedDetection;
 use crate::detect::panner::{PanContext, Panner};
@@ -33,7 +33,7 @@ fn test_calibration() -> Calibration {
     let cam = || Lens::fisheye(W, H, 32.0, 32.0, 32.0, 32.0, [0.0; 4]);
     Calibration::new(
         vec![cam(), cam()],
-        Topology {
+        LShapeTopology {
             intersect: 0.5,
             x_ty: 0.0,
             x_rz: 0.0,

--- a/crates/reco-core/src/shaders/cylindrical_mono.wgsl
+++ b/crates/reco-core/src/shaders/cylindrical_mono.wgsl
@@ -3,9 +3,12 @@
 // Models the video as a texture painted on the inside surface of a
 // cylinder of radius `focal_length`. The virtual camera sits on the
 // cylinder axis and looks outward; pan/tilt/zoom rotate the camera
-// and scale the FOV. Based on the projection used by
-// gilbertchen/actionstitch-player (180-degree cylindrical video
-// player, MIT license; see projection.rs attribution).
+// and scale the FOV. This is the established projection convention
+// for pre-stitched 180-degree panoramic footage.
+//
+// SYNC_WITH: src/stitch/cylinder.rs - this draft predates the CPU map
+// and still carries the old conventions; the mono GPU pass rewrite
+// adopts the CPU map's ray construction, theta sign, and units.
 //
 // Geometry summary:
 //   - Cylinder radius:          focal_length (world units)

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -304,6 +304,9 @@ unsafe impl Send for NvmmPlaneInfo {}
 /// - Jetson NVMM zero-copy (DMA-buf + NvBufSurface): `NvmmResident`
 #[non_exhaustive]
 pub enum StereoFrame {
+    /// A single pre-stitched panorama frame for mono topologies (the
+    /// cylinder): CPU-resident YUV420P planes of the one source.
+    Mono(YuvData),
     /// CPU-resident YUV420P planes (3 planes per camera).
     Yuv420p(FramePair),
     /// CPU-resident NV12 planes (2 planes per camera).

--- a/crates/reco-core/src/stitch/cpu.rs
+++ b/crates/reco-core/src/stitch/cpu.rs
@@ -58,8 +58,7 @@ fn check_plane(plane: &[u8], expected: usize) -> Result<(), StitchError> {
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn stitch_rgba(
     projection: &dyn Projection,
-    left: &Nv12Planes,
-    right: &Nv12Planes,
+    planes: &[Nv12Planes<'_>],
     cam: (u32, u32),
     calib: &Calibration,
     config: &ViewportConfig,
@@ -69,19 +68,18 @@ pub(crate) fn stitch_rgba(
 ) -> Result<Vec<u8>, StitchError> {
     let (cw, ch) = cam;
     check_source_dims(cw, ch)?;
+    check_camera_count(projection, planes.len())?;
     let (w, h) = (cw as usize, ch as usize);
-    check_plane(left.y, w * h)?;
-    check_plane(left.uv, w * (h / 2))?;
-    check_plane(right.y, w * h)?;
-    check_plane(right.uv, w * (h / 2))?;
+    for p in planes {
+        check_plane(p.y, w * h)?;
+        check_plane(p.uv, w * (h / 2))?;
+    }
+    let samplers: Vec<_> = planes
+        .iter()
+        .map(|p| move |u, v| sample_nv12(p, cw, ch, u, v, full_range))
+        .collect();
     Ok(stitch_with(
-        projection,
-        calib,
-        config,
-        yaw,
-        pitch,
-        |u, v| sample_nv12(left, cw, ch, u, v, full_range),
-        |u, v| sample_nv12(right, cw, ch, u, v, full_range),
+        projection, calib, config, yaw, pitch, &samplers,
     ))
 }
 
@@ -93,8 +91,7 @@ pub(crate) fn stitch_rgba(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn stitch_rgba_yuv420p(
     projection: &dyn Projection,
-    left: &YuvPlanes,
-    right: &YuvPlanes,
+    planes: &[YuvPlanes<'_>],
     cam: (u32, u32),
     calib: &Calibration,
     config: &ViewportConfig,
@@ -104,43 +101,56 @@ pub(crate) fn stitch_rgba_yuv420p(
 ) -> Result<Vec<u8>, StitchError> {
     let (cw, ch) = cam;
     check_source_dims(cw, ch)?;
+    check_camera_count(projection, planes.len())?;
     let (w, h) = (cw as usize, ch as usize);
     let chroma = (w / 2) * (h / 2);
-    check_plane(left.y, w * h)?;
-    check_plane(left.u, chroma)?;
-    check_plane(left.v, chroma)?;
-    check_plane(right.y, w * h)?;
-    check_plane(right.u, chroma)?;
-    check_plane(right.v, chroma)?;
+    for p in planes {
+        check_plane(p.y, w * h)?;
+        check_plane(p.u, chroma)?;
+        check_plane(p.v, chroma)?;
+    }
+    let samplers: Vec<_> = planes
+        .iter()
+        .map(|p| move |u, v| sample_yuv420p(p, cw, ch, u, v, full_range))
+        .collect();
     Ok(stitch_with(
-        projection,
-        calib,
-        config,
-        yaw,
-        pitch,
-        |u, v| sample_yuv420p(left, cw, ch, u, v, full_range),
-        |u, v| sample_yuv420p(right, cw, ch, u, v, full_range),
+        projection, calib, config, yaw, pitch, &samplers,
     ))
+}
+
+/// The number of input frames must match what the projection consumes;
+/// a mismatch would silently sample the wrong camera.
+fn check_camera_count(projection: &dyn Projection, planes: usize) -> Result<(), StitchError> {
+    if planes != usize::from(projection.camera_count()) {
+        return Err(StitchError::InvalidConfig(format!(
+            "projection '{}' consumes {} camera(s) but {planes} frame(s) were supplied",
+            projection.name(),
+            projection.camera_count(),
+        )));
+    }
+    Ok(())
 }
 
 /// Format-agnostic gather and composite driven by the projection.
 ///
 /// The surface list comes from [`Projection::surface_maps`] - this is the
-/// L1 dispatch made real. `sample_left` / `sample_right` map a normalised
-/// camera UV to sRGB-domain RGB for their respective source frame; the
-/// loop itself knows nothing about the pixel format.
+/// L1 dispatch made real. `samplers[i]` maps a normalised camera UV to
+/// sRGB-domain RGB for source frame `i`; the loop itself knows nothing
+/// about the pixel format.
 fn stitch_with(
     projection: &dyn Projection,
     calib: &Calibration,
     config: &ViewportConfig,
     yaw: f32,
     pitch: f32,
-    sample_left: impl Fn(f64, f64) -> [f64; 3],
-    sample_right: impl Fn(f64, f64) -> [f64; 3],
+    samplers: &[impl Fn(f64, f64) -> [f64; 3]],
 ) -> Vec<u8> {
     let surfaces = projection.surface_maps(calib, config, yaw, pitch);
-    let samplers: [&dyn Fn(f64, f64) -> [f64; 3]; 2] = [&sample_left, &sample_right];
-    composite_rgba(&surfaces, &samplers, config.width, config.height)
+    let sampler_refs: Vec<&dyn Fn(f64, f64) -> [f64; 3]> = samplers
+        .iter()
+        .map(|s| s as &dyn Fn(f64, f64) -> [f64; 3])
+        .collect();
+    composite_rgba(&surfaces, &sampler_refs, config.width, config.height)
 }
 
 /// Composite an ordered surface list into an opaque RGBA buffer.

--- a/crates/reco-core/src/stitch/cylinder.rs
+++ b/crates/reco-core/src/stitch/cylinder.rs
@@ -6,15 +6,36 @@
 //! camera and intersects the cylinder; the hit's angle and height give
 //! the video UV.
 //!
-//! SYNC_WITH: shaders/cylindrical_mono.wgsl - ray construction (top
-//! row of the output looks up), the screen-rotation fold, the
-//! theta-from-forward convention (straight ahead samples u = 0.5, u
-//! grows with yaw), and the bounds discard must match; the CPU/GPU
-//! cylinder oracle pins the agreement.
+//! The pan frame honours the calibration's rig orientation
+//! ([`Framing`] tilt/roll) exactly like the L-shape does: yaw rotates
+//! around the tilted+rolled up axis, so panning a tilted rig rolls
+//! the rendered viewport progressively toward the edges.
+//! SYNC_WITH: geometry/rig_correction.rs `rig_frame` - the frame
+//! construction must match or the two topologies disagree on what a
+//! calibrated tilt means.
+//! SYNC_WITH: shaders/cylindrical_mono.wgsl - ray construction, the
+//! theta sign, and the bounds discard; the CPU/GPU cylinder oracle
+//! pins the agreement.
 
-use crate::calibration::CylinderTopology;
+use crate::calibration::{CylinderTopology, Framing};
 use crate::render::viewport::ViewportConfig;
 use crate::stitch::{SurfaceMap, SurfaceUv};
+
+/// Rotate `v` around the unit axis `k` by `angle` (Rodrigues).
+fn rotate(v: [f64; 3], k: [f64; 3], angle: f64) -> [f64; 3] {
+    let (s, c) = angle.sin_cos();
+    let kv = [
+        k[1] * v[2] - k[2] * v[1],
+        k[2] * v[0] - k[0] * v[2],
+        k[0] * v[1] - k[1] * v[0],
+    ];
+    let kdv = k[0] * v[0] + k[1] * v[1] + k[2] * v[2];
+    [
+        v[0] * c + kv[0] * s + k[0] * kdv * (1.0 - c),
+        v[1] * c + kv[1] * s + k[1] * kdv * (1.0 - c),
+        v[2] * c + kv[2] * s + k[2] * kdv * (1.0 - c),
+    ]
+}
 
 /// Per-frame inverse map: output pixel -> pre-stitched panorama UV.
 ///
@@ -22,11 +43,11 @@ use crate::stitch::{SurfaceMap, SurfaceUv};
 /// convention; the GPU runs the same math in f32 and the oracle
 /// absorbs the difference).
 pub(crate) struct CylinderMap {
-    /// Rotated camera basis scaled for ray construction: the ray for
-    /// NDC `(x, y)` is `forward + right_eff * x * tan_h + up_eff * y * tan_v`.
+    /// Rotated camera basis for ray construction: the ray for NDC
+    /// `(x, y)` is `forward + right * x * tan_h + up * y * tan_v`.
     forward: [f64; 3],
-    right_eff: [f64; 3],
-    up_eff: [f64; 3],
+    right: [f64; 3],
+    up: [f64; 3],
     tan_half_h: f64,
     tan_half_v: f64,
     /// Cylinder radius (world units).
@@ -42,49 +63,50 @@ pub(crate) struct CylinderMap {
 impl CylinderMap {
     /// Build the map for one output frame at the given pose.
     ///
-    /// The yaw/pitch convention is [`VirtualCamera`]'s
-    /// (`yaw_pitch_to_direction`): the mono camera basis looks along
-    /// `-Z` with `+X` right and `+Y` up. Positive yaw turns toward
-    /// `-X` (VirtualCamera's sense), i.e. toward the video's left
-    /// half - what matters is that screen-right samples video-right.
-    ///
-    /// [`VirtualCamera`]: crate::geometry::VirtualCamera
+    /// The mono camera basis looks along `-Z` with `+X` right and
+    /// `+Y` up (`VirtualCamera::new([0, 0, 1])`), and the pose
+    /// composition mirrors `view_matrix`: yaw around the rig frame's
+    /// up axis, pitch around the yaw-rotated base right.
     pub fn new(
         topology: &CylinderTopology,
+        framing: &Framing,
         source_height_px: f64,
         config: &ViewportConfig,
         yaw: f32,
         pitch: f32,
     ) -> Self {
-        let (yaw, pitch) = (yaw as f64, pitch as f64);
-        let (sin_y, cos_y) = yaw.sin_cos();
-        let (sin_p, cos_p) = pitch.sin_cos();
+        let base_forward = [0.0, 0.0, -1.0];
+        let base_right = [1.0, 0.0, 0.0];
+        let world_up = [0.0, 1.0, 0.0];
 
-        // dir = base_forward*(cosP*cosY) - base_right*(cosP*sinY) + up*sinP
-        // with base_forward = -Z, base_right = +X (SYNC_WITH
-        // VirtualCamera::yaw_pitch_to_direction).
-        let forward = [-cos_p * sin_y, sin_p, -cos_p * cos_y];
-        // The camera's right stays horizontal under pitch; up completes
-        // the right-handed basis (up = right x forward).
-        let right = [cos_y, 0.0, -sin_y];
-        let up = [
-            right[1] * forward[2] - right[2] * forward[1],
-            right[2] * forward[0] - right[0] * forward[2],
-            right[0] * forward[1] - right[1] * forward[0],
-        ];
+        // Rig frame (SYNC_WITH rig_correction::rig_frame): tilt rotates
+        // forward + up around base right; roll rotates up around the
+        // tilted forward, leaving it unchanged.
+        let mut f0 = base_forward;
+        let mut u = world_up;
+        if framing.tilt.abs() > 1e-9 {
+            f0 = rotate(f0, base_right, framing.tilt);
+            u = rotate(u, base_right, framing.tilt);
+        }
+        if framing.roll.abs() > 1e-9 {
+            u = rotate(u, f0, -framing.roll);
+        }
 
-        // Fold the screen rotation (tilt around the view axis) into the
-        // basis: offsets (a, b) rotate to (a*cr - b*sr, a*sr + b*cr).
-        let (sr, cr) = topology.screen_rotation_deg.to_radians().sin_cos();
-        let right_eff = [
-            right[0] * cr + up[0] * sr,
-            right[1] * cr + up[1] * sr,
-            right[2] * cr + up[2] * sr,
-        ];
-        let up_eff = [
-            up[0] * cr - right[0] * sr,
-            up[1] * cr - right[1] * sr,
-            up[2] * cr - right[2] * sr,
+        // Pose (SYNC_WITH geometry::view_matrix): yaw around the rig
+        // up, pitch around the yaw-rotated base right; the SCREEN axes
+        // come from the rotated forward + up pair, exactly like the
+        // look-at construction - deriving right from the pitch axis
+        // would silently drop the rig roll.
+        let (yaw, pitch) = (f64::from(yaw), f64::from(pitch));
+        let pitch_axis = rotate(base_right, u, yaw);
+        let forward = rotate(rotate(f0, u, yaw), pitch_axis, pitch);
+        let up = rotate(rotate(u, u, yaw), pitch_axis, pitch);
+        // f0 and u stay orthonormal through every rotation, so the
+        // cross product is already unit length.
+        let right = [
+            forward[1] * up[2] - forward[2] * up[1],
+            forward[2] * up[0] - forward[0] * up[2],
+            forward[0] * up[1] - forward[1] * up[0],
         ];
 
         let tan_half_v = (f64::from(config.fov_degrees).to_radians() * 0.5).tan();
@@ -92,8 +114,8 @@ impl CylinderMap {
 
         Self {
             forward,
-            right_eff,
-            up_eff,
+            right,
+            up,
             tan_half_h: tan_half_v * aspect,
             tan_half_v,
             radius: topology.focal_length,
@@ -114,9 +136,9 @@ impl SurfaceMap for CylinderMap {
         let a = ndc_x * self.tan_half_h;
         let b = ndc_y * self.tan_half_v;
         let ray = [
-            self.forward[0] + self.right_eff[0] * a + self.up_eff[0] * b,
-            self.forward[1] + self.right_eff[1] * a + self.up_eff[1] * b,
-            self.forward[2] + self.right_eff[2] * a + self.up_eff[2] * b,
+            self.forward[0] + self.right[0] * a + self.up[0] * b,
+            self.forward[1] + self.right[1] * a + self.up[1] * b,
+            self.forward[2] + self.right[2] * a + self.up[2] * b,
         ];
 
         // Intersect with the cylinder x^2 + z^2 = r^2 (camera on the
@@ -169,8 +191,43 @@ mod tests {
         }
     }
 
+    fn level() -> Framing {
+        Framing {
+            axis_offset: 0.0,
+            tilt: 0.0,
+            roll: 0.0,
+        }
+    }
+
     fn map(yaw: f32, pitch: f32) -> CylinderMap {
-        CylinderMap::new(&CylinderTopology::default(), SRC_H, &cfg(), yaw, pitch)
+        CylinderMap::new(
+            &CylinderTopology::default(),
+            &level(),
+            SRC_H,
+            &cfg(),
+            yaw,
+            pitch,
+        )
+    }
+
+    /// Rig-frame map over a tall painted band, so tilted/rolled
+    /// samples at pan edges stay inside the coverage.
+    fn map_rig(tilt: f64, roll: f64, yaw: f32) -> CylinderMap {
+        CylinderMap::new(
+            &CylinderTopology {
+                video_height: Some(20_000.0),
+                ..Default::default()
+            },
+            &Framing {
+                axis_offset: 0.0,
+                tilt,
+                roll,
+            },
+            SRC_H,
+            &cfg(),
+            yaw,
+            0.0,
+        )
     }
 
     /// Half-pixel slack: the output center pixel (100, 50) sits half a
@@ -236,6 +293,7 @@ mod tests {
                 video_height: Some(100_000.0),
                 ..Default::default()
             },
+            &level(),
             SRC_H,
             &cfg(),
             0.0,
@@ -266,30 +324,60 @@ mod tests {
     }
 
     #[test]
-    fn screen_rotation_tilts_the_sampling() {
-        let level = map(0.0, 0.0);
-        let tilted = CylinderMap::new(
-            &CylinderTopology {
-                screen_rotation_deg: 10.0,
-                ..Default::default()
-            },
-            SRC_H,
-            &cfg(),
-            0.0,
-            0.0,
-        );
-        // Off-center horizontally: a tilt shifts its vertical sample.
-        let l = level.sample_uv(180, 50).unwrap();
-        let t = tilted.sample_uv(180, 50).unwrap();
+    fn rig_tilt_shifts_the_band_at_pan_center() {
+        // At yaw 0 a tilted rig frame points the rest-forward up by
+        // the tilt: the center pixel samples r*tan(t) above the video
+        // center, exactly like pitching by t (band height 20k here).
+        let tilted = map_rig(0.15, 0.0, 0.0);
+        let s = tilted.sample_uv(100, 50).unwrap();
+        let t = CylinderTopology::default();
+        let expected = 0.5 - t.focal_length * (0.15f64).tan() / 20_000.0;
+        assert!((s.v - expected).abs() < TOL, "v = {} vs {expected}", s.v);
+    }
+
+    #[test]
+    fn rig_tilt_rolls_the_view_at_pan_edges() {
+        // THE tilt signature: pan a tilted rig sideways and the
+        // horizon rolls. Level rig at yaw 0.9: two pixels on the same
+        // output row sample the same video height (symmetry). Tilted
+        // rig: they diverge. Pixels sit at +-23 deg of horizontal FOV
+        // so yaw + offset stays inside the 180-degree sweep.
+        let level_v = {
+            let m = map_rig(0.0, 0.0, 0.9);
+            let l = m.sample_uv(60, 50).unwrap();
+            let r = m.sample_uv(140, 50).unwrap();
+            (l.v - r.v).abs()
+        };
+        let tilted_v = {
+            let m = map_rig(0.15, 0.0, 0.9);
+            let l = m.sample_uv(60, 50).unwrap();
+            let r = m.sample_uv(140, 50).unwrap();
+            (l.v - r.v).abs()
+        };
+        assert!(level_v < 5e-3, "level rig stays symmetric: {level_v}");
         assert!(
-            (l.v - t.v).abs() > 1e-3,
-            "screen rotation must displace off-center samples: {} vs {}",
-            l.v,
-            t.v
+            tilted_v > 5e-3,
+            "tilted rig must roll the view when panned: {tilted_v}"
         );
-        // The center pixel stays put (it lies on the rotation axis).
-        let lc = level.sample_uv(100, 50).unwrap();
-        let tc = tilted.sample_uv(100, 50).unwrap();
-        assert!((lc.u - tc.u).abs() < TOL && (lc.v - tc.v).abs() < TOL);
+    }
+
+    #[test]
+    fn rig_roll_tilts_the_sampling_like_the_surface_roll() {
+        // Rig roll = the painted surface rolled around the view axis
+        // (the player's screen-tilt correction): off-center samples
+        // displace vertically, the center pixel stays on the axis.
+        let level_m = map_rig(0.0, 0.0, 0.0);
+        let rolled = map_rig(0.0, 0.15, 0.0);
+        let l = level_m.sample_uv(180, 50).unwrap();
+        let r = rolled.sample_uv(180, 50).unwrap();
+        assert!(
+            (l.v - r.v).abs() > 1e-3,
+            "roll must displace off-center samples: {} vs {}",
+            l.v,
+            r.v
+        );
+        let lc = level_m.sample_uv(100, 50).unwrap();
+        let rc = rolled.sample_uv(100, 50).unwrap();
+        assert!((lc.u - rc.u).abs() < TOL && (lc.v - rc.v).abs() < TOL);
     }
 }

--- a/crates/reco-core/src/stitch/cylinder.rs
+++ b/crates/reco-core/src/stitch/cylinder.rs
@@ -48,14 +48,22 @@ pub(crate) struct CylinderMap {
     forward: [f64; 3],
     right: [f64; 3],
     up: [f64; 3],
+    /// Half-frustum extents at unit distance: `tan(fov/2)` vertically,
+    /// times the output aspect horizontally. They scale NDC into the
+    /// ray basis above.
     tan_half_h: f64,
     tan_half_v: f64,
-    /// Cylinder radius (world units).
+    /// Cylinder radius (world units) = `CylinderTopology::focal_length`:
+    /// how far the painted surface sits from the axis camera.
     radius: f64,
-    /// Full angular sweep in radians.
+    /// Full angular sweep in radians: a hit's azimuth inside
+    /// `[-sweep/2, +sweep/2]` maps linearly to source U.
     sweep: f64,
-    /// Half the painted height (world units).
+    /// Half the painted height (world units): bounds the ray-cylinder
+    /// hit vertically and maps linearly to source V.
     half_height: f64,
+    /// Output dimensions, cast once here because `sample_uv` runs per
+    /// output pixel.
     out_w: f64,
     out_h: f64,
 }
@@ -63,10 +71,16 @@ pub(crate) struct CylinderMap {
 impl CylinderMap {
     /// Build the map for one output frame at the given pose.
     ///
+    /// The parameters split by lifetime: `topology` and `framing` are
+    /// the calibrated document (static), `yaw`/`pitch` are the
+    /// per-frame render pose, and the viewport FOV plus output
+    /// dimensions ride in `config`. `source_height_px` backs
+    /// `CylinderTopology::video_height`'s default.
+    ///
     /// The mono camera basis looks along `-Z` with `+X` right and
-    /// `+Y` up (`VirtualCamera::new([0, 0, 1])`), and the pose
-    /// composition mirrors `view_matrix`: yaw around the rig frame's
-    /// up axis, pitch around the yaw-rotated base right.
+    /// `+Y` up ([`VirtualCamera::mono`](crate::geometry::VirtualCamera::mono)),
+    /// and the pose composition mirrors `view_matrix`: yaw around the
+    /// rig frame's up axis, pitch around the yaw-rotated base right.
     pub fn new(
         topology: &CylinderTopology,
         framing: &Framing,
@@ -81,7 +95,9 @@ impl CylinderMap {
 
         // Rig frame (SYNC_WITH rig_correction::rig_frame): tilt rotates
         // forward + up around base right; roll rotates up around the
-        // tilted forward, leaving it unchanged.
+        // tilted forward, leaving it unchanged. The epsilon guards
+        // skip the no-op rotations so a level rig keeps bit-exact
+        // base axes.
         let mut f0 = base_forward;
         let mut u = world_up;
         if framing.tilt.abs() > 1e-9 {

--- a/crates/reco-core/src/stitch/cylinder.rs
+++ b/crates/reco-core/src/stitch/cylinder.rs
@@ -44,8 +44,9 @@ impl CylinderMap {
     ///
     /// The yaw/pitch convention is [`VirtualCamera`]'s
     /// (`yaw_pitch_to_direction`): the mono camera basis looks along
-    /// `-Z` with `+X` right and `+Y` up, and positive yaw pans toward
-    /// the video's right half (u > 0.5).
+    /// `-Z` with `+X` right and `+Y` up. Positive yaw turns toward
+    /// `-X` (VirtualCamera's sense), i.e. toward the video's left
+    /// half - what matters is that screen-right samples video-right.
     ///
     /// [`VirtualCamera`]: crate::geometry::VirtualCamera
     pub fn new(
@@ -128,9 +129,14 @@ impl SurfaceMap for CylinderMap {
         let t = self.radius / horiz;
         let hit_y = ray[1] * t;
 
-        // Angle from the world forward axis (-Z), growing with yaw:
-        // straight ahead is 0, the video's right half is positive.
-        let theta = (-ray[0]).atan2(-ray[2]);
+        // Angle from the world forward axis (-Z), positive toward
+        // screen-right (+X at pose zero): straight ahead is 0 and the
+        // right half of the output samples the right half of the
+        // video. VirtualCamera's positive yaw turns toward -X, so
+        // panning right means decreasing yaw - the sign never
+        // surfaces (coverage is symmetric and panners work in the
+        // same basis), but a mismatch here mirrors the image.
+        let theta = ray[0].atan2(-ray[2]);
 
         let u = 0.5 + theta / self.sweep;
         let v = 0.5 - hit_y / (self.half_height * 2.0);
@@ -179,17 +185,33 @@ mod tests {
     }
 
     #[test]
-    fn positive_yaw_pans_toward_higher_u() {
+    fn screen_right_samples_video_right() {
+        // The un-mirrored invariant: at pose zero, the right side of
+        // the output shows the right half of the panorama.
+        let m = map(0.0, 0.0);
+        let left_px = m.sample_uv(10, 50).unwrap();
+        let right_px = m.sample_uv(190, 50).unwrap();
+        assert!(
+            left_px.u < 0.5 && right_px.u > 0.5,
+            "screen left/right must sample video left/right: {} / {}",
+            left_px.u,
+            right_px.u
+        );
+    }
+
+    #[test]
+    fn yaw_follows_the_virtual_camera_sense() {
+        // VirtualCamera's positive yaw turns toward -X = the video's
+        // left half; the magnitude is exact (0.4 rad over a PI sweep).
         let ahead = map(0.0, 0.0).sample_uv(100, 50).unwrap();
         let panned = map(0.4, 0.0).sample_uv(100, 50).unwrap();
         assert!(
-            panned.u > ahead.u + 0.05,
-            "yaw +0.4 must move u right: {} -> {}",
+            panned.u < ahead.u - 0.05,
+            "yaw +0.4 turns toward the video's left: {} -> {}",
             ahead.u,
             panned.u
         );
-        // 0.4 rad over a PI sweep = 0.4/PI in u.
-        let expected = 0.5 + 0.4 / std::f64::consts::PI;
+        let expected = 0.5 - 0.4 / std::f64::consts::PI;
         assert!((panned.u - expected).abs() < 5e-3, "u = {}", panned.u);
     }
 

--- a/crates/reco-core/src/stitch/cylinder.rs
+++ b/crates/reco-core/src/stitch/cylinder.rs
@@ -1,0 +1,273 @@
+//! Inverse map for the mono cylindrical projection.
+//!
+//! The pre-stitched panorama is painted on the inside of a cylinder of
+//! radius `focal_length`; the virtual camera sits on the cylinder axis
+//! at the origin. Each output pixel casts a ray through the virtual
+//! camera and intersects the cylinder; the hit's angle and height give
+//! the video UV.
+//!
+//! SYNC_WITH: shaders/cylindrical_mono.wgsl - ray construction (top
+//! row of the output looks up), the screen-rotation fold, the
+//! theta-from-forward convention (straight ahead samples u = 0.5, u
+//! grows with yaw), and the bounds discard must match; the CPU/GPU
+//! cylinder oracle pins the agreement.
+
+use crate::calibration::CylinderTopology;
+use crate::render::viewport::ViewportConfig;
+use crate::stitch::{SurfaceMap, SurfaceUv};
+
+/// Per-frame inverse map: output pixel -> pre-stitched panorama UV.
+///
+/// All quantities are precomputed f64 (the CPU side's precision
+/// convention; the GPU runs the same math in f32 and the oracle
+/// absorbs the difference).
+pub(crate) struct CylinderMap {
+    /// Rotated camera basis scaled for ray construction: the ray for
+    /// NDC `(x, y)` is `forward + right_eff * x * tan_h + up_eff * y * tan_v`.
+    forward: [f64; 3],
+    right_eff: [f64; 3],
+    up_eff: [f64; 3],
+    tan_half_h: f64,
+    tan_half_v: f64,
+    /// Cylinder radius (world units).
+    radius: f64,
+    /// Full angular sweep in radians.
+    sweep: f64,
+    /// Half the painted height (world units).
+    half_height: f64,
+    out_w: f64,
+    out_h: f64,
+}
+
+impl CylinderMap {
+    /// Build the map for one output frame at the given pose.
+    ///
+    /// The yaw/pitch convention is [`VirtualCamera`]'s
+    /// (`yaw_pitch_to_direction`): the mono camera basis looks along
+    /// `-Z` with `+X` right and `+Y` up, and positive yaw pans toward
+    /// the video's right half (u > 0.5).
+    ///
+    /// [`VirtualCamera`]: crate::geometry::VirtualCamera
+    pub fn new(
+        topology: &CylinderTopology,
+        source_height_px: f64,
+        config: &ViewportConfig,
+        yaw: f32,
+        pitch: f32,
+    ) -> Self {
+        let (yaw, pitch) = (yaw as f64, pitch as f64);
+        let (sin_y, cos_y) = yaw.sin_cos();
+        let (sin_p, cos_p) = pitch.sin_cos();
+
+        // dir = base_forward*(cosP*cosY) - base_right*(cosP*sinY) + up*sinP
+        // with base_forward = -Z, base_right = +X (SYNC_WITH
+        // VirtualCamera::yaw_pitch_to_direction).
+        let forward = [-cos_p * sin_y, sin_p, -cos_p * cos_y];
+        // The camera's right stays horizontal under pitch; up completes
+        // the right-handed basis (up = right x forward).
+        let right = [cos_y, 0.0, -sin_y];
+        let up = [
+            right[1] * forward[2] - right[2] * forward[1],
+            right[2] * forward[0] - right[0] * forward[2],
+            right[0] * forward[1] - right[1] * forward[0],
+        ];
+
+        // Fold the screen rotation (tilt around the view axis) into the
+        // basis: offsets (a, b) rotate to (a*cr - b*sr, a*sr + b*cr).
+        let (sr, cr) = topology.screen_rotation_deg.to_radians().sin_cos();
+        let right_eff = [
+            right[0] * cr + up[0] * sr,
+            right[1] * cr + up[1] * sr,
+            right[2] * cr + up[2] * sr,
+        ];
+        let up_eff = [
+            up[0] * cr - right[0] * sr,
+            up[1] * cr - right[1] * sr,
+            up[2] * cr - right[2] * sr,
+        ];
+
+        let tan_half_v = (f64::from(config.fov_degrees).to_radians() * 0.5).tan();
+        let aspect = f64::from(config.width) / f64::from(config.height);
+
+        Self {
+            forward,
+            right_eff,
+            up_eff,
+            tan_half_h: tan_half_v * aspect,
+            tan_half_v,
+            radius: topology.focal_length,
+            sweep: topology.sweep_deg.to_radians(),
+            half_height: topology.video_height.unwrap_or(source_height_px) * 0.5,
+            out_w: f64::from(config.width),
+            out_h: f64::from(config.height),
+        }
+    }
+}
+
+impl SurfaceMap for CylinderMap {
+    fn sample_uv(&self, out_x: u32, out_y: u32) -> Option<SurfaceUv> {
+        // Pixel centre -> NDC, +Y up (the top output row looks up).
+        let ndc_x = (f64::from(out_x) + 0.5) / self.out_w * 2.0 - 1.0;
+        let ndc_y = 1.0 - (f64::from(out_y) + 0.5) / self.out_h * 2.0;
+
+        let a = ndc_x * self.tan_half_h;
+        let b = ndc_y * self.tan_half_v;
+        let ray = [
+            self.forward[0] + self.right_eff[0] * a + self.up_eff[0] * b,
+            self.forward[1] + self.right_eff[1] * a + self.up_eff[1] * b,
+            self.forward[2] + self.right_eff[2] * a + self.up_eff[2] * b,
+        ];
+
+        // Intersect with the cylinder x^2 + z^2 = r^2 (camera on the
+        // axis, so the positive hit is r over the ray's horizontal
+        // reach). A near-vertical ray never meets the wall.
+        let horiz = (ray[0] * ray[0] + ray[2] * ray[2]).sqrt();
+        if horiz < 1e-9 {
+            return None;
+        }
+        let t = self.radius / horiz;
+        let hit_y = ray[1] * t;
+
+        // Angle from the world forward axis (-Z), growing with yaw:
+        // straight ahead is 0, the video's right half is positive.
+        let theta = (-ray[0]).atan2(-ray[2]);
+
+        let u = 0.5 + theta / self.sweep;
+        let v = 0.5 - hit_y / (self.half_height * 2.0);
+        if !(0.0..=1.0).contains(&u) || !(0.0..=1.0).contains(&v) {
+            return None;
+        }
+
+        Some(SurfaceUv {
+            u,
+            v,
+            // Single opaque surface: the blend edge is unused.
+            edge: 1.0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 1080px source; the defaults (r=2400px, 180-deg sweep) give a
+    /// vertical band of atan(540/2400) = +-0.221 rad of pitch.
+    const SRC_H: f64 = 1080.0;
+
+    fn cfg() -> ViewportConfig {
+        ViewportConfig {
+            width: 200,
+            height: 100,
+            fov_degrees: 60.0,
+        }
+    }
+
+    fn map(yaw: f32, pitch: f32) -> CylinderMap {
+        CylinderMap::new(&CylinderTopology::default(), SRC_H, &cfg(), yaw, pitch)
+    }
+
+    /// Half-pixel slack: the output center pixel (100, 50) sits half a
+    /// pixel off the exact optical axis, which at r=2400 is ~0.013 in v.
+    const TOL: f64 = 2e-2;
+
+    #[test]
+    fn center_pixel_at_zero_pose_samples_the_video_center() {
+        let s = map(0.0, 0.0).sample_uv(100, 50).expect("center covered");
+        assert!((s.u - 0.5).abs() < TOL, "u = {}", s.u);
+        assert!((s.v - 0.5).abs() < TOL, "v = {}", s.v);
+    }
+
+    #[test]
+    fn positive_yaw_pans_toward_higher_u() {
+        let ahead = map(0.0, 0.0).sample_uv(100, 50).unwrap();
+        let panned = map(0.4, 0.0).sample_uv(100, 50).unwrap();
+        assert!(
+            panned.u > ahead.u + 0.05,
+            "yaw +0.4 must move u right: {} -> {}",
+            ahead.u,
+            panned.u
+        );
+        // 0.4 rad over a PI sweep = 0.4/PI in u.
+        let expected = 0.5 + 0.4 / std::f64::consts::PI;
+        assert!((panned.u - expected).abs() < 5e-3, "u = {}", panned.u);
+    }
+
+    #[test]
+    fn positive_pitch_looks_up_toward_lower_v() {
+        let up = map(0.0, 0.2).sample_uv(100, 50).unwrap();
+        // Center ray at pitch p hits at y = r*tan(p): v = 0.5 - r*tan(p)/h.
+        let t = CylinderTopology::default();
+        let expected = 0.5 - t.focal_length * (0.2f64).tan() / SRC_H;
+        assert!(
+            up.v < 0.5 && (up.v - expected).abs() < TOL,
+            "v = {} vs {expected}",
+            up.v
+        );
+    }
+
+    #[test]
+    fn top_output_row_samples_above_the_bottom_row() {
+        // A tall painted band so both extreme rows land inside it.
+        let tall = CylinderMap::new(
+            &CylinderTopology {
+                video_height: Some(100_000.0),
+                ..Default::default()
+            },
+            SRC_H,
+            &cfg(),
+            0.0,
+            0.0,
+        );
+        let top = tall.sample_uv(100, 0).unwrap();
+        let bottom = tall.sample_uv(100, 99).unwrap();
+        assert!(
+            top.v < bottom.v,
+            "the top output row must sample the upper video region: {} vs {}",
+            top.v,
+            bottom.v
+        );
+    }
+
+    #[test]
+    fn rays_beyond_the_sweep_are_discarded() {
+        // 180-degree sweep: looking straight backward has no coverage.
+        let s = map(std::f32::consts::PI, 0.0).sample_uv(100, 50);
+        assert!(s.is_none(), "the back of the cylinder is unpainted");
+    }
+
+    #[test]
+    fn rays_beyond_the_painted_height_are_discarded() {
+        // Looking up past the band: pitch well beyond atan(540/2400).
+        let s = map(0.0, 0.5).sample_uv(100, 50);
+        assert!(s.is_none(), "above the painted band");
+    }
+
+    #[test]
+    fn screen_rotation_tilts_the_sampling() {
+        let level = map(0.0, 0.0);
+        let tilted = CylinderMap::new(
+            &CylinderTopology {
+                screen_rotation_deg: 10.0,
+                ..Default::default()
+            },
+            SRC_H,
+            &cfg(),
+            0.0,
+            0.0,
+        );
+        // Off-center horizontally: a tilt shifts its vertical sample.
+        let l = level.sample_uv(180, 50).unwrap();
+        let t = tilted.sample_uv(180, 50).unwrap();
+        assert!(
+            (l.v - t.v).abs() > 1e-3,
+            "screen rotation must displace off-center samples: {} vs {}",
+            l.v,
+            t.v
+        );
+        // The center pixel stays put (it lies on the rotation axis).
+        let lc = level.sample_uv(100, 50).unwrap();
+        let tc = tilted.sample_uv(100, 50).unwrap();
+        assert!((lc.u - tc.u).abs() < TOL && (lc.v - tc.v).abs() < TOL);
+    }
+}

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -193,7 +193,7 @@ impl CpuExecutor {
 /// `StitchPipeline::update_calibration` does on the GPU side.
 fn derive_scene(calib: &Calibration) -> SceneGeometry {
     let aspect = calib.lenses[0].width as f32 / calib.lenses[0].height as f32;
-    SceneGeometry::new(&calib.topology, &calib.framing, aspect)
+    SceneGeometry::for_calibration(calib, aspect)
 }
 
 impl StitchExecutor for CpuExecutor {
@@ -1098,7 +1098,13 @@ impl Executor {
     /// Set the seam blend width (document field; no geometry rebuild).
     pub fn set_blend_width(&mut self, width: f32) {
         match self {
-            Executor::Cpu(c) => c.calib.topology.blend_width = width,
+            Executor::Cpu(c) => {
+                if let Some(t) = c.calib.topology.l_shape_mut() {
+                    t.blend_width = width;
+                } else {
+                    log::warn!("set_blend_width({width}) ignored: this topology has no seam");
+                }
+            }
             #[cfg(feature = "gpu")]
             Executor::Gpu(g) => g.pipeline.set_blend_width(width),
         }
@@ -1290,7 +1296,7 @@ mod tests {
             cal.framing.tilt = tilt;
             cal.framing.roll = roll;
             let plane_aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-            let scene = SceneGeometry::new(&cal.topology, &cal.framing, plane_aspect);
+            let scene = SceneGeometry::for_calibration(&cal, plane_aspect);
             let coverage = CoverageBoundary::from_calibration(&cal, &scene);
             let cam = VirtualCamera::new(&scene.camera_position);
             let fov = (coverage.max_fov_degrees() * fov_factor).min(60.0);

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -68,11 +68,11 @@ pub enum StitchError {
 /// pan. Output is `width * height * 4` sRGB-domain RGBA, identical in layout
 /// across backends (the GPU and CPU agree to ~1 LSB).
 pub trait StitchExecutor {
-    /// Stitch one NV12 frame pair to RGBA at the configured output size.
+    /// Stitch one frame set (one NV12 plane pair per camera, in
+    /// projection order) to RGBA at the configured output size.
     fn stitch(
         &mut self,
-        left: &Nv12Planes,
-        right: &Nv12Planes,
+        planes: &[Nv12Planes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError>;
@@ -143,15 +143,13 @@ impl CpuExecutor {
     /// GPU arm's readback ring).
     pub fn stitch_nv12(
         &self,
-        left: &Nv12Planes<'_>,
-        right: &Nv12Planes<'_>,
+        planes: &[Nv12Planes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
         stitch_rgba(
             self.projection.as_ref(),
-            left,
-            right,
+            planes,
             self.cam,
             &self.calib,
             &self.config,
@@ -168,15 +166,13 @@ impl CpuExecutor {
     /// inherent entry covers planar YUV sources (file decode).
     pub fn stitch_yuv(
         &self,
-        left: &YuvPlanes<'_>,
-        right: &YuvPlanes<'_>,
+        planes: &[YuvPlanes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
         super::cpu::stitch_rgba_yuv420p(
             self.projection.as_ref(),
-            left,
-            right,
+            planes,
             self.cam,
             &self.calib,
             &self.config,
@@ -199,14 +195,13 @@ fn derive_scene(calib: &Calibration) -> SceneGeometry {
 impl StitchExecutor for CpuExecutor {
     fn stitch(
         &mut self,
-        left: &Nv12Planes,
-        right: &Nv12Planes,
+        planes: &[Nv12Planes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
-        // Plane-size + dimension validation lives in stitch_rgba, which
+        // Plane-size + camera-count validation lives in stitch_rgba, which
         // returns a typed error instead of panicking on a short/truncated frame.
-        self.stitch_nv12(left, right, yaw, pitch)
+        self.stitch_nv12(planes, yaw, pitch)
     }
 
     fn output_dims(&self) -> (u32, u32) {
@@ -918,11 +913,18 @@ impl GpuExecutor {
 impl StitchExecutor for GpuExecutor {
     fn stitch(
         &mut self,
-        left: &Nv12Planes,
-        right: &Nv12Planes,
+        planes: &[Nv12Planes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
+        // The GPU upload path is stereo-shaped today; mono programs
+        // land with their own bind layout at the cylinder GPU step.
+        let [left, right] = planes else {
+            return Err(StitchError::InvalidConfig(format!(
+                "the GPU executor's synchronous stitch consumes exactly 2                  camera frames, got {}",
+                planes.len()
+            )));
+        };
         // The synchronous contract is NV12-specific; the underlying
         // upload only debug-asserts the format, so guard it here with
         // a typed error instead of corrupting textures in release.
@@ -1211,15 +1213,14 @@ impl Executor {
 impl StitchExecutor for Executor {
     fn stitch(
         &mut self,
-        left: &Nv12Planes,
-        right: &Nv12Planes,
+        planes: &[Nv12Planes<'_>],
         yaw: f32,
         pitch: f32,
     ) -> Result<Vec<u8>, StitchError> {
         match self {
-            Executor::Cpu(c) => c.stitch(left, right, yaw, pitch),
+            Executor::Cpu(c) => c.stitch(planes, yaw, pitch),
             #[cfg(feature = "gpu")]
-            Executor::Gpu(g) => g.stitch(left, right, yaw, pitch),
+            Executor::Gpu(g) => g.stitch(planes, yaw, pitch),
         }
     }
 
@@ -1338,7 +1339,7 @@ mod tests {
                     fov,
                     aspect_out,
                 );
-                let frac = black_frac(&backend.stitch(&planes, &planes, ry, rp).unwrap());
+                let frac = black_frac(&backend.stitch(&[planes, planes], ry, rp).unwrap());
                 assert!(
                     frac < 0.01,
                     "black fraction {frac:.4} at tilt={tilt} roll={roll} fov={fov:.1} target=({wy},{wp})"
@@ -1389,7 +1390,7 @@ mod tests {
             uv: &short,
         };
         // Must return a typed error, not panic (matches the GPU backend).
-        let err = backend.stitch(&planes, &planes, 0.0, 0.0).unwrap_err();
+        let err = backend.stitch(&[planes, planes], 0.0, 0.0).unwrap_err();
         assert!(matches!(err, StitchError::FrameSizeMismatch { .. }));
     }
 
@@ -1437,7 +1438,7 @@ mod tests {
         let mut outputs = Vec::new();
         for b in backends {
             assert_eq!(b.output_dims(), (out_w, out_h));
-            outputs.push(b.stitch(&left, &right, yaw, pitch).expect("stitch"));
+            outputs.push(b.stitch(&[left, right], yaw, pitch).expect("stitch"));
         }
         let (cpu_rgba, gpu_rgba) = (&outputs[0], &outputs[1]);
         assert_eq!(cpu_rgba.len(), (out_w * out_h * 4) as usize);

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -182,7 +182,11 @@ pub(crate) fn l_shape_plane_maps(
 ) -> (PlaneMap, PlaneMap) {
     // Both planes share the camera aspect (a stereo rig's two cameras match).
     let plane_aspect = calib.lenses[0].width as f32 / calib.lenses[0].height as f32;
-    let scene = SceneGeometry::new(&calib.topology, &calib.framing, plane_aspect);
+    let topology = calib
+        .topology
+        .l_shape()
+        .expect("l_shape_plane_maps requires the L-shape topology");
+    let scene = SceneGeometry::new(topology, &calib.framing, plane_aspect);
 
     let out_aspect = config.width as f32 / config.height as f32;
     let projection = opengl_to_wgpu_matrix()

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -29,6 +29,7 @@
 //! additions, gated on profiling (see the cpu-stitch portability work).
 
 mod cpu;
+pub(crate) mod cylinder;
 mod executor;
 pub(crate) mod geometry;
 #[cfg(feature = "gpu")]

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -104,7 +104,7 @@ pub(crate) mod test_support {
     // either way so the fixtures stay in sync.
     #![cfg_attr(not(feature = "gpu"), allow(dead_code))]
 
-    use crate::calibration::{Calibration, Framing, Lens, Topology};
+    use crate::calibration::{Calibration, Framing, LShapeTopology, Lens};
     #[cfg(feature = "gpu")]
     use crate::gpu::{GpuContext, GpuError};
 
@@ -123,7 +123,7 @@ pub(crate) mod test_support {
         };
         Calibration::new(
             vec![cam(), cam()],
-            Topology {
+            LShapeTopology {
                 intersect: 0.5,
                 x_ty: 0.0,
                 x_rz: 0.0,

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -298,8 +298,7 @@ mod tests {
 
         let out = stitch_rgba(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (w, h),
             &calib,
             &cfg,
@@ -329,8 +328,7 @@ mod tests {
 
         let a = stitch_rgba(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (w, h),
             &calib,
             &cfg,
@@ -341,8 +339,7 @@ mod tests {
         .unwrap();
         let b = stitch_rgba(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (w, h),
             &calib,
             &cfg,
@@ -425,8 +422,7 @@ mod tests {
         // CPU reference on the same inputs (limited range, matching the GPU default).
         let cpu_rgba = stitch_rgba(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (cam_w, cam_h),
             &calib,
             &config,
@@ -520,8 +516,7 @@ mod tests {
 
         let cpu_rgba = stitch_rgba_yuv420p(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (cam_w, cam_h),
             &calib,
             &config,
@@ -630,8 +625,7 @@ mod tests {
         let gpu_rgba = gpu_rgba.expect("gpu frame");
         let cpu_rgba = stitch_rgba(
             &LShapeProjection,
-            left,
-            right,
+            &[*left, *right],
             cam,
             calib,
             config,
@@ -943,8 +937,7 @@ mod tests {
         // ~1px of output (fov 75 over 192px ~= 0.007 rad/px); 0.01 rad is decisive.
         let perturbed = stitch_rgba(
             &LShapeProjection,
-            &left,
-            &right,
+            &[left, right],
             (cam_w, cam_h),
             &cal,
             &config,

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -579,12 +579,14 @@ impl AppState {
 
     /// Apply an edited Topology to the renderer. `preview_dirty`
     /// triggers a re-render on the next timer tick.
-    fn apply_layout(&mut self, layout: reco_core::calibration::Topology) {
+    fn apply_layout(&mut self, layout: reco_core::calibration::LShapeTopology) {
         if let Some(cal) = self.calibration.as_mut() {
-            cal.topology = layout.clone();
+            cal.topology = reco_core::calibration::Topology::LShape(layout.clone());
         }
         if let Some(bridge) = self.bridge.as_mut() {
-            bridge.engine_mut().update_topology(layout);
+            bridge
+                .engine_mut()
+                .update_topology(reco_core::calibration::Topology::LShape(layout));
             self.preview_dirty = true;
         }
         self.clamp_targets();
@@ -621,7 +623,9 @@ impl AppState {
     /// Restore Topology to the values loaded at init (or after auto-cal).
     fn reset_calibration(&mut self) {
         if let Some(base) = self.cal_baseline.clone() {
-            self.apply_layout(base.topology);
+            if let Some(t) = base.topology.l_shape() {
+                self.apply_layout(t.clone());
+            }
             self.apply_framing(base.framing);
         }
     }
@@ -922,8 +926,12 @@ impl AppState {
         // Mirror into the source-of-truth calibration so topology slider
         // edits (which clone-and-reapply the whole Topology) and saves
         // cannot revert the blend to a stale value.
-        if let Some(cal) = self.calibration.as_mut() {
-            cal.topology.blend_width = w;
+        if let Some(t) = self
+            .calibration
+            .as_mut()
+            .and_then(|cal| cal.topology.l_shape_mut())
+        {
+            t.blend_width = w;
         }
         if let Some(bridge) = self.bridge.as_mut() {
             bridge.engine_mut().set_blend_width(w);
@@ -2818,7 +2826,11 @@ fn main() -> anyhow::Result<()> {
     let state_ref = Rc::clone(&state);
     app.on_changed_cal_intersect(move |v| {
         let mut s = state_ref.borrow_mut();
-        let Some(mut layout) = s.calibration.as_ref().map(|c| c.topology.clone()) else {
+        let Some(mut layout) = s
+            .calibration
+            .as_ref()
+            .and_then(|c| c.topology.l_shape().cloned())
+        else {
             return;
         };
         layout.intersect = v as f64;
@@ -2846,7 +2858,11 @@ fn main() -> anyhow::Result<()> {
     let state_ref = Rc::clone(&state);
     app.on_changed_cal_x_ty(move |v| {
         let mut s = state_ref.borrow_mut();
-        let Some(mut layout) = s.calibration.as_ref().map(|c| c.topology.clone()) else {
+        let Some(mut layout) = s
+            .calibration
+            .as_ref()
+            .and_then(|c| c.topology.l_shape().cloned())
+        else {
             return;
         };
         layout.x_ty = v as f64;
@@ -2892,14 +2908,16 @@ fn main() -> anyhow::Result<()> {
         let mut s = state_ref.borrow_mut();
         s.reset_calibration();
         if let (Some(app), Some(layout)) = (app_weak.upgrade(), s.cal_baseline.as_ref()) {
-            app.set_cal_intersect(layout.topology.intersect as f32);
+            if let Some(t) = layout.topology.l_shape() {
+                app.set_cal_intersect(t.intersect as f32);
+                app.set_cal_x_ty(t.x_ty as f32);
+            }
             app.set_cal_camera_axis_offset(layout.framing.axis_offset as f32);
-            app.set_cal_x_ty(layout.topology.x_ty as f32);
             // The reset also restored framing tilt/roll and the topology's
             // blend in the renderer - keep the View-panel sliders in sync.
             app.set_rig_tilt((layout.framing.tilt as f32).to_degrees());
             app.set_rig_roll((layout.framing.roll as f32).to_degrees());
-            app.set_blend_width(layout.topology.blend_width);
+            app.set_blend_width(layout.topology.blend_width());
             app.set_cal_dirty(false);
         }
     });
@@ -4266,7 +4284,7 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
             let blend_width = s
                 .bridge
                 .as_ref()
-                .map(|b| b.engine().calibration().topology.blend_width);
+                .map(|b| b.engine().calibration().topology.blend_width());
             // Lens-correction strength came in via the loaded calibration and
             // the renderer was seeded with it at bridge creation; mirror it
             // into AppState so a later save re-persists the right value.
@@ -4348,9 +4366,11 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     app.set_preview_frame(img);
                 }
                 if let Some(layout) = layout {
-                    app.set_cal_intersect(layout.topology.intersect as f32);
+                    if let Some(t) = layout.topology.l_shape() {
+                        app.set_cal_intersect(t.intersect as f32);
+                        app.set_cal_x_ty(t.x_ty as f32);
+                    }
                     app.set_cal_camera_axis_offset(layout.framing.axis_offset as f32);
-                    app.set_cal_x_ty(layout.topology.x_ty as f32);
                     app.set_cal_dirty(false);
                 }
                 if let Some(rt) = rig_tilt_rad {
@@ -4552,7 +4572,7 @@ fn handle_calibration_result(
                     let blend_width = state
                         .bridge
                         .as_ref()
-                        .map(|b| b.engine().calibration().topology.blend_width);
+                        .map(|b| b.engine().calibration().topology.blend_width());
                     let lens_correction =
                         state.calibration.as_ref().map(|c| c.lenses[0].correction);
                     if let Some(lc) = lens_correction {
@@ -4615,9 +4635,11 @@ fn handle_calibration_result(
                             app.set_preview_frame(img);
                         }
                         if let Some(layout) = layout_baseline.as_ref() {
-                            app.set_cal_intersect(layout.topology.intersect as f32);
+                            if let Some(t) = layout.topology.l_shape() {
+                                app.set_cal_intersect(t.intersect as f32);
+                                app.set_cal_x_ty(t.x_ty as f32);
+                            }
                             app.set_cal_camera_axis_offset(layout.framing.axis_offset as f32);
-                            app.set_cal_x_ty(layout.topology.x_ty as f32);
                             app.set_cal_dirty(false);
                         }
                         if let Some(rt) = rig_tilt_rad {

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -579,6 +579,9 @@ pub fn create_encoder(
 pub struct FfmpegMonoSource {
     rx: std::sync::mpsc::Receiver<YuvData>,
     info: SourceInfo,
+    input: crate::stitch_job::InputPath,
+    software_decode: bool,
+    current_frame: u64,
     exhausted: bool,
 }
 
@@ -614,6 +617,9 @@ impl FfmpegMonoSource {
         Ok(Self {
             rx,
             info,
+            input: input.clone(),
+            software_decode,
+            current_frame: 0,
             exhausted: false,
         })
     }
@@ -630,7 +636,10 @@ impl reco_core::source::FrameSource for FfmpegMonoSource {
             return Ok(None);
         }
         match self.rx.recv() {
-            Ok(yuv) => Ok(Some(StereoFrame::Mono(yuv))),
+            Ok(yuv) => {
+                self.current_frame += 1;
+                Ok(Some(StereoFrame::Mono(yuv)))
+            }
             Err(_) => {
                 self.exhausted = true;
                 Ok(None)
@@ -643,17 +652,43 @@ impl reco_core::source::FrameSource for FfmpegMonoSource {
     }
 
     fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
-        let mut skipped = 0;
-        while skipped < count {
-            match self.rx.recv() {
-                Ok(_) => skipped += 1,
-                Err(_) => {
-                    self.exhausted = true;
-                    break;
+        self.seek(self.current_frame + count)?;
+        Ok(count)
+    }
+
+    fn seek(&mut self, frame: u64) -> Result<(), SourceError> {
+        // Same two strategies as `FfmpegFileSource::seek`: a short
+        // forward seek drains the already-running decoder; anything
+        // else respawns it at the target keyframe. Decode-and-discard
+        // for a large `start_time` would decode the entire prefix.
+        if frame >= self.current_frame {
+            let skip = frame - self.current_frame;
+            let max_forward = (self.info.fps * 10.0) as u64;
+            if skip <= max_forward {
+                for _ in 0..skip {
+                    match self.rx.recv() {
+                        Ok(_) => self.current_frame += 1,
+                        Err(_) => {
+                            self.exhausted = true;
+                            break;
+                        }
+                    }
                 }
+                return Ok(());
             }
         }
-        Ok(skipped)
+
+        let secs = frame as f64 / self.info.fps;
+        log::debug!("mono seek to frame {frame} ({secs:.1}s)");
+        self.rx = FfmpegFileSource::spawn_single_decoder_at(
+            self.input.clone(),
+            "mono",
+            Some(secs),
+            self.software_decode,
+        );
+        self.current_frame = frame;
+        self.exhausted = false;
+        Ok(())
     }
 }
 

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -568,6 +568,95 @@ pub fn create_encoder(
     Ok((encoder, name))
 }
 
+// -- FFmpeg Mono Source --
+
+/// Single-video source for mono topologies (pre-stitched panoramas).
+///
+/// Decodes one file on a background thread and delivers
+/// [`StereoFrame::Mono`] frames - the single-input dual of
+/// [`FfmpegFileSource`] for cylinder calibrations.
+#[cfg(feature = "ffmpeg")]
+pub struct FfmpegMonoSource {
+    rx: std::sync::mpsc::Receiver<YuvData>,
+    info: SourceInfo,
+    exhausted: bool,
+}
+
+#[cfg(feature = "ffmpeg")]
+impl FfmpegMonoSource {
+    /// Open a mono source. `software_decode` forces the software
+    /// decoder (the `--cpu` path).
+    pub fn open(
+        input: &crate::stitch_job::InputPath,
+        software_decode: bool,
+    ) -> Result<Self, SourceError> {
+        let probe_path = input.first_path();
+        reco_core::source::validate_input_path(probe_path)?;
+        let probe =
+            ffmpeg::decoder::VideoDecoder::open(probe_path).map_err(|e| SourceError::Init {
+                path: probe_path.display().to_string(),
+                reason: format!("{e}"),
+            })?;
+        let fps_r = probe.frame_rate();
+        let fps = probe.fps();
+        let total_frames = input_duration_secs(input).map(|dur| (dur * fps) as u64);
+        let info = SourceInfo {
+            width: probe.width(),
+            height: probe.height(),
+            fps,
+            fps_rational: Some((fps_r.0, fps_r.1)),
+            total_frames,
+        };
+        drop(probe);
+
+        let rx =
+            FfmpegFileSource::spawn_single_decoder_at(input.clone(), "mono", None, software_decode);
+        Ok(Self {
+            rx,
+            info,
+            exhausted: false,
+        })
+    }
+}
+
+#[cfg(feature = "ffmpeg")]
+impl reco_core::source::FrameSource for FfmpegMonoSource {
+    fn info(&self) -> SourceInfo {
+        self.info.clone()
+    }
+
+    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+        if self.exhausted {
+            return Ok(None);
+        }
+        match self.rx.recv() {
+            Ok(yuv) => Ok(Some(StereoFrame::Mono(yuv))),
+            Err(_) => {
+                self.exhausted = true;
+                Ok(None)
+            }
+        }
+    }
+
+    fn total_frames(&self) -> Option<u64> {
+        self.info.total_frames
+    }
+
+    fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
+        let mut skipped = 0;
+        while skipped < count {
+            match self.rx.recv() {
+                Ok(_) => skipped += 1,
+                Err(_) => {
+                    self.exhausted = true;
+                    break;
+                }
+            }
+        }
+        Ok(skipped)
+    }
+}
+
 // -- FFmpeg File Encoder --
 
 /// File encoder backed by FFmpeg.

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -50,6 +50,8 @@ pub struct SmartFileSource {
 
 enum SourceMode {
     Cpu(crate::adapters::FfmpegFileSource),
+    /// Single pre-stitched panorama for mono topologies.
+    Mono(crate::adapters::FfmpegMonoSource),
     #[cfg(target_os = "linux")]
     GpuZeroCopy(Box<LinuxZeroCopyState>),
     #[cfg(target_os = "macos")]
@@ -545,6 +547,33 @@ impl SmartFileSource {
         )
     }
 
+    /// Open a single-input mono source (cylinder calibrations).
+    ///
+    /// Always CPU frames - the mono GPU pass is not wired yet.
+    /// `software_decode` forces the software decoder (`--cpu`).
+    pub fn open_mono(
+        input: &crate::stitch_job::InputPath,
+        software_decode: bool,
+    ) -> Result<Self, SourceError> {
+        let source = crate::adapters::FfmpegMonoSource::open(input, software_decode)?;
+        let info = source.info();
+        log::info!(
+            "SmartFileSource: mono CPU decode ({}x{})",
+            info.width,
+            info.height
+        );
+        Ok(Self {
+            mode: SourceMode::Mono(source),
+            info,
+            pixel_format: GpuPixelFormat::Nv12,
+            full_range: false,
+            left_rotation: 0,
+            right_rotation: 0,
+            decode_mode: "CPU mono",
+            exhausted: false,
+        })
+    }
+
     /// Human-readable description of the active decode path.
     pub fn decode_mode(&self) -> &'static str {
         self.decode_mode
@@ -615,6 +644,7 @@ impl FrameSource for SmartFileSource {
 
     fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
         match &mut self.mode {
+            SourceMode::Mono(source) => source.next_frame(),
             SourceMode::Cpu(source) => {
                 let frame = source.next_frame()?;
                 if frame.is_none() {
@@ -683,11 +713,12 @@ impl FrameSource for SmartFileSource {
     }
 
     fn is_gpu_resident(&self) -> bool {
-        !matches!(self.mode, SourceMode::Cpu(_))
+        !matches!(self.mode, SourceMode::Cpu(_) | SourceMode::Mono(_))
     }
 
     fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
         match &mut self.mode {
+            SourceMode::Mono(source) => source.skip_frames(count),
             #[cfg(target_os = "linux")]
             SourceMode::GpuZeroCopy(state) => {
                 let rx = state
@@ -759,6 +790,7 @@ impl FrameSource for SmartFileSource {
         // implement `try_next_frame`, so their local flag is sufficient).
         match &self.mode {
             SourceMode::Cpu(source) => self.exhausted || source.is_exhausted(),
+            SourceMode::Mono(_) => self.exhausted,
             #[cfg(target_os = "linux")]
             SourceMode::GpuZeroCopy(_) => self.exhausted,
             #[cfg(target_os = "macos")]

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -35,7 +35,8 @@ use reco_core::source::FrameSource;
 /// is managed internally.
 pub struct StitchJob {
     left: InputPath,
-    right: InputPath,
+    /// `None` for mono (single-input) topologies.
+    right: Option<InputPath>,
     calibration: CalibrationSource,
     output: PathBuf,
 
@@ -239,7 +240,7 @@ impl StitchJob {
     ) -> Self {
         Self {
             left: left.into(),
-            right: right.into(),
+            right: Some(right.into()),
             calibration: CalibrationSource::File(calibration.as_ref().to_path_buf()),
             output: output.as_ref().to_path_buf(),
             codec: Codec::default(),
@@ -267,6 +268,24 @@ impl StitchJob {
         }
     }
 
+    /// Create a single-input job for mono topologies (the cylinder's
+    /// pre-stitched panorama). The calibration document must carry a
+    /// mono topology; [`run`](Self::run) rejects the mismatch.
+    pub fn mono(
+        input: impl Into<InputPath>,
+        calibration: impl AsRef<Path>,
+        output: impl AsRef<Path>,
+    ) -> Self {
+        let mut job = Self::new(
+            input,
+            InputPath::Single(PathBuf::new()),
+            calibration,
+            output,
+        );
+        job.right = None;
+        job
+    }
+
     /// Create a job with in-memory calibration (no JSON file needed).
     pub fn with_calibration(
         left: impl Into<InputPath>,
@@ -275,6 +294,17 @@ impl StitchJob {
         output: impl AsRef<Path>,
     ) -> Self {
         let mut job = Self::new(left, right, Path::new(""), output);
+        job.calibration = CalibrationSource::Memory(Box::new(calibration));
+        job
+    }
+
+    /// [`Self::mono`] with an in-memory calibration.
+    pub fn mono_with_calibration(
+        input: impl Into<InputPath>,
+        calibration: reco_core::calibration::Calibration,
+        output: impl AsRef<Path>,
+    ) -> Self {
+        let mut job = Self::mono(input, Path::new(""), output);
         job.calibration = CalibrationSource::Memory(Box::new(calibration));
         job
     }
@@ -575,37 +605,57 @@ impl StitchJob {
             log::info!("Sync offset: {} frames (from calibration)", effective_sync);
         }
 
+        // Input arity must match the calibration's topology before any
+        // decoder spins up.
+        let mono = cal.topology.camera_count() == 1;
+        match (mono, &self.right) {
+            (true, Some(_)) => {
+                return Err(StitchError::Other(
+                    "this calibration's topology consumes one input video, but two were \
+                     given"
+                        .into(),
+                ));
+            }
+            (false, None) => {
+                return Err(StitchError::Other(
+                    "this calibration's topology needs left and right input videos".into(),
+                ));
+            }
+            _ => {}
+        }
+
         // Decode + render strategy. --cpu never touches the GPU;
         // otherwise the GPU renders and decode is zero-copy unless
-        // forced off.
+        // forced off. Mono topologies render on the CPU executor
+        // regardless (the mono GPU pass is not wired yet).
         log::debug!(
-            "StitchJob::run: cpu_stitch={} force_cpu_decode={}",
+            "StitchJob::run: mono={mono} cpu_stitch={} force_cpu_decode={}",
             self.cpu_stitch,
             self.force_cpu_decode
         );
-        let (gpu, mut source) = if self.cpu_stitch {
-            log::info!("CPU stitch: software render + software decode, no GPU touched (--cpu)");
+        let (gpu, mut source) = if mono {
+            if !self.cpu_stitch {
+                log::info!("mono topology: software render (the mono GPU pass is not wired yet)");
+            }
             (
                 None,
-                crate::SmartFileSource::open_cpu_only(
-                    &self.left,
-                    &self.right,
-                    effective_sync,
-                    true,
-                )?,
+                crate::SmartFileSource::open_mono(&self.left, self.cpu_stitch)?,
+            )
+        } else if self.cpu_stitch {
+            log::info!("CPU stitch: software render + software decode, no GPU touched (--cpu)");
+            let right = self.right.as_ref().expect("arity checked above");
+            (
+                None,
+                crate::SmartFileSource::open_cpu_only(&self.left, right, effective_sync, true)?,
             )
         } else {
+            let right = self.right.as_ref().expect("arity checked above");
             let gpu = reco_core::gpu::GpuContext::new_blocking()?;
             let source = if self.force_cpu_decode {
                 log::info!("Force CPU decode: zero-copy disabled by --no-zero-copy");
-                crate::SmartFileSource::open_cpu_only(
-                    &self.left,
-                    &self.right,
-                    effective_sync,
-                    false,
-                )?
+                crate::SmartFileSource::open_cpu_only(&self.left, right, effective_sync, false)?
             } else {
-                crate::SmartFileSource::open(&self.left, &self.right, &gpu, effective_sync)?
+                crate::SmartFileSource::open(&self.left, right, &gpu, effective_sync)?
             };
             (Some(gpu), source)
         };
@@ -667,8 +717,9 @@ impl StitchJob {
             }
             None => {
                 gpu_name = "software (CPU)".to_string();
+                let projection = reco_core::projection::for_topology(&cal.topology);
                 let executor = reco_core::stitch::CpuExecutor::new(
-                    Box::new(reco_core::projection::LShapeProjection),
+                    projection,
                     cal,
                     viewport,
                     info.width,
@@ -739,7 +790,13 @@ impl StitchJob {
         // included so passthrough spans the whole recording, not just file 1.
         let audio_source = match &self.audio {
             AudioMode::CopyFrom(0) => Some(self.left.all_paths()),
-            AudioMode::CopyFrom(1) => Some(self.right.all_paths()),
+            AudioMode::CopyFrom(1) => match &self.right {
+                Some(right) => Some(right.all_paths()),
+                None => {
+                    log::warn!("AudioMode::CopyFrom(1) - a mono job has no right input");
+                    None
+                }
+            },
             AudioMode::CopyFrom(n) => {
                 log::warn!("AudioMode::CopyFrom({n}) - only 0 (left) and 1 (right) are valid");
                 None

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -618,17 +618,24 @@ impl StitchJob {
 
         // Build session. Blend lives on the calibration; an explicit job
         // override replaces it, otherwise the saved value renders as-is.
-        if let Some(blend) = self.blend_width {
-            log::info!(
-                "seam blend: overriding calibration value {} with {blend}",
-                cal.topology.blend_width
-            );
-            cal.topology.blend_width = blend;
-        } else {
-            log::info!(
-                "seam blend: using calibration value {}",
-                cal.topology.blend_width
-            );
+        // Seamless topologies (the mono cylinder) have no blend to set.
+        match (self.blend_width, cal.topology.l_shape_mut()) {
+            (Some(blend), Some(topology)) => {
+                log::info!(
+                    "seam blend: overriding calibration value {} with {blend}",
+                    topology.blend_width
+                );
+                topology.blend_width = blend;
+            }
+            (Some(blend), None) => {
+                log::warn!("seam blend override {blend} ignored: this topology has no seam");
+            }
+            (None, _) => {
+                log::info!(
+                    "seam blend: using calibration value {}",
+                    cal.topology.blend_width()
+                );
+            }
         }
         let viewport = reco_core::render::viewport::ViewportConfig {
             width: out_w,


### PR DESCRIPTION
## What

Step 13's first half: the mono cylinder becomes a real projection, and `reco stitch pano.mp4 -c cylinder.json` imports pre-stitched 180-degree footage end to end on the CPU executor. Serves the pre-stitched-import demand (#180, #181).

- **Calibration topology is a tagged enum**: `{"type": "l-shape" | "cylinder", ...}`; legacy untagged documents parse as L-shape unchanged. `CylinderTopology` carries the cylindrical-player convention (focal_length 2400px, 180-degree sweep; `video_height` omitted = the source's pixel height). `validate()` enforces lens count against the topology's camera count. L-shape-specific consumers (calibrate optimizer, GUI sliders, preview tuning) go through `l_shape()` accessors and no-op or warn on seamless topologies.
- **The executor stitch seam goes N-ary**: `stitch_rgba` / `StitchExecutor::stitch` take one plane set per camera in projection order with a typed camera-count check - the composite loop was already N-surface. `CameraId`, sources, and the engine submit API deliberately stay stereo-shaped; the future N-camera work starts from this seam.
- **CPU cylinder inverse map** (`stitch/cylinder.rs`): ray-cylinder intersection in `VirtualCamera`'s yaw/pitch convention with screen rotation folded into the basis, `SYNC_WITH` the shader. Fixes two draft-shader defects along the way: the theta convention (the forward ray fell outside the video) and the units mismatch (normalized height painted a sliver). Coverage is the analytic rectangle (yaw ±sweep/2, pitch ±atan(h/2r)). `CylindricalProjectionConfig` is deleted - the calibration document is the single home, and `projection::for_topology` resolves the projection a document calls for.
- **Mono input path**: `StitchCore::submit_frame_mono_yuv` (detection idles with a one-shot warning until the mono detection mapping lands; the GPU arm returns a typed error until the mono GPU pass is wired), `StereoFrame::Mono`, a single-decoder `FfmpegMonoSource` behind `SmartFileSource::open_mono`, and an optional CLI right positional with input arity checked against the calibration before any decoder spins up.

## Not in this PR (follow-up)

The mono **GPU** pass: `GpuProgram` needs a pass-shape extension (fullscreen draw, its own uniform/bind layout) and the shader needs its NV12 rework + the CPU/GPU cylinder oracle. Mono renders on the CPU executor until then, stated loudly at run time. AI tracking on mono footage (#180) needs the mono detection mapping - same follow-up.

## Testing

- Schema: legacy-untagged parse, tagged cylinder round-trip, lens-count and parameter validation.
- Cylinder map: 7 geometry unit tests (center/yaw/pitch conventions, sweep and height discards, screen rotation).
- Session: mono end-to-end in the default suite (mock mono source -> CPU cylinder stitch -> NV12 -> sink), alongside the existing stereo CPU e2e.
- GPU oracles re-run green through the N-ary seam.
- Real binary: 30/30 frames of a 1080p clip through `reco stitch <one input> -c cylinder.json` at 6.5 fps (single-threaded CPU); two-inputs-vs-cylinder-calibration rejected with a typed error; stereo paths re-verified by the full suite.