### PR TITLE
Aspect ratio plumbing and topology-driven GPU projection default

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ consumer-side workaround.
 - `crates/reco-detect/` — AI detection backends (ORT CPU/GPU, TensorRT, NCNN, CoreML/Metal)
 - `crates/reco-autocam/` — AI camera control (directors, trajectory smoothing, ROI filtering)
 - `crates/reco-calibrate/` — Stereo camera calibration (AKAZE features, optimization)
+- `crates/reco-control/` — Typed control intents (pose, hotkeys) shared by interactive consumers
 - `crates/reco-gui/` — Slint GUI consumer (wgpu zero-copy preview)
 - `crates/reco-obs/` — OBS Studio source plugin (async-frame ingestion + BGRA + interactive pan/zoom)
 

--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -148,8 +148,7 @@ pub fn run_preview(
     // Precompute max FOV from coverage boundary using calibration metadata.
     // The actual CoverageBoundary is computed inside StitchCore::new().
     let max_fov = {
-        let aspect = info.width as f32 / info.height as f32;
-        let scene = reco_core::render::scene::SceneGeometry::for_calibration(&cal, aspect);
+        let scene = reco_core::render::scene::SceneGeometry::for_calibration(&cal);
         let coverage = reco_core::projection::CoverageBoundary::from_calibration(&cal, &scene);
         coverage.max_fov_degrees().min(FOV_MAX)
     };

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -63,22 +63,6 @@ pub enum CalibrationError {
         value: u32,
     },
 
-    /// Lenses disagree on aspect ratio. The plane geometry applies
-    /// `lenses[0]`'s aspect to every surface, so a mismatch would
-    /// render silently wrong.
-    #[error(
-        "lens[{index}] aspect {}x{} does not match lens[0] aspect {}x{}",
-        found.0, found.1, first.0, first.1
-    )]
-    LensAspectMismatch {
-        /// Index of the offending lens.
-        index: usize,
-        /// `lenses[0]` dimensions (width, height).
-        first: (u32, u32),
-        /// Offending lens dimensions (width, height).
-        found: (u32, u32),
-    },
-
     /// A dimension exceeds [`MAX_DIM`] and would cause an excessive GPU allocation.
     #[error("lens[{index}] {field} exceeds the maximum of {max}, got {value}")]
     DimensionTooLarge {
@@ -470,18 +454,6 @@ impl Calibration {
         }
     }
 
-    /// The shared source aspect ratio (width / height of the input
-    /// frames).
-    ///
-    /// Reads `lenses[0]`; validation guarantees the vector is
-    /// non-empty and that every lens agrees on aspect, so one value
-    /// speaks for all cameras. Distinct from the output aspect
-    /// (`ViewportConfig::aspect_ratio`) - the two differ whenever the
-    /// viewport is not shaped like the sources.
-    pub fn source_aspect(&self) -> f32 {
-        self.lenses[0].aspect()
-    }
-
     /// Load and validate a calibration from a JSON file.
     pub fn from_file(path: &std::path::Path) -> Result<Self, CalibrationLoadError> {
         use std::io::Read;
@@ -581,22 +553,6 @@ impl Calibration {
         }
         for (i, lens) in self.lenses.iter().enumerate() {
             validate_lens(lens, i)?;
-        }
-        // The plane geometry applies lenses[0]'s aspect to every
-        // surface (see `source_aspect`), so mismatched lens aspects
-        // would render silently wrong. Exact integer cross-product
-        // comparison - no float epsilon.
-        for (i, lens) in self.lenses.iter().enumerate().skip(1) {
-            let first = &self.lenses[0];
-            if u64::from(lens.width) * u64::from(first.height)
-                != u64::from(first.width) * u64::from(lens.height)
-            {
-                return Err(CalibrationError::LensAspectMismatch {
-                    index: i,
-                    first: (first.width, first.height),
-                    found: (lens.width, lens.height),
-                });
-            }
         }
         validate_topology(&self.topology)?;
         validate_framing(&self.framing, &self.topology)?;
@@ -1140,28 +1096,6 @@ mod tests {
             c.validate(),
             Err(CalibrationError::LensCountMismatch { found: 3, .. })
         ));
-    }
-
-    #[test]
-    fn rejects_mismatched_lens_aspect() {
-        // Plane geometry applies lenses[0]'s aspect to every surface;
-        // a disagreeing lens would render silently wrong.
-        let mut c = valid_cal();
-        c.lenses[1].width /= 2;
-        assert!(matches!(
-            c.validate(),
-            Err(CalibrationError::LensAspectMismatch { index: 1, .. })
-        ));
-    }
-
-    #[test]
-    fn accepts_equal_aspect_different_dims() {
-        // Same aspect at different resolutions is fine - only the
-        // ratio feeds the plane geometry.
-        let mut c = valid_cal();
-        c.lenses[1].width *= 2;
-        c.lenses[1].height *= 2;
-        assert!(c.validate().is_ok(), "got {:?}", c.validate());
     }
 
     #[test]

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -63,6 +63,22 @@ pub enum CalibrationError {
         value: u32,
     },
 
