### PR TITLE
Add manual ground/top-plane tilt correction

### DIFF
--- a/crates/reco-autocam/src/panners/field.rs
+++ b/crates/reco-autocam/src/panners/field.rs
@@ -1151,6 +1151,12 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             Framing {
                 axis_offset: 0.24,

--- a/crates/reco-autocam/src/panners/sweep.rs
+++ b/crates/reco-autocam/src/panners/sweep.rs
@@ -108,6 +108,12 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             Framing {
                 axis_offset: 0.24,

--- a/crates/reco-calibrate/src/optimizer.rs
+++ b/crates/reco-calibrate/src/optimizer.rs
@@ -416,6 +416,12 @@ impl Optimizer for NelderMeadOptimizer {
             },
             z_rz: 0.0,
             blend_width: reco_core::calibration::DEFAULT_BLEND_WIDTH,
+            ground_tilt_x: 0.0,
+            ground_tilt_z: 0.0,
+            top_tilt_x: 0.0,
+            top_tilt_z: 0.0,
+            ground_tilt_band_width: reco_core::calibration::DEFAULT_TILT_BAND_WIDTH,
+            top_tilt_band_width: reco_core::calibration::DEFAULT_TILT_BAND_WIDTH,
         };
         let framing = Framing {
             axis_offset: params.cam_d,

--- a/crates/reco-core/src/calibration.rs
+++ b/crates/reco-core/src/calibration.rs
@@ -197,6 +197,19 @@ impl Lens {
             correction: 1.0,
         }
     }
+
+    /// Focal-scale constant `k` for [`Topology::ground_tilt_x`] /
+    /// [`Topology::ground_tilt_z`]'s `warp_ground_y(t, c, k)`: `k = fy /
+    /// (2 * width)`.
+    ///
+    /// `t` (plane-space y) is measured in "plane width = 1.0" units, not
+    /// pixels or radians, so the tangent-addition identity `warp(t, c, k)
+    /// = (k*c + t) / (1 - c*t/k)` needs this same-units focal-length scale
+    /// to convert between them - treating `t` as if it already equaled
+    /// `tan(phi)` applies the identity at the wrong scale.
+    pub fn ground_tilt_k(&self) -> f64 {
+        self.fy / (2.0 * self.width as f64)
+    }
 }
 
 /// 3D placement of the source planes plus the overlap seam.
@@ -227,6 +240,46 @@ pub struct Topology {
     /// Seam blend width as a fraction of the plane overlap. `0.0` = hard seam.
     #[serde(default = "default_blend_width")]
     pub blend_width: f32,
+
+    /// Ground-plane tilt correction for the x-plane (`lenses[1]`'s
+    /// content). `tan(theta)` of an additional tilt applied only near the
+    /// bottom of frame (close to the camera, where flat two-plane
+    /// parallax error is largest); mathematically identity below a
+    /// near-field threshold and ramped in via a smoothstep beyond it. See
+    /// [`crate::stitch::geometry::band_limited_ground_warp`] for the
+    /// exact math (the GPU shader is a direct port of that same
+    /// function). `0.0` (the default) is a no-op - existing calibrations
+    /// render unchanged.
+    #[serde(default)]
+    pub ground_tilt_x: f64,
+    /// Ground-plane tilt correction for the z-plane (`lenses[0]`'s
+    /// content). See [`Self::ground_tilt_x`] - same math, applied to the
+    /// other plane.
+    #[serde(default)]
+    pub ground_tilt_z: f64,
+    /// Top-of-frame tilt correction for the x-plane. Mirror image of
+    /// [`Self::ground_tilt_x`]: same band-limited tangent warp, but
+    /// one-sided the other way - identity at and below the horizon,
+    /// ramped in only near the top of frame (far background content).
+    /// `0.0` (the default) is a no-op.
+    #[serde(default)]
+    pub top_tilt_x: f64,
+    /// Top-of-frame tilt correction for the z-plane. See
+    /// [`Self::top_tilt_x`] - same math, applied to the other plane.
+    #[serde(default)]
+    pub top_tilt_z: f64,
+    /// `|t|` at and beyond which [`Self::ground_tilt_x`]/
+    /// [`Self::ground_tilt_z`]'s correction reaches full strength (the
+    /// ramp always *starts* at the fixed
+    /// [`crate::stitch::geometry::GROUND_TILT_BAND_START`] - only where
+    /// it finishes is adjustable). Default `0.16`.
+    #[serde(default = "default_tilt_band_width")]
+    pub ground_tilt_band_width: f64,
+    /// Same as [`Self::ground_tilt_band_width`], for
+    /// [`Self::top_tilt_x`]/[`Self::top_tilt_z`]'s band (ramping toward
+    /// the top of frame instead of the bottom).
+    #[serde(default = "default_tilt_band_width")]
+    pub top_tilt_band_width: f64,
 }
 
 /// Default seam blend width for calibrations that do not specify one.
@@ -235,6 +288,20 @@ pub const DEFAULT_BLEND_WIDTH: f32 = 0.05;
 
 fn default_blend_width() -> f32 {
     DEFAULT_BLEND_WIDTH
+}
+
+/// Inclusive bound for [`Topology::ground_tilt_x`]/`z`/[`Topology::top_tilt_x`]/`z`.
+pub const TILT_RANGE: f64 = 0.3;
+/// Inclusive bounds for [`Topology::ground_tilt_band_width`]/[`Topology::top_tilt_band_width`].
+pub const TILT_BAND_WIDTH_RANGE: (f64, f64) = (0.09, 0.4);
+
+/// Default tilt-correction band width - matches the value this band was
+/// fixed at before the field existed, so existing calibrations render
+/// unchanged.
+pub const DEFAULT_TILT_BAND_WIDTH: f64 = 0.16;
+
+fn default_tilt_band_width() -> f64 {
+    DEFAULT_TILT_BAND_WIDTH
 }
 
 /// The virtual camera's calibrated coordinate frame: the axis/orientation that
@@ -598,6 +665,48 @@ fn validate_topology(t: &Topology) -> Result<(), CalibrationError> {
         });
     }
 
