### PR TITLE
feat: improve GUI options for frame_all

### DIFF
--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -65,6 +65,8 @@ pub struct AutocamUiConfig {
     pub fov_tight: f32,
     pub fov_wide: f32,
     pub fov_default: f32,
+    /// Margin added around detected players in frame-all mode, degrees.
+    pub frame_all_margin_deg: f32,
 }
 
 /// Telemetry sink that forwards snapshots to the Slint UI thread.
@@ -308,6 +310,7 @@ pub fn run_export(
                 fov_tight: ac.fov_tight,
                 fov_wide: ac.fov_wide,
                 fov_default: ac.fov_default,
+                frame_all_margin_deg: ac.frame_all_margin_deg,
                 // Preset is the base; the visible knobs above overlay it
                 // (they mirror the preset until the user tweaks them).
                 ..reco_autocam::panners::FieldPannerConfig::from_preset_name(&ac.preset)

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -3413,6 +3413,7 @@ fn main() -> anyhow::Result<()> {
             app.set_export_fov_tight(cfg.fov_tight);
             app.set_export_fov_wide(cfg.fov_wide);
             app.set_export_fov_default(cfg.fov_default);
+            app.set_export_frame_all_margin(cfg.frame_all_margin_deg);
         }
         #[cfg(not(feature = "autocam"))]
         let _ = (&app_weak, &name);
@@ -3498,6 +3499,7 @@ fn main() -> anyhow::Result<()> {
             fov_tight: app.get_export_fov_tight(),
             fov_wide: app.get_export_fov_wide(),
             fov_default: app.get_export_fov_default(),
+            frame_all_margin_deg: app.get_export_frame_all_margin(),
         };
         let replay_enabled = app.get_export_replay_enabled();
         let events_enabled = app.get_export_events_enabled();

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -557,7 +557,15 @@ export component RecoApp inherits Window {
     in-out property <float> export-ball-weight: 0.20;
     in-out property <float> export-fov-tight: 22.0;
     in-out property <float> export-fov-wide: 58.0;
+    in-out property <float> export-frame-all-margin: 5.0;
     in-out property <float> export-fov-default: 40.0;
+
+    changed export-framing => {
+        if (self.export-framing != "frame_all") {
+            self.export-fov-tight = self.export-fov-tight.clamp(10.0, 40.0);
+            self.export-fov-wide = self.export-fov-wide.clamp(40.0, 90.0);
+        }
+    }
     in-out property <bool> export-replay-enabled: false;
     in-out property <bool> export-events-enabled: false;
 
@@ -2674,8 +2682,8 @@ export component RecoApp inherits Window {
                                 padding: 0;
                                 LabeledSlider {
                                     label: "Tight";
-                                    minimum: 10.0;
-                                    maximum: 40.0;
+                                    minimum: root.export-framing == "frame_all" ? 0.0 : 10.0;
+                                    maximum: root.export-framing == "frame_all" ? 180.0 : 40.0;
                                     value <=> root.export-fov-tight;
                                     decimals: 0;
                                 }
@@ -2688,11 +2696,18 @@ export component RecoApp inherits Window {
                                 }
                                 LabeledSlider {
                                     label: "Wide";
-                                    minimum: 40.0;
-                                    maximum: 90.0;
+                                    minimum: root.export-framing == "frame_all" ? 0.0 : 40.0;
+                                    maximum: root.export-framing == "frame_all" ? 180.0 : 90.0;
                                     value <=> root.export-fov-wide;
                                     decimals: 0;
                                 }
+                            }
+                            if root.export-framing == "frame_all" : LabeledSlider {
+                                label: "Margin";
+                                minimum: 0.0;
+                                maximum: 20.0;
+                                value <=> root.export-frame-all-margin;
+                                decimals: 0;
                             }
                         }
                     }


### PR DESCRIPTION
## Description

Allows more range for advanced settings when "frame_all" framing is selected. FOV tight and wide now allows 0-180, as well as adding a slider for FOV margin. I did **NOT** include any changes to the default values because I haven't tested extensively but so far I've gotten significantly better results with "frame_all" using:
FOV tight: 0
FOV wide: 180
FOV margin: 5

The tradeoff here is the ai tracking becomes extremely sensitive to false positive person detections, so I also set my ROI a solid 3-5 yards in from the actual sidelines.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes (the ones relevant to my changes did, seem to be existing issues elsewhere)
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass (same as above)
- [x] I added or updated tests where it made sense

## Screenshots

<img width="542" height="469" alt="Capture" src="https://github.com/user-attachments/assets/95b956bc-2792-4201-ac75-a060dda5324d" />