+    /// Lenses disagree on aspect ratio. The plane geometry applies
+    /// `lenses[0]`'s aspect to every surface, so a mismatch would
+    /// render silently wrong.
+    #[error(
+        "lens[{index}] aspect {}x{} does not match lens[0] aspect {}x{}",
+        found.0, found.1, first.0, first.1
+    )]
+    LensAspectMismatch {
+        /// Index of the offending lens.
+        index: usize,
+        /// `lenses[0]` dimensions (width, height).
+        first: (u32, u32),
+        /// Offending lens dimensions (width, height).
+        found: (u32, u32),
+    },
+
     /// A dimension exceeds [`MAX_DIM`] and would cause an excessive GPU allocation.
     #[error("lens[{index}] {field} exceeds the maximum of {max}, got {value}")]
     DimensionTooLarge {
@@ -220,6 +236,17 @@ impl Lens {
             distortion: [0.0; 4],
             correction: 1.0,
         }
+    }
+
+    /// Aspect ratio of this lens's calibration frame (width / height).
+    ///
+    /// Returns 1.0 if height is zero (degenerate, rejected by
+    /// validation) - mirrors `ViewportConfig::aspect_ratio`.
+    pub fn aspect(&self) -> f32 {
+        if self.height == 0 {
+            return 1.0;
+        }
+        self.width as f32 / self.height as f32
     }
 }
 
@@ -443,6 +470,18 @@ impl Calibration {
         }
     }
 
+    /// The shared source aspect ratio (width / height of the input
+    /// frames).
+    ///
+    /// Reads `lenses[0]`; validation guarantees the vector is
+    /// non-empty and that every lens agrees on aspect, so one value
+    /// speaks for all cameras. Distinct from the output aspect
+    /// (`ViewportConfig::aspect_ratio`) - the two differ whenever the
+    /// viewport is not shaped like the sources.
+    pub fn source_aspect(&self) -> f32 {
+        self.lenses[0].aspect()
+    }
+
     /// Load and validate a calibration from a JSON file.
     pub fn from_file(path: &std::path::Path) -> Result<Self, CalibrationLoadError> {
         use std::io::Read;
@@ -542,6 +581,22 @@ impl Calibration {
         }
         for (i, lens) in self.lenses.iter().enumerate() {
             validate_lens(lens, i)?;
+        }
+        // The plane geometry applies lenses[0]'s aspect to every
+        // surface (see `source_aspect`), so mismatched lens aspects
+        // would render silently wrong. Exact integer cross-product
+        // comparison - no float epsilon.
+        for (i, lens) in self.lenses.iter().enumerate().skip(1) {
+            let first = &self.lenses[0];
+            if u64::from(lens.width) * u64::from(first.height)
+                != u64::from(first.width) * u64::from(lens.height)
+            {
+                return Err(CalibrationError::LensAspectMismatch {
+                    index: i,
+                    first: (first.width, first.height),
+                    found: (lens.width, lens.height),
+                });
+            }
         }
         validate_topology(&self.topology)?;
         validate_framing(&self.framing, &self.topology)?;
@@ -1085,6 +1140,28 @@ mod tests {
             c.validate(),
             Err(CalibrationError::LensCountMismatch { found: 3, .. })
         ));