+    for (name, val) in [
+        ("topology.ground_tilt_x", t.ground_tilt_x),
+        ("topology.ground_tilt_z", t.ground_tilt_z),
+        ("topology.top_tilt_x", t.top_tilt_x),
+        ("topology.top_tilt_z", t.top_tilt_z),
+    ] {
+        if !val.is_finite() {
+            return Err(CalibrationError::NonFiniteFloat {
+                field: name.to_owned(),
+                value: format!("{val}"),
+            });
+        }
+        if !(-TILT_RANGE..=TILT_RANGE).contains(&val) {
+            return Err(CalibrationError::OutOfRange {
+                field: name.to_owned(),
+                value: val,
+                min: -TILT_RANGE,
+                max: TILT_RANGE,
+            });
+        }
+    }
+
+    for (name, val) in [
+        ("topology.ground_tilt_band_width", t.ground_tilt_band_width),
+        ("topology.top_tilt_band_width", t.top_tilt_band_width),
+    ] {
+        if !val.is_finite() {
+            return Err(CalibrationError::NonFiniteFloat {
+                field: name.to_owned(),
+                value: format!("{val}"),
+            });
+        }
+        if !(TILT_BAND_WIDTH_RANGE.0..=TILT_BAND_WIDTH_RANGE.1).contains(&val) {
+            return Err(CalibrationError::OutOfRange {
+                field: name.to_owned(),
+                value: val,
+                min: TILT_BAND_WIDTH_RANGE.0,
+                max: TILT_BAND_WIDTH_RANGE.1,
+            });
+        }
+    }
+
     Ok(())
 }
 
@@ -721,6 +830,12 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             framing: Framing {
                 axis_offset: 0.25,

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -487,6 +487,43 @@ impl StitchCore {
         self.executor.set_blend_width(width);
     }
 
+    /// Set the ground-plane tilt correction for the x-plane (per-frame
+    /// uniform; coverage unaffected). See
+    /// [`crate::calibration::Topology::ground_tilt_x`].
+    pub fn set_ground_tilt_x(&mut self, tilt: f32) {
+        self.executor.set_ground_tilt_x(tilt);
+    }
+
+    /// Set the ground-plane tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::ground_tilt_z`].
+    pub fn set_ground_tilt_z(&mut self, tilt: f32) {
+        self.executor.set_ground_tilt_z(tilt);
+    }
+
+    /// Set the top-of-frame tilt correction for the x-plane. See
+    /// [`crate::calibration::Topology::top_tilt_x`].
+    pub fn set_top_tilt_x(&mut self, tilt: f32) {
+        self.executor.set_top_tilt_x(tilt);
+    }
+
+    /// Set the top-of-frame tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::top_tilt_z`].
+    pub fn set_top_tilt_z(&mut self, tilt: f32) {
+        self.executor.set_top_tilt_z(tilt);
+    }
+
+    /// Set the ground-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::ground_tilt_band_width`].
+    pub fn set_ground_tilt_band_width(&mut self, width: f32) {
+        self.executor.set_ground_tilt_band_width(width);
+    }
+
+    /// Set the top-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::top_tilt_band_width`].
+    pub fn set_top_tilt_band_width(&mut self, width: f32) {
+        self.executor.set_top_tilt_band_width(width);
+    }
+
     /// Set the lens-correction strength on every lens (`0` = pinhole,
     /// `1` = full KB4).
     pub fn set_lens_correction_amount(&mut self, amount: f32) {

--- a/crates/reco-core/src/detect/panner.rs
+++ b/crates/reco-core/src/detect/panner.rs
@@ -247,6 +247,12 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             Framing {
                 axis_offset: 0.24,

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -497,6 +497,12 @@ mod tests {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             Framing {
                 axis_offset: 0.2398,

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -271,6 +271,42 @@ impl StitchPipeline {
         self.calibration.topology.blend_width = width;
     }
 
+    /// Set the ground-plane tilt correction for the x-plane (per-frame
+    /// uniform; no scene rebuild). See [`crate::calibration::Topology::ground_tilt_x`].
+    pub fn set_ground_tilt_x(&mut self, tilt: f32) {
+        self.calibration.topology.ground_tilt_x = tilt as f64;
+    }
+
+    /// Set the ground-plane tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::ground_tilt_z`].
+    pub fn set_ground_tilt_z(&mut self, tilt: f32) {
+        self.calibration.topology.ground_tilt_z = tilt as f64;
+    }
+
+    /// Set the top-of-frame tilt correction for the x-plane. See
+    /// [`crate::calibration::Topology::top_tilt_x`].
+    pub fn set_top_tilt_x(&mut self, tilt: f32) {
+        self.calibration.topology.top_tilt_x = tilt as f64;
+    }
+
+    /// Set the top-of-frame tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::top_tilt_z`].
+    pub fn set_top_tilt_z(&mut self, tilt: f32) {
+        self.calibration.topology.top_tilt_z = tilt as f64;
+    }
+
+    /// Set the ground-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::ground_tilt_band_width`].
+    pub fn set_ground_tilt_band_width(&mut self, width: f32) {
+        self.calibration.topology.ground_tilt_band_width = width as f64;
+    }
+
+    /// Set the top-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::top_tilt_band_width`].
+    pub fn set_top_tilt_band_width(&mut self, width: f32) {
+        self.calibration.topology.top_tilt_band_width = width as f64;
+    }
+
     /// Update calibration parameters. Recomputes [`SceneGeometry`] from the
     /// new layout. Takes effect on the next render call (uniforms are rebuilt
     /// each frame from the stored calibration and scene).

--- a/crates/reco-core/src/render/renderer.rs
+++ b/crates/reco-core/src/render/renderer.rs
@@ -59,6 +59,8 @@ pub(crate) struct GpuUniforms {
     color_offset_blend: [f32; 4],
     flags: [u32; 4],
     pub(crate) lens_preview: [f32; 4],
+    ground_tilt: [f32; 4],
+    top_tilt: [f32; 4],
 }
 
 /// Vertex with 3D position and UV coordinates.
@@ -840,6 +842,21 @@ impl Renderer {
             self.is_full_range,
         );
         left_uniforms.lens_preview[0] = calibration.lenses[0].correction;
+        // z-plane (lenses[0]) <-> left - see the same swap-convention note
+        // in stitch::geometry::l_shape_plane_maps.
+        let left_k = calibration.lenses[0].ground_tilt_k() as f32;
+        left_uniforms.ground_tilt = [
+            calibration.topology.ground_tilt_z as f32,
+            left_k,
+            scene.plane_aspect,
+            0.0,
+        ];
+        left_uniforms.top_tilt = [
+            calibration.topology.top_tilt_z as f32,
+            left_k,
+            calibration.topology.ground_tilt_band_width as f32,
+            calibration.topology.top_tilt_band_width as f32,
+        ];
 
         let right_mvp = projection * view * scene.model_matrix_right();
         let mut right_uniforms = build_gpu_uniforms(
@@ -852,6 +869,20 @@ impl Renderer {
             self.is_full_range,
         );
         right_uniforms.lens_preview[0] = calibration.lenses[1].correction;
+        // x-plane (lenses[1]) <-> right.
+        let right_k = calibration.lenses[1].ground_tilt_k() as f32;
+        right_uniforms.ground_tilt = [
+            calibration.topology.ground_tilt_x as f32,
+            right_k,
+            scene.plane_aspect,
+            0.0,
+        ];
+        right_uniforms.top_tilt = [
+            calibration.topology.top_tilt_x as f32,
+            right_k,
+            calibration.topology.ground_tilt_band_width as f32,
+            calibration.topology.top_tilt_band_width as f32,
+        ];
 
         gpu.queue.write_buffer(
             &self.left.uniform_buffer,
@@ -1196,6 +1227,10 @@ pub(crate) fn build_gpu_uniforms(
         // Full correction for normal stitching. LensPreviewRenderer
         // overrides this field for the single-camera preview mode.
         lens_preview: [1.0, 0.0, 0.0, 0.0],
+        // Overwritten by encode_stitch_pass right after construction
+        // (mirrors lens_preview[0] above) - identity here (tilt=0.0).
+        ground_tilt: [0.0, 0.0, 0.0, 0.0],
+        top_tilt: [0.0, 0.0, 0.0, 0.0],
     }
 }
 

--- a/crates/reco-core/src/render/scene.rs
+++ b/crates/reco-core/src/render/scene.rs
@@ -131,6 +131,12 @@ mod tests {
             x_rx: 0.0,
             z_rz: 0.0,
             blend_width: 0.05,
+            ground_tilt_x: 0.0,
+            ground_tilt_z: 0.0,
+            top_tilt_x: 0.0,
+            top_tilt_z: 0.0,
+            ground_tilt_band_width: 0.16,
+            top_tilt_band_width: 0.16,
         }
     }
 
@@ -164,6 +170,12 @@ mod tests {
             x_rx: 0.0,
             z_rz: 0.0,
             blend_width: 0.05,
+            ground_tilt_x: 0.0,
+            ground_tilt_z: 0.0,
+            top_tilt_x: 0.0,
+            top_tilt_z: 0.0,
+            ground_tilt_band_width: 0.16,
+            top_tilt_band_width: 0.16,
         };
 
         let geom = SceneGeometry::new(&topology, &framing(0.24), 16.0 / 9.0);

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -41,6 +41,12 @@ fn test_calibration() -> Calibration {
             x_rx: 0.0,
             z_rz: 0.0,
             blend_width: 0.05,
+            ground_tilt_x: 0.0,
+            ground_tilt_z: 0.0,
+            top_tilt_x: 0.0,
+            top_tilt_z: 0.0,
+            ground_tilt_band_width: 0.16,
+            top_tilt_band_width: 0.16,
         },
         Framing {
             axis_offset: 0.25,

--- a/crates/reco-core/src/shaders/fisheye.wgsl
+++ b/crates/reco-core/src/shaders/fisheye.wgsl
@@ -28,6 +28,19 @@ struct Uniforms {
     // lens_preview.x: correction_amount (0.0 = no correction, 1.0 = full KB4)
     // lens_preview.y: split_view (> 0.5 = left half uncorrected, right half corrected)
     lens_preview: vec4<f32>,
+    // Ground-plane tilt correction (see band_limited_ground_warp below).
+    // ground_tilt.x: tan(theta) tilt scalar, 0.0 = no-op
+    // ground_tilt.y: k, this camera's ground_tilt_k() focal-scale constant
+    // ground_tilt.z: this plane's aspect ratio (width / height)
+    // ground_tilt.w: unused padding
+    ground_tilt: vec4<f32>,
+    // Top-of-frame tilt correction - mirror of ground_tilt, one-sided the
+    // other way (see band_limited_top_warp below).
+    // top_tilt.x: tan(theta) tilt scalar, 0.0 = no-op
+    // top_tilt.y: k (same value as ground_tilt.y - same camera)
+    // top_tilt.z: ground_tilt_band_width (full-strength threshold)
+    // top_tilt.w: top_tilt_band_width (full-strength threshold)
+    top_tilt: vec4<f32>,
 };
 
 // YUV420P plane textures (Y = full res R8Unorm, U/V = half res R8Unorm)
@@ -159,6 +172,60 @@ fn sample_yuv(uv: vec2<f32>) -> vec4<f32> {
     return vec4<f32>(rgb, 1.0);
 }
 
+// ---- Ground/top-plane tilt correction ----
+//
+// Adds a small additional tilt near the bottom (ground) or top of frame,
+// where the flat two-plane approximation's parallax error is largest.
+// `t` (plane-space y) is in "plane width = 1.0" units; `c = tan(theta)`
+// is the extra tilt; `k = fy / (2 * width)` converts between them (see
+// `Lens::ground_tilt_k`'s doc comment for the full derivation). Must
+// mirror `stitch::geometry::{warp_ground_y, band_limited_ground_warp,
+// band_limited_top_warp}` exactly - the CPU dual is a correctness oracle
+// for this shader, not just a GPU-less fallback.
+
+const GROUND_TILT_BAND_START: f32 = 0.08;
+
+fn smoothstep_band(edge0: f32, edge1: f32, x: f32) -> f32 {
+    let t = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+    return t * t * (3.0 - 2.0 * t);
+}
+
+fn warp_ground_y(t: f32, c: f32, k: f32) -> f32 {
+    var denom = 1.0 - c * t / k;
+    if abs(denom) < 1e-9 {
+        denom = select(-1e-9, 1e-9, denom >= 0.0);
+    }
+    return (k * c + t) / denom;
+}
+
+// One-sided in t, NOT abs(t): t>0 (near field/ground) ramps in, t<=0
+// (above the horizon) is always identity.
+fn band_limited_ground_warp(t: f32, c: f32, k: f32, band_full: f32) -> f32 {
+    if t <= 0.0 {
+        return t;
+    }
+    let full = max(band_full, GROUND_TILT_BAND_START + 0.01);
+    let weight = smoothstep_band(GROUND_TILT_BAND_START, full, t);
+    if weight == 0.0 {
+        return t;
+    }
+    return t + weight * (warp_ground_y(t, c, k) - t);
+}
+
+// Mirror of band_limited_ground_warp: t>=0 (at/below the horizon) is
+// always identity, only t<0 (top of frame) ramps in.
+fn band_limited_top_warp(t: f32, c: f32, k: f32, band_full: f32) -> f32 {
+    if t >= 0.0 {
+        return t;
+    }
+    let full = max(band_full, GROUND_TILT_BAND_START + 0.01);
+    let weight = smoothstep_band(GROUND_TILT_BAND_START, full, -t);
+    if weight == 0.0 {
+        return t;
+    }
+    return t + weight * (warp_ground_y(t, c, k) - t);
+}
+
 // ---- Fragment shader ----
 
 @fragment
@@ -169,7 +236,24 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     // (Done here instead of the vertex shader because some embedded
     // GPU drivers pass vertex attributes directly to the fragment
     // stage, ignoring vertex shader output for user-defined varyings.)
-    let uv = in.uv * 2.0 - vec2<f32>(0.5);
+    var uv = in.uv * 2.0 - vec2<f32>(0.5);
+
+    // Ground/top tilt: operates on the RAW (non-extended) fragment uv.y,
+    // BEFORE the extended-UV remap above is used for anything else -
+    // must stay in this exact order to match the CPU dual in
+    // stitch::geometry::PlaneMap::sample_uv.
+    if u.ground_tilt.x != 0.0 || u.top_tilt.x != 0.0 {
+        var plane_y = (in.uv.y - 0.5) / u.ground_tilt.z;
+        if u.ground_tilt.x != 0.0 {
+            plane_y = band_limited_ground_warp(
+                plane_y, u.ground_tilt.x, u.ground_tilt.y, u.top_tilt.z);
+        }
+        if u.top_tilt.x != 0.0 {
+            plane_y = band_limited_top_warp(
+                plane_y, u.top_tilt.x, u.top_tilt.y, u.top_tilt.w);
+        }
+        uv.y = (plane_y * u.ground_tilt.z + 0.5) * 2.0 - 0.5;
+    }
 
     // Raw mode: negative correction bypasses all projection math
     // and samples the input texture directly at the fragment UV.

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -531,6 +531,66 @@ impl Executor {
         }
     }
 
+    /// Set the ground-plane tilt correction for the x-plane (document
+    /// field; no geometry rebuild). See [`crate::calibration::Topology::ground_tilt_x`].
+    pub fn set_ground_tilt_x(&mut self, tilt: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.ground_tilt_x = tilt as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_ground_tilt_x(tilt),
+        }
+    }
+
+    /// Set the ground-plane tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::ground_tilt_z`].
+    pub fn set_ground_tilt_z(&mut self, tilt: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.ground_tilt_z = tilt as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_ground_tilt_z(tilt),
+        }
+    }
+
+    /// Set the top-of-frame tilt correction for the x-plane. See
+    /// [`crate::calibration::Topology::top_tilt_x`].
+    pub fn set_top_tilt_x(&mut self, tilt: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.top_tilt_x = tilt as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_top_tilt_x(tilt),
+        }
+    }
+
+    /// Set the top-of-frame tilt correction for the z-plane. See
+    /// [`crate::calibration::Topology::top_tilt_z`].
+    pub fn set_top_tilt_z(&mut self, tilt: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.top_tilt_z = tilt as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_top_tilt_z(tilt),
+        }
+    }
+
+    /// Set the ground-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::ground_tilt_band_width`].
+    pub fn set_ground_tilt_band_width(&mut self, width: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.ground_tilt_band_width = width as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_ground_tilt_band_width(width),
+        }
+    }
+
+    /// Set the top-tilt band's full-strength threshold. See
+    /// [`crate::calibration::Topology::top_tilt_band_width`].
+    pub fn set_top_tilt_band_width(&mut self, width: f32) {
+        match self {
+            Executor::Cpu(c) => c.calib.topology.top_tilt_band_width = width as f64,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(g) => g.pipeline.set_top_tilt_band_width(width),
+        }
+    }
+
     /// Set the lens-correction strength on every lens, clamped to `[0, 1]`.
     pub fn set_lens_correction_amount(&mut self, amount: f32) {
         match self {
@@ -834,5 +894,64 @@ mod tests {
         assert_eq!(cpu_rgba.len(), (out_w * out_h * 4) as usize);
         Agreement::compare(gpu_rgba, cpu_rgba)
             .assert_within(AgreementBounds::DEFAULT, "backend cpu-vs-gpu");
+    }
+
+    #[test]
+    #[cfg(feature = "gpu")]
+    fn cpu_and_gpu_backends_agree_with_ground_top_tilt() {
+        let Some(gpu) = gpu_or_skip() else {
+            return;
+        };
+
+        let (cam_w, cam_h) = (192u32, 108u32);
+        let (out_w, out_h) = (160u32, 90u32);
+        let mut calib = calib(cam_w, cam_h);
+        calib.topology.ground_tilt_x = 0.09;
+        calib.topology.ground_tilt_z = -0.07;
+        calib.topology.top_tilt_x = -0.05;
+        calib.topology.top_tilt_z = 0.06;
+        calib.topology.ground_tilt_band_width = 0.22;
+        calib.topology.top_tilt_band_width = 0.18;
+        let config = ViewportConfig {
+            width: out_w,
+            height: out_h,
+            ..Default::default()
+        };
+        let (ly, luv) = nv12(cam_w, cam_h, 0);
+        let (ry, ruv) = nv12(cam_w, cam_h, 30);
+        let left = Nv12Planes { y: &ly, uv: &luv };
+        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let (yaw, pitch) = (0.08f32, -0.04f32);
+
+        let mut cpu = CpuExecutor::new(
+            Box::new(crate::projection::LShapeProjection),
+            calib.clone(),
+            config.clone(),
+            cam_w,
+            cam_h,
+            false,
+        )
+        .expect("cpu backend");
+        let mut gpu = GpuExecutor::new(
+            gpu,
+            GpuExecutorConfig {
+                viewport: config,
+                ..GpuExecutorConfig::new(calib, cam_w, cam_h, InputFormat::Nv12)
+            },
+        )
+        .expect("gpu backend");
+
+        let backends: [&mut dyn StitchExecutor; 2] = [&mut cpu, &mut gpu];
+        let mut outputs = Vec::new();
+        for b in backends {
+            assert_eq!(b.output_dims(), (out_w, out_h));
+            outputs.push(b.stitch(&left, &right, yaw, pitch).expect("stitch"));
+        }
+        let (cpu_rgba, gpu_rgba) = (&outputs[0], &outputs[1]);
+        assert_eq!(cpu_rgba.len(), (out_w * out_h * 4) as usize);
+        Agreement::compare(gpu_rgba, cpu_rgba).assert_within(
+            AgreementBounds::DEFAULT,
+            "backend cpu-vs-gpu, ground/top tilt active",
+        );
     }
 }

--- a/crates/reco-core/src/stitch/geometry.rs
+++ b/crates/reco-core/src/stitch/geometry.rs
@@ -18,6 +18,55 @@ use crate::render::viewport::ViewportConfig;
 
 use super::{SurfaceMap, SurfaceUv};
 
+/// `|t|` at and beyond which a tilt correction reaches full strength - the
+/// ramp always *starts* here; see [`crate::calibration::Topology::ground_tilt_band_width`].
+pub(crate) const GROUND_TILT_BAND_START: f64 = 0.08;
+
+fn smoothstep_band(edge0: f64, edge1: f64, x: f64) -> f64 {
+    let t = ((x - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Tangent-addition warp: adds an extra tilt `c = tan(theta)` to
+/// plane-space `t`, scaled by `k` (see [`Lens::ground_tilt_k`]).
+/// `warp_ground_y(t, 0.0, k) == t` exactly, so `c = 0` is a no-op.
+pub(crate) fn warp_ground_y(t: f64, c: f64, k: f64) -> f64 {
+    let mut denom = 1.0 - c * t / k;
+    if denom.abs() < 1e-9 {
+        denom = if denom >= 0.0 { 1e-9 } else { -1e-9 };
+    }
+    (k * c + t) / denom
+}
+
+/// Ground-plane tilt: one-sided in `t` (NOT `t.abs()`) - `t > 0` (near
+/// field/ground) ramps in via a smoothstep from [`GROUND_TILT_BAND_START`]
+/// to `band_full`; `t <= 0` (above the horizon) is always identity.
+pub(crate) fn band_limited_ground_warp(t: f64, c: f64, k: f64, band_full: f64) -> f64 {
+    if t <= 0.0 {
+        return t;
+    }
+    let full = band_full.max(GROUND_TILT_BAND_START + 0.01);
+    let weight = smoothstep_band(GROUND_TILT_BAND_START, full, t);
+    if weight == 0.0 {
+        return t;
+    }
+    t + weight * (warp_ground_y(t, c, k) - t)
+}
+
+/// Mirror of [`band_limited_ground_warp`]: `t >= 0` is always identity,
+/// only `t < 0` (top of frame) ramps in.
+pub(crate) fn band_limited_top_warp(t: f64, c: f64, k: f64, band_full: f64) -> f64 {
+    if t >= 0.0 {
+        return t;
+    }
+    let full = band_full.max(GROUND_TILT_BAND_START + 0.01);
+    let weight = smoothstep_band(GROUND_TILT_BAND_START, full, -t);
+    if weight == 0.0 {
+        return t;
+    }
+    t + weight * (warp_ground_y(t, c, k) - t)
+}
+
 /// Inverse map for one camera plane of the L-shape projection.
 ///
 /// Holds the per-frame inverse rasterization (output NDC -> plane-local) plus
@@ -50,10 +99,21 @@ pub(crate) struct PlaneMap {
     d: [f64; 4],
     /// Lens-correction amount in `[0, 1]` (`1` = full KB4, `0` = pinhole).
     correction: f64,
+    /// Ground-plane tilt `c = tan(theta)`, `0.0` = no-op.
+    ground_tilt_c: f64,
+    /// Top-of-frame tilt `c = tan(theta)`, `0.0` = no-op.
+    top_tilt_c: f64,
+    /// Shared focal-scale constant for both bands (see [`Lens::ground_tilt_k`]).
+    tilt_k: f64,
+    /// Ground band's full-strength threshold.
+    ground_tilt_band_width: f64,
+    /// Top band's full-strength threshold.
+    top_tilt_band_width: f64,
 }
 
 impl PlaneMap {
     /// Build a plane map from its model matrix and the shared view-projection.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         model: Matrix4<f32>,
         view_projection: &Matrix4<f32>,
@@ -62,6 +122,10 @@ impl PlaneMap {
         out_h: u32,
         plane_aspect: f64,
         correction: f64,
+        ground_tilt_c: f64,
+        top_tilt_c: f64,
+        ground_tilt_band_width: f64,
+        top_tilt_band_width: f64,
     ) -> Self {
         let mvp = view_projection * model;
         // For a quad at z = 0 in model space, `clip = M3 * [x, y, 1]` where M3
@@ -94,6 +158,11 @@ impl PlaneMap {
             cy_n: cam.cy / h,
             d: cam.distortion,
             correction,
+            ground_tilt_c,
+            top_tilt_c,
+            tilt_k: cam.ground_tilt_k(),
+            ground_tilt_band_width,
+            top_tilt_band_width,
         }
     }
 }
@@ -132,13 +201,41 @@ impl SurfaceMap for PlaneMap {
         // Plane-local -> texture UV (inverse of the quad vertex layout:
         // `local_x = uv_x - 0.5`, `local_y = (0.5 - uv_y) / aspect`).
         let uv_x = local_x + 0.5;
-        let uv_y = 0.5 - local_y * self.plane_aspect;
+        let mut uv_y = 0.5 - local_y * self.plane_aspect;
 
         // The GPU rasterizes a FINITE quad (uv in [0,1]); the extended-UV remap
         // below only widens the sampling domain, not the rasterized footprint.
         // Reject pixels outside the quad so CPU coverage matches the GPU's.
+        // This must run on the RAW (pre-warp) uv_y - the tilt warp only
+        // remaps which source pixel a covered output pixel samples, it
+        // never changes which output pixels the quad covers (mirrors the
+        // GPU: rasterization uses the unwarped vertex positions, only the
+        // fragment shader applies the warp).
         if !(0.0..=1.0).contains(&uv_x) || !(0.0..=1.0).contains(&uv_y) {
             return None;
+        }
+
+        // Ground/top tilt: same order as fisheye.wgsl's fs_main - warp the
+        // raw (non-extended) uv_y before the extended-UV remap below.
+        if self.ground_tilt_c != 0.0 || self.top_tilt_c != 0.0 {
+            let mut plane_y = (uv_y - 0.5) / self.plane_aspect;
+            if self.ground_tilt_c != 0.0 {
+                plane_y = band_limited_ground_warp(
+                    plane_y,
+                    self.ground_tilt_c,
+                    self.tilt_k,
+                    self.ground_tilt_band_width,
+                );
+            }
+            if self.top_tilt_c != 0.0 {
+                plane_y = band_limited_top_warp(
+                    plane_y,
+                    self.top_tilt_c,
+                    self.tilt_k,
+                    self.top_tilt_band_width,
+                );
+            }
+            uv_y = plane_y * self.plane_aspect + 0.5;
         }
 
         // Shader's extended-UV remap (`uv * 2 - 0.5`) that widens the sampling
@@ -203,6 +300,9 @@ pub(crate) fn l_shape_plane_maps(
     let view_projection = projection * view;
 
     let aspect = plane_aspect as f64;
+    // z-plane (lenses[0]) <-> left, x-plane (lenses[1]) <-> right - verified
+    // against SceneGeometry::model_matrix_left/right's actual plane
+    // positions, not assumed from naming.
     let left = PlaneMap::new(
         scene.model_matrix_left(),
         &view_projection,
@@ -211,6 +311,10 @@ pub(crate) fn l_shape_plane_maps(
         config.height,
         aspect,
         calib.lenses[0].correction as f64,
+        calib.topology.ground_tilt_z,
+        calib.topology.top_tilt_z,
+        calib.topology.ground_tilt_band_width,
+        calib.topology.top_tilt_band_width,
     );
     let right = PlaneMap::new(
         scene.model_matrix_right(),
@@ -220,6 +324,10 @@ pub(crate) fn l_shape_plane_maps(
         config.height,
         aspect,
         calib.lenses[1].correction as f64,
+        calib.topology.ground_tilt_x,
+        calib.topology.top_tilt_x,
+        calib.topology.ground_tilt_band_width,
+        calib.topology.top_tilt_band_width,
     );
     (left, right)
 }
@@ -250,5 +358,51 @@ mod tests {
             covered > 0,
             "expected the planes to cover part of the output"
         );
+    }
+
+    #[test]
+    fn warp_ground_y_is_identity_when_tilt_is_zero() {
+        for t in [-0.5, -0.1, 0.0, 0.1, 0.3, 0.5] {
+            assert_eq!(warp_ground_y(t, 0.0, 0.19), t);
+        }
+    }
+
+    #[test]
+    fn band_limited_ground_warp_is_identity_below_band_start() {
+        // At and below GROUND_TILT_BAND_START, and everywhere t <= 0, the
+        // ramp weight is zero regardless of the tilt scalar.
+        let c = 0.1;
+        let k = 0.19;
+        let band_full = 0.2;
+        for t in [-0.3, -0.01, 0.0, GROUND_TILT_BAND_START] {
+            assert_eq!(band_limited_ground_warp(t, c, k, band_full), t);
+        }
+    }
+
+    #[test]
+    fn band_limited_ground_warp_shifts_beyond_band_start() {
+        let c = 0.1;
+        let k = 0.19;
+        let band_full = 0.2;
+        let t = 0.25; // beyond band_full, ramp fully engaged
+        let warped = band_limited_ground_warp(t, c, k, band_full);
+        assert_ne!(warped, t, "expected the tilt to actually shift t");
+        // At full ramp strength the result should equal the raw warp.
+        assert!((warped - warp_ground_y(t, c, k)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn band_limited_top_warp_is_one_sided_the_other_way() {
+        // Mirror of band_limited_ground_warp: identity for t >= 0 (at/below
+        // the horizon), ramps in only for t < 0 (top of frame).
+        let c = -0.08;
+        let k = 0.19;
+        let band_full = 0.2;
+        for t in [0.0, 0.01, 0.3] {
+            assert_eq!(band_limited_top_warp(t, c, k, band_full), t);
+        }
+        let t = -0.25;
+        let warped = band_limited_top_warp(t, c, k, band_full);
+        assert_ne!(warped, t, "expected the tilt to actually shift t");
     }
 }

--- a/crates/reco-core/src/stitch/mod.rs
+++ b/crates/reco-core/src/stitch/mod.rs
@@ -129,6 +129,12 @@ pub(crate) mod test_support {
                 x_rx: 0.0,
                 z_rz: 0.0,
                 blend_width: 0.05,
+                ground_tilt_x: 0.0,
+                ground_tilt_z: 0.0,
+                top_tilt_x: 0.0,
+                top_tilt_z: 0.0,
+                ground_tilt_band_width: 0.16,
+                top_tilt_band_width: 0.16,
             },
             Framing {
                 axis_offset: 0.25,

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -931,6 +931,83 @@ impl AppState {
         }
     }
 
+    /// Set the ground-plane tilt correction for the x-plane. Reasonable
+    /// range is -0.3 to 0.3 (matches the calibration slider).
+    fn set_ground_tilt_x(&mut self, tilt: f32) {
+        let tilt = tilt.clamp(-0.3, 0.3);
+        // Mirror into the source-of-truth calibration, same rationale as
+        // set_blend_width - Topology slider edits clone-and-reapply the
+        // whole Topology and must not revert this to a stale value.
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.ground_tilt_x = tilt as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_ground_tilt_x(tilt);
+            self.preview_dirty = true;
+        }
+    }
+
+    /// Set the ground-plane tilt correction for the z-plane.
+    fn set_ground_tilt_z(&mut self, tilt: f32) {
+        let tilt = tilt.clamp(-0.3, 0.3);
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.ground_tilt_z = tilt as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_ground_tilt_z(tilt);
+            self.preview_dirty = true;
+        }
+    }
+
+    /// Set the top-of-frame tilt correction for the x-plane.
+    fn set_top_tilt_x(&mut self, tilt: f32) {
+        let tilt = tilt.clamp(-0.3, 0.3);
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.top_tilt_x = tilt as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_top_tilt_x(tilt);
+            self.preview_dirty = true;
+        }
+    }
+
+    /// Set the top-of-frame tilt correction for the z-plane.
+    fn set_top_tilt_z(&mut self, tilt: f32) {
+        let tilt = tilt.clamp(-0.3, 0.3);
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.top_tilt_z = tilt as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_top_tilt_z(tilt);
+            self.preview_dirty = true;
+        }
+    }
+
+    /// Set the ground-tilt band's full-strength threshold. Range 0.09-0.4
+    /// (matches the calibration slider).
+    fn set_ground_tilt_band_width(&mut self, width: f32) {
+        let width = width.clamp(0.09, 0.4);
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.ground_tilt_band_width = width as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_ground_tilt_band_width(width);
+            self.preview_dirty = true;
+        }
+    }
+
+    /// Set the top-tilt band's full-strength threshold.
+    fn set_top_tilt_band_width(&mut self, width: f32) {
+        let width = width.clamp(0.09, 0.4);
+        if let Some(cal) = self.calibration.as_mut() {
+            cal.topology.top_tilt_band_width = width as f64;
+        }
+        if let Some(bridge) = self.bridge.as_mut() {
+            bridge.engine_mut().set_top_tilt_band_width(width);
+            self.preview_dirty = true;
+        }
+    }
+
     fn set_rig_tilt(&mut self, deg: f32) {
         if let Some(cal) = self.calibration.as_mut() {
             cal.framing.tilt = (deg as f64).to_radians();
@@ -2765,6 +2842,60 @@ fn main() -> anyhow::Result<()> {
 
     let state_ref = Rc::clone(&state);
     let app_weak = app.as_weak();
+    app.on_changed_cal_ground_tilt_x(move |v| {
+        state_ref.borrow_mut().set_ground_tilt_x(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_cal_ground_tilt_z(move |v| {
+        state_ref.borrow_mut().set_ground_tilt_z(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_cal_top_tilt_x(move |v| {
+        state_ref.borrow_mut().set_top_tilt_x(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_cal_top_tilt_z(move |v| {
+        state_ref.borrow_mut().set_top_tilt_z(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_cal_ground_tilt_band_width(move |v| {
+        state_ref.borrow_mut().set_ground_tilt_band_width(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
+    app.on_changed_cal_top_tilt_band_width(move |v| {
+        state_ref.borrow_mut().set_top_tilt_band_width(v);
+        if let Some(app) = app_weak.upgrade() {
+            app.set_cal_dirty(true);
+        }
+    });
+
+    let state_ref = Rc::clone(&state);
+    let app_weak = app.as_weak();
     app.on_changed_rig_tilt(move |deg| {
         state_ref.borrow_mut().set_rig_tilt(deg);
         if let Some(app) = app_weak.upgrade() {
@@ -2902,6 +3033,12 @@ fn main() -> anyhow::Result<()> {
             app.set_rig_tilt((layout.framing.tilt as f32).to_degrees());
             app.set_rig_roll((layout.framing.roll as f32).to_degrees());
             app.set_blend_width(layout.topology.blend_width);
+            app.set_cal_ground_tilt_x(layout.topology.ground_tilt_x as f32);
+            app.set_cal_ground_tilt_z(layout.topology.ground_tilt_z as f32);
+            app.set_cal_top_tilt_x(layout.topology.top_tilt_x as f32);
+            app.set_cal_top_tilt_z(layout.topology.top_tilt_z as f32);
+            app.set_cal_ground_tilt_band_width(layout.topology.ground_tilt_band_width as f32);
+            app.set_cal_top_tilt_band_width(layout.topology.top_tilt_band_width as f32);
             app.set_cal_dirty(false);
         }
     });
@@ -4352,6 +4489,14 @@ fn try_init_and_update(state: &Rc<RefCell<AppState>>, app_weak: &slint::Weak<Rec
                     app.set_cal_intersect(layout.topology.intersect as f32);
                     app.set_cal_camera_axis_offset(layout.framing.axis_offset as f32);
                     app.set_cal_x_ty(layout.topology.x_ty as f32);
+                    app.set_cal_ground_tilt_x(layout.topology.ground_tilt_x as f32);
+                    app.set_cal_ground_tilt_z(layout.topology.ground_tilt_z as f32);
+                    app.set_cal_top_tilt_x(layout.topology.top_tilt_x as f32);
+                    app.set_cal_top_tilt_z(layout.topology.top_tilt_z as f32);
+                    app.set_cal_ground_tilt_band_width(
+                        layout.topology.ground_tilt_band_width as f32,
+                    );
+                    app.set_cal_top_tilt_band_width(layout.topology.top_tilt_band_width as f32);
                     app.set_cal_dirty(false);
                 }
                 if let Some(rt) = rig_tilt_rad {
@@ -4619,6 +4764,16 @@ fn handle_calibration_result(
                             app.set_cal_intersect(layout.topology.intersect as f32);
                             app.set_cal_camera_axis_offset(layout.framing.axis_offset as f32);
                             app.set_cal_x_ty(layout.topology.x_ty as f32);
+                            app.set_cal_ground_tilt_x(layout.topology.ground_tilt_x as f32);
+                            app.set_cal_ground_tilt_z(layout.topology.ground_tilt_z as f32);
+                            app.set_cal_top_tilt_x(layout.topology.top_tilt_x as f32);
+                            app.set_cal_top_tilt_z(layout.topology.top_tilt_z as f32);
+                            app.set_cal_ground_tilt_band_width(
+                                layout.topology.ground_tilt_band_width as f32,
+                            );
+                            app.set_cal_top_tilt_band_width(
+                                layout.topology.top_tilt_band_width as f32,
+                            );
                             app.set_cal_dirty(false);
                         }
                         if let Some(rt) = rig_tilt_rad {

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -517,6 +517,12 @@ export component RecoApp inherits Window {
     in-out property <float> cal-intersect: 0.0;
     in-out property <float> cal-camera-axis-offset: 0.0;
     in-out property <float> cal-x-ty: 0.0;
+    in-out property <float> cal-ground-tilt-x: 0.0;
+    in-out property <float> cal-ground-tilt-z: 0.0;
+    in-out property <float> cal-top-tilt-x: 0.0;
+    in-out property <float> cal-top-tilt-z: 0.0;
+    in-out property <float> cal-ground-tilt-band-width: 0.16;
+    in-out property <float> cal-top-tilt-band-width: 0.16;
     in-out property <bool> cal-dirty: false;  // true when user has edited
 
     // Side panel visibility (unified Controls + Stats).
@@ -712,6 +718,12 @@ export component RecoApp inherits Window {
     callback changed-cal-intersect(float);
     callback changed-cal-camera-axis-offset(float);
     callback changed-cal-x-ty(float);
+    callback changed-cal-ground-tilt-x(float);
+    callback changed-cal-ground-tilt-z(float);
+    callback changed-cal-top-tilt-x(float);
+    callback changed-cal-top-tilt-z(float);
+    callback changed-cal-ground-tilt-band-width(float);
+    callback changed-cal-top-tilt-band-width(float);
     callback save-calibration();
     callback reset-calibration();
     // Live lens parameter editing. Fires on any of the 8 sliders per
@@ -1533,6 +1545,60 @@ export component RecoApp inherits Window {
                             value <=> root.cal-x-ty;
                             decimals: 3;
                             changed(v) => { root.changed-cal-x-ty(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Ground tilt X";
+                            minimum: -0.3;
+                            maximum: 0.3;
+                            value <=> root.cal-ground-tilt-x;
+                            decimals: 5;
+                            changed(v) => { root.changed-cal-ground-tilt-x(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Ground tilt Z";
+                            minimum: -0.3;
+                            maximum: 0.3;
+                            value <=> root.cal-ground-tilt-z;
+                            decimals: 5;
+                            changed(v) => { root.changed-cal-ground-tilt-z(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Top tilt X";
+                            minimum: -0.3;
+                            maximum: 0.3;
+                            value <=> root.cal-top-tilt-x;
+                            decimals: 5;
+                            changed(v) => { root.changed-cal-top-tilt-x(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Top tilt Z";
+                            minimum: -0.3;
+                            maximum: 0.3;
+                            value <=> root.cal-top-tilt-z;
+                            decimals: 5;
+                            changed(v) => { root.changed-cal-top-tilt-z(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Ground tilt band width";
+                            minimum: 0.09;
+                            maximum: 0.4;
+                            value <=> root.cal-ground-tilt-band-width;
+                            decimals: 2;
+                            changed(v) => { root.changed-cal-ground-tilt-band-width(v); }
+                        }
+
+                        LabeledSlider {
+                            label: "Top tilt band width";
+                            minimum: 0.09;
+                            maximum: 0.4;
+                            value <=> root.cal-top-tilt-band-width;
+                            decimals: 2;
+                            changed(v) => { root.changed-cal-top-tilt-band-width(v); }
                         }
 
                         // Saving lives in one place: the "Save Calibration"


### PR DESCRIPTION
Reimplemented from scratch against the current architecture, like the
seam-positioning and color-matching PRs before it — neither `ground_tilt`
nor `top_tilt` exist anywhere in the current codebase.

Adds a small additional tilt near the bottom (ground) or top of frame,
where the flat two-plane approximation's parallax error is largest:
`tan(theta)` of extra tilt, applied only within an adjustable band near
the respective edge (identity everywhere else), via the tangent-addition
identity `warp(t, c, k) = (k*c + t) / (1 - c*t/k)` where `t` is plane-space
y and `k = fy / (2*width)` converts between "plane width = 1.0" units and
the tangent-addition math's own scale.

New `Topology` fields: `ground_tilt_x`/`z`, `top_tilt_x`/`z` (the tilt
scalars — manual-only, no automatic fitting path exists for either), and
`ground_tilt_band_width`/`top_tilt_band_width` (the ramp's adjustable
full-strength threshold; the ramp always *starts* at a fixed
`GROUND_TILT_BAND_START = 0.08`). All six default to a no-op (`0.0` tilt /
`0.16` band width), so existing calibrations render unchanged.

**Unlike color-matching, this got a full CPU mirror** rather than being
made GPU-only/opt-in: the warp is pure closed-form arithmetic with no
state, so it was tractable to add to `stitch::geometry::PlaneMap::
sample_uv` (operating on the same raw, pre-extended-UV-remap `uv.y` as the
GPU shader, in the same order, so the two backends agree by construction).
Verified with a new end-to-end agreement test that actually ran on real
GPU hardware with non-zero tilt on both planes
(`cpu_and_gpu_backends_agree_with_ground_top_tilt`), plus focused unit
tests on the warp math itself (identity below the band threshold, a real
shift beyond it, and the top-tilt's mirrored one-sidedness).

GPU-side wiring turned out simpler than the seam-positioning/
color-matching precedent needed: `encode_stitch_pass` already receives the
full `Calibration`, so the two new `vec4<f32>` uniform fields
(`ground_tilt`, `top_tilt`) are populated directly from
`calibration.topology` inside it — no new params threaded through
`render_to_target`/`render_to_view` or `StitchPipeline`'s public render
methods. Only a genuine live-editable-without-scene-rebuild setter chain
was needed: `StitchPipeline::set_ground_tilt_x`/`z`/`set_top_tilt_x`/`z`/
`set_*_band_width` (mirrors `set_blend_width` exactly) → `Executor` →
`StitchCore` → reco-gui's preview bridge.

reco-gui: 6 new `LabeledSlider`s in the Calibration panel (tilt values
`-0.3..0.3` at 5 decimals, band widths `0.09..0.4` at 2 decimals),
mirroring the existing Intersect/x_ty sliders' wiring exactly, including
all 3 calibration-sync sites (reset, file-load, and post-auto-calibrate
reload).

`reco-calibrate`'s optimizer and `reco-autocam`'s panner test fixtures
were updated only for the new required `Topology` fields (defaulted to
no-op) — the automatic-fitting path for these tilt values doesn't exist
and is out of scope here.

Verified: `fmt --check` clean; `cargo test -p reco-core` (156 passed,
including the new GPU agreement test and 4 new geometry unit tests; only
the 2 pre-existing CUDA hardware-gap failures, unrelated), `-p reco-gui`
(65/65), `-p reco-calibrate` (48/48, including the optimizer fitting tests
— confirms the required-field addition didn't disturb existing fitting
behavior), `-p reco-autocam` (6/6); full workspace build clean.

<img width="303" height="487" alt="Calibration" src="https://github.com/user-attachments/assets/0daea2f0-37d7-47db-9f9b-0aa020575c44" />