+    }
+
+    #[test]
+    fn rejects_mismatched_lens_aspect() {
+        // Plane geometry applies lenses[0]'s aspect to every surface;
+        // a disagreeing lens would render silently wrong.
+        let mut c = valid_cal();
+        c.lenses[1].width /= 2;
+        assert!(matches!(
+            c.validate(),
+            Err(CalibrationError::LensAspectMismatch { index: 1, .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_equal_aspect_different_dims() {
+        // Same aspect at different resolutions is fine - only the
+        // ratio feeds the plane geometry.
+        let mut c = valid_cal();
+        c.lenses[1].width *= 2;
+        c.lenses[1].height *= 2;
+        assert!(c.validate().is_ok(), "got {:?}", c.validate());
     }
 
     #[test]

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -277,8 +277,7 @@ const CONVERGENCE_EPS: f64 = 1e-10;
 /// use reco_core::render::scene::SceneGeometry;
 ///
 /// # fn example(cal: &Calibration) {
-/// let aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-/// let scene = SceneGeometry::for_calibration(cal, aspect);
+/// let scene = SceneGeometry::for_calibration(cal);
 /// if let Some(pos) = camera_to_panorama(CameraId::Left, 0.5, 0.5, cal, &scene) {
 ///     println!("Center of left camera maps to yaw={:.3}, pitch={:.3}", pos.yaw, pos.pitch);
 /// }
@@ -458,8 +457,7 @@ mod tests {
     use crate::calibration::{Calibration, Framing, LShapeTopology, Lens};
 
     fn test_scene(cal: &Calibration) -> SceneGeometry {
-        let aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-        SceneGeometry::for_calibration(cal, aspect)
+        SceneGeometry::for_calibration(cal)
     }
 
     fn test_calibration() -> Calibration {
@@ -944,7 +942,7 @@ mod tests {
     #[test]
     fn cylindrical_coverage_is_the_analytic_rectangle() {
         let cal = cylinder_cal();
-        let scene = SceneGeometry::for_calibration(&cal, 3840.0 / 1080.0);
+        let scene = SceneGeometry::for_calibration(&cal);
         let coverage = CylindricalProjection.coverage(&cal, &scene);
         let (y_lo, y_hi) = coverage.yaw_range();
         assert!(

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -122,8 +122,7 @@ impl StitchPipeline {
         }
 
         let output_format = output_format.into();
-        let aspect = calibration.lenses[0].width as f32 / calibration.lenses[0].height as f32;
-        let scene = SceneGeometry::for_calibration(&calibration, aspect);
+        let scene = SceneGeometry::for_calibration(&calibration);
         let renderer = Renderer::new(
             &gpu,
             program,
@@ -263,8 +262,7 @@ impl StitchPipeline {
     ///
     /// No GPU pipeline recreation needed - only the uniform data changes.
     pub fn update_calibration(&mut self, calibration: Calibration) {
-        let aspect = calibration.lenses[0].width as f32 / calibration.lenses[0].height as f32;
-        self.scene = SceneGeometry::for_calibration(&calibration, aspect);
+        self.scene = SceneGeometry::for_calibration(&calibration);
         self.calibration = calibration;
         log::debug!("Pipeline calibration updated");
     }

--- a/crates/reco-core/src/render/renderer.rs
+++ b/crates/reco-core/src/render/renderer.rs
@@ -957,7 +957,7 @@ impl Renderer {
         blend_width: f32,
         target_view: &wgpu::TextureView,
     ) {
-        let aspect = viewport.config.width as f32 / viewport.config.height as f32;
+        let aspect = viewport.config.aspect_ratio();
         let encoder = self.encode_stitch_pass(
             gpu,
             scene,

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -75,9 +75,9 @@ impl SceneGeometry {
 
     /// Scene geometry for a calibration document: plane placement for
     /// the L-shape, the inert identity for plane-less topologies
-    /// (their projections never sample it). `aspect` is the source
-    /// frame `width / height`.
-    pub fn for_calibration(calibration: &Calibration, aspect: f32) -> Self {
+    /// (their projections never sample it).
+    pub fn for_calibration(calibration: &Calibration) -> Self {
+        let aspect = calibration.source_aspect();
         match &calibration.topology {
             Topology::LShape(t) => Self::new(t, &calibration.framing, aspect),
             Topology::Cylinder(_) => Self::mono_identity(aspect),

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -77,7 +77,11 @@ impl SceneGeometry {
     /// the L-shape, the inert identity for plane-less topologies
     /// (their projections never sample it).
     pub fn for_calibration(calibration: &Calibration) -> Self {
-        let aspect = calibration.source_aspect();
+        // Known limitation: the plane math sizes BOTH planes with lens
+        // 0's aspect. Per-lens aspects are a supported calibration
+        // (validation deliberately does not reject them) and land when
+        // each projection derives its own scene.
+        let aspect = calibration.lenses[0].aspect();
         match &calibration.topology {
             Topology::LShape(t) => Self::new(t, &calibration.framing, aspect),
             Topology::Cylinder(_) => Self::mono_identity(aspect),

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -188,8 +188,7 @@ impl CpuExecutor {
 /// executor's cache and its mutation paths - mirrors what
 /// `StitchPipeline::update_calibration` does on the GPU side.
 fn derive_scene(calib: &Calibration) -> SceneGeometry {
-    let aspect = calib.lenses[0].width as f32 / calib.lenses[0].height as f32;
-    SceneGeometry::for_calibration(calib, aspect)
+    SceneGeometry::for_calibration(calib)
 }
 
 impl StitchExecutor for CpuExecutor {
@@ -237,8 +236,9 @@ pub struct GpuExecutorConfig {
     /// for consumers that prefer to swizzle on upload instead of on
     /// readback.
     pub output_format: wgpu::TextureFormat,
-    /// Projection to stitch through. `None` selects the two-camera
-    /// L-shape ([`LShapeProjection`](crate::projection::LShapeProjection)).
+    /// Projection to stitch through. `None` resolves the projection
+    /// matching the calibration's topology (the out-of-tree injection
+    /// point for custom projections).
     pub projection: Option<Box<dyn Projection>>,
     /// Whether source YUV uses full-range (JPEG) quantization.
     pub full_range: bool,
@@ -309,9 +309,14 @@ impl GpuExecutor {
     /// pull an async runtime into non-test code; callers create it via
     /// [`GpuContext::new`].
     pub fn new(gpu: GpuContext, config: GpuExecutorConfig) -> Result<Self, StitchError> {
-        let projection: Box<dyn Projection> = config
-            .projection
-            .unwrap_or_else(|| Box::new(crate::projection::LShapeProjection));
+        let projection: Box<dyn Projection> = config.projection.unwrap_or_else(|| {
+            let p = crate::projection::for_topology(&config.calibration.topology);
+            log::debug!(
+                "no projection injected; resolved '{}' from the calibration topology",
+                p.name()
+            );
+            p
+        });
         if usize::from(projection.camera_count()) != config.calibration.lenses.len() {
             return Err(StitchError::InvalidConfig(format!(
                 "projection '{}' consumes {} cameras but the calibration has {} lenses",
@@ -1296,8 +1301,7 @@ mod tests {
             let mut cal = calib(cam_w, cam_h);
             cal.framing.tilt = tilt;
             cal.framing.roll = roll;
-            let plane_aspect = cal.lenses[0].width as f32 / cal.lenses[0].height as f32;
-            let scene = SceneGeometry::for_calibration(&cal, plane_aspect);
+            let scene = SceneGeometry::for_calibration(&cal);
             let coverage = CoverageBoundary::from_calibration(&cal, &scene);
             let cam = VirtualCamera::new(&scene.camera_position);
             let fov = (coverage.max_fov_degrees() * fov_factor).min(60.0);

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -180,15 +180,16 @@ pub(crate) fn l_shape_plane_maps(
     yaw: f32,
     pitch: f32,
 ) -> (PlaneMap, PlaneMap) {
-    // Both planes share the camera aspect (a stereo rig's two cameras match).
-    let plane_aspect = calib.lenses[0].width as f32 / calib.lenses[0].height as f32;
+    // Both planes share the source aspect (validation enforces that
+    // every lens agrees on it).
+    let plane_aspect = calib.source_aspect();
     let topology = calib
         .topology
         .l_shape()
         .expect("l_shape_plane_maps requires the L-shape topology");
     let scene = SceneGeometry::new(topology, &calib.framing, plane_aspect);
 
-    let out_aspect = config.width as f32 / config.height as f32;
+    let out_aspect = config.aspect_ratio();
     let projection = opengl_to_wgpu_matrix()
         * Perspective3::new(
             out_aspect,

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -180,9 +180,10 @@ pub(crate) fn l_shape_plane_maps(
     yaw: f32,
     pitch: f32,
 ) -> (PlaneMap, PlaneMap) {
-    // Both planes share the source aspect (validation enforces that
-    // every lens agrees on it).
-    let plane_aspect = calib.source_aspect();
+    // Known limitation: both planes are sized with lens 0's aspect.
+    // Mixed-aspect rigs are valid calibrations; honoring each lens's
+    // own aspect lands when the L-shape derives its own scene.
+    let plane_aspect = calib.lenses[0].aspect();
     let topology = calib
         .topology
         .l_shape()


### PR DESCRIPTION
## Description

Plumbing ahead of the projection self-ownership refactor:

- `Lens::aspect()` names the per-lens source aspect; inline `width / height` recomputations replaced, and the existing `ViewportConfig::aspect_ratio()` is now used at the output-aspect sites.
- `SceneGeometry::for_calibration` drops its aspect parameter (always derivable from the calibration). CLI preview previously passed the decoded video's aspect and could build a scene disagreeing with the stitch path.
- A `GpuExecutorConfig` without an injected projection now resolves the projection from the calibration topology instead of hardcoding the L-shape; the choice is logged. Mono submits keep failing behind the typed not-wired guard until the mono GPU pass lands.
- Lenses with differing aspects remain valid calibrations: that constraint is each projection's call. The plane math's lens-0 limitation is documented at the sites that embody it.
- AGENTS.md crate list gains reco-control.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense