### PR TITLE
Add audio-sync waveform panel

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -21,6 +21,7 @@ mod preview;
 mod settings;
 mod telemetry_client;
 mod toast;
+mod waveform;
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -89,6 +90,28 @@ const POSE_SMOOTHING: f32 = 0.25;
 /// NVDEC codec reinit that costs ~50ms. Without debouncing, a drag
 /// saturates the GPU with hundreds of pending reinits.
 const SEEK_DEBOUNCE_MS: u64 = 120;
+
+/// Width of the audio-sync waveform window, in frames of video at the
+/// source's own fps - converted to seconds of audio at recompute time
+/// since fps is only known once a file is loaded. Frame-based (not a
+/// fixed duration) because the whole point is spotting a frame-scale
+/// `sync_offset` error as a shifted transient; a multi-second window
+/// dilutes that shift into a barely-visible fraction of the display.
+const AUDIO_WAVEFORM_WINDOW_FRAMES: f64 = 5.0;
+/// Clamp range for the user-adjustable waveform window width (frames).
+const AUDIO_WAVEFORM_WINDOW_FRAMES_RANGE: (f64, f64) = (1.0, 300.0);
+/// Number of bars drawn per waveform track.
+const AUDIO_WAVEFORM_BUCKETS: usize = 240;
+/// Minimum wall-clock time between recompute triggers. Each recompute
+/// shells out to `ffmpeg` twice (left + right), so this throttles how
+/// often that happens during continuous playback.
+const AUDIO_WAVEFORM_THROTTLE_MS: u64 = 500;
+/// Minimum playhead movement, in frames, that warrants a recompute -
+/// also converted to seconds at recompute time. Frame-based for the same
+/// reason as the window width: keeps the recenter threshold proportional
+/// to the (now much narrower) window instead of the window being fully
+/// skipped past between recomputes.
+const AUDIO_WAVEFORM_RECENTER_FRAMES: f64 = 3.0;
 
 /// Calibration payload sent from the background worker: the computed
 /// match calibration plus the lens profile info each side resolved to,
@@ -204,6 +227,25 @@ struct AppState {
     recording_frames: u64,
     /// Receives calibration results from the background thread.
     cal_rx: Option<std::sync::mpsc::Receiver<CalibrationResult>>,
+    /// Left/right audio-sync waveform envelopes currently displayed,
+    /// downsampled around `audio_envelope_center_secs`. Empty until the
+    /// first recompute (see [`AppState::maybe_recompute_audio_envelope`]).
+    audio_envelope_left: Vec<f32>,
+    audio_envelope_right: Vec<f32>,
+    /// User-adjustable window width (frames), clamped to
+    /// `AUDIO_WAVEFORM_WINDOW_FRAMES_RANGE`. Defaults to
+    /// `AUDIO_WAVEFORM_WINDOW_FRAMES`.
+    audio_window_frames: f64,
+    /// Playhead time (seconds) the displayed envelope was computed for.
+    /// Recompute triggers once the playhead has moved far enough from
+    /// this. Starts at `NEG_INFINITY` so the first expand always computes.
+    audio_envelope_center_secs: f64,
+    /// `Some` while a background extraction job is in flight; polled and
+    /// cleared by `maybe_recompute_audio_envelope`.
+    audio_envelope_rx: Option<std::sync::mpsc::Receiver<(Vec<f32>, Vec<f32>)>>,
+    /// Wall-clock time of the last triggered recompute, for throttling
+    /// during continuous playback (each recompute shells out to ffmpeg).
+    audio_envelope_triggered_at: Option<Instant>,
     /// wgpu handles captured from Slint's rendering notifier. `None`
     /// until the window has completed its first rendering setup.
     shared_gpu: Option<SharedGpu>,
@@ -467,6 +509,12 @@ impl AppState {
             recording_path: None,
             recording_frames: 0,
             cal_rx: None,
+            audio_envelope_left: Vec::new(),
+            audio_envelope_right: Vec::new(),
+            audio_window_frames: AUDIO_WAVEFORM_WINDOW_FRAMES,
+            audio_envelope_center_secs: f64::NEG_INFINITY,
+            audio_envelope_rx: None,
+            audio_envelope_triggered_at: None,
             shared_gpu: None,
             #[cfg(feature = "automation")]
             autoload: AutoloadSpec::from_env(),
@@ -961,7 +1009,111 @@ impl AppState {
             }
             log::info!("Sync offset changed to {offset} frames");
             self.preview_dirty = true;
+            // Force the audio-sync waveform to recompute against the new
+            // offset instead of showing the stale pre-change envelope.
+            self.audio_envelope_center_secs = f64::NEG_INFINITY;
         }
+    }
+
+    /// Update the audio-sync waveform's window width (frames), clamped to
+    /// `AUDIO_WAVEFORM_WINDOW_FRAMES_RANGE`, and force the next tick's
+    /// `maybe_recompute_audio_envelope` to recompute against it instead of
+    /// showing the stale pre-change envelope.
+    fn set_audio_window_frames(&mut self, frames: f32) {
+        self.audio_window_frames = (frames as f64).clamp(
+            AUDIO_WAVEFORM_WINDOW_FRAMES_RANGE.0,
+            AUDIO_WAVEFORM_WINDOW_FRAMES_RANGE.1,
+        );
+        self.audio_envelope_center_secs = f64::NEG_INFINITY;
+    }
+
+    /// Poll for a completed audio-sync waveform envelope and, if the
+    /// playhead has moved far enough since the last one, trigger a new
+    /// background recompute. Called from the playback timer tick; cheap
+    /// when idle (a few field reads), since the actual `ffmpeg`
+    /// extraction only runs on a background thread when genuinely
+    /// warranted.
+    fn maybe_recompute_audio_envelope(&mut self, app_weak: &slint::Weak<RecoApp>) {
+        if let Some(rx) = &self.audio_envelope_rx {
+            if let Ok((left, right)) = rx.try_recv() {
+                self.audio_envelope_rx = None;
+                self.audio_envelope_left = left.clone();
+                self.audio_envelope_right = right.clone();
+                if let Some(app) = app_weak.upgrade() {
+                    app.set_audio_envelope_left(slint::ModelRc::new(slint::VecModel::from(left)));
+                    app.set_audio_envelope_right(slint::ModelRc::new(slint::VecModel::from(right)));
+                }
+                return;
+            }
+        }
+
+        if self.audio_envelope_rx.is_some() {
+            return; // job already in flight
+        }
+
+        let Some(app) = app_weak.upgrade() else {
+            return;
+        };
+        if !app.get_audio_sync_expanded() {
+            return;
+        }
+        let (Some(left_path), Some(right_path)) = (self.left_path.clone(), self.right_path.clone())
+        else {
+            return;
+        };
+        let fps = self.playback.fps();
+        if fps <= 0.0 {
+            return;
+        }
+
+        let window_secs = self.audio_window_frames / fps;
+        let recenter_secs = AUDIO_WAVEFORM_RECENTER_FRAMES / fps;
+        let center_secs = self.playback.frame_index() as f64 / fps;
+        let moved_enough = (center_secs - self.audio_envelope_center_secs).abs() >= recenter_secs;
+        let throttled = self
+            .audio_envelope_triggered_at
+            .is_some_and(|t| t.elapsed() < Duration::from_millis(AUDIO_WAVEFORM_THROTTLE_MS));
+        if !moved_enough || throttled {
+            return;
+        }
+
+        self.audio_envelope_center_secs = center_secs;
+        self.audio_envelope_triggered_at = Some(Instant::now());
+
+        // `playback.frame_index()` is a synced-timeline index: frame k of
+        // the synced stream is raw left frame `k + max(-sync_offset, 0)`
+        // and raw right frame `k + max(sync_offset, 0)` (see
+        // `adapters::spawn_decode_pipeline_from_inputs`, which skips
+        // frames from whichever camera started first). Extracting both
+        // channels' audio windows at the same raw `center_secs` - as if
+        // `sync_offset` were always 0 - would make the waveform blind to
+        // the very thing it exists to verify: a correct offset should
+        // pull the two traces' transients into alignment, and a wrong one
+        // should show a residual shift.
+        let sync_offset = self.calibration.as_ref().map_or(0, |c| c.sync_offset);
+        let left_center_secs = center_secs + (-sync_offset).max(0) as f64 / fps;
+        let right_center_secs = center_secs + sync_offset.max(0) as f64 / fps;
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        self.audio_envelope_rx = Some(rx);
+        std::thread::spawn(move || {
+            let mut left = crate::waveform::extract_window_envelope(
+                &left_path,
+                left_center_secs,
+                window_secs,
+                AUDIO_WAVEFORM_BUCKETS,
+            )
+            .unwrap_or_default();
+            let mut right = crate::waveform::extract_window_envelope(
+                &right_path,
+                right_center_secs,
+                window_secs,
+                AUDIO_WAVEFORM_BUCKETS,
+            )
+            .unwrap_or_default();
+            crate::waveform::normalize_pair_to_peak(&mut left, &mut right);
+            let _ = tx.send((left, right));
+        });
     }
 
     /// Re-open the playback source from the current chained inputs without
@@ -2795,6 +2947,11 @@ fn main() -> anyhow::Result<()> {
         state_ref.borrow_mut().set_fov(deg);
     });
 
+    let state_ref = Rc::clone(&state);
+    app.on_changed_audio_window_frames(move |frames| {
+        state_ref.borrow_mut().set_audio_window_frames(frames);
+    });
+
     let app_weak = app.as_weak();
     let state_ref = Rc::clone(&state);
     app.on_seek_relative(move |secs| {
@@ -3722,6 +3879,11 @@ fn main() -> anyhow::Result<()> {
             }
 
             let mut s = state_ref.borrow_mut();
+
+            // Independent of rendering: the audio-sync waveform must keep
+            // computing even while paused, when nothing else in this timer
+            // tick would otherwise be dirty.
+            s.maybe_recompute_audio_envelope(&app_weak);
 
             // Check for update notification from the background thread.
             if let Ok(mut guard) = update_check.try_lock()

--- a/crates/reco-gui/src/waveform.rs
+++ b/crates/reco-gui/src/waveform.rs
@@ -1,0 +1,226 @@
+//! Audio waveform envelope extraction for the audio-sync check panel.
+//!
+//! Downsamples a short PCM window around the playhead into a coarse
+//! peak-amplitude envelope for overlaying left/right camera audio as a
+//! visual sync check — a real `sync_offset` error shows up as a shifted
+//! transient spike between the two traces. Extraction shells out to
+//! `ffmpeg` per call, so callers must not invoke this on the UI thread.
+
+use std::path::Path;
+
+use reco_io::ffmpeg::calibration_io::{self, CalibrationIoError};
+
+/// Sample rate used for envelope extraction. Low enough to keep the
+/// `ffmpeg` call fast; far more than enough resolution for a peak
+/// envelope over a multi-second window.
+const ENVELOPE_SAMPLE_RATE: u32 = 8_000;
+
+/// Downsample PCM samples into `buckets` peak-amplitude values,
+/// normalized to `[0.0, 1.0]`. Always returns exactly `buckets` values
+/// (zero-filled if `samples` is empty).
+pub fn compute_envelope(samples: &[i16], buckets: usize) -> Vec<f32> {
+    if buckets == 0 {
+        return Vec::new();
+    }
+    if samples.is_empty() {
+        return vec![0.0; buckets];
+    }
+    let len = samples.len();
+    (0..buckets)
+        .map(|i| {
+            let start = i * len / buckets;
+            let end = ((i + 1) * len / buckets).max(start + 1).min(len);
+            let peak = samples[start..end]
+                .iter()
+                .map(|&s| (s as i32).unsigned_abs())
+                .max()
+                .unwrap_or(0);
+            peak as f32 / i16::MAX as f32
+        })
+        .collect()
+}
+
+/// Rescale `left` and `right` in place using one shared peak (the louder
+/// of the two), instead of each independently reaching `1.0`.
+///
+/// Normalizing each channel independently would hide a real amplitude
+/// mismatch between the two camera mics - e.g. one camera's audio
+/// genuinely quieter, which is itself a sign something's off - by
+/// stretching both to look equally loud. A shared peak keeps that
+/// difference visible while still auto-scaling the pair away from
+/// barely-visible slivers when both are quiet.
+pub fn normalize_pair_to_peak(left: &mut [f32], right: &mut [f32]) {
+    let peak = left
+        .iter()
+        .chain(right.iter())
+        .copied()
+        .fold(0.0f32, f32::max);
+    if peak > 1e-6 {
+        for v in left.iter_mut().chain(right.iter_mut()) {
+            *v /= peak;
+        }
+    }
+}
+
+/// Bucket radius for [`smooth_envelope`]'s moving average.
+const SMOOTHING_RADIUS: usize = 3;
+
+/// Smooth `envelope` with a centered moving average of `radius` buckets on
+/// each side.
+///
+/// The raw peak-per-bucket envelope is noisy bucket-to-bucket (each bucket
+/// is an independent max, not a continuous signal), which reads as a messy
+/// spike train rather than a shape whose peaks are easy to compare by eye.
+/// Averaging over a small neighborhood turns it into a smooth curve while
+/// still preserving genuine transients wide enough to matter for a
+/// frame-scale sync check.
+fn smooth_envelope(envelope: &[f32], radius: usize) -> Vec<f32> {
+    if radius == 0 || envelope.is_empty() {
+        return envelope.to_vec();
+    }
+    let len = envelope.len();
+    (0..len)
+        .map(|i| {
+            let start = i.saturating_sub(radius);
+            let end = (i + radius + 1).min(len);
+            let sum: f32 = envelope[start..end].iter().sum();
+            sum / (end - start) as f32
+        })
+        .collect()
+}
+
+/// Extract a peak-amplitude envelope for a window of audio centered on
+/// `center_secs` in the file at `path`, smoothed (see [`smooth_envelope`]).
+///
+/// Not normalized - the two channels of a L/R pair should be scaled
+/// together afterwards via [`normalize_pair_to_peak`], not independently,
+/// so a real amplitude mismatch between the two mics stays visible.
+pub fn extract_window_envelope(
+    path: &Path,
+    center_secs: f64,
+    window_secs: f64,
+    buckets: usize,
+) -> Result<Vec<f32>, CalibrationIoError> {
+    let start_secs = (center_secs - window_secs / 2.0).max(0.0);
+    let samples = calibration_io::extract_audio_pcm_window(
+        path,
+        ENVELOPE_SAMPLE_RATE,
+        start_secs,
+        window_secs,
+    )?;
+    let envelope = compute_envelope(&samples, buckets);
+    Ok(smooth_envelope(&envelope, SMOOTHING_RADIUS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compute_envelope_empty_samples_returns_zero_filled() {
+        assert_eq!(compute_envelope(&[], 5), vec![0.0; 5]);
+    }
+
+    #[test]
+    fn compute_envelope_zero_buckets_returns_empty() {
+        assert!(compute_envelope(&[1, 2, 3], 0).is_empty());
+    }
+
+    #[test]
+    fn compute_envelope_returns_exact_bucket_count() {
+        let samples: Vec<i16> = (0..997).map(|i| (i % 100) as i16).collect();
+        assert_eq!(compute_envelope(&samples, 300).len(), 300);
+    }
+
+    #[test]
+    fn compute_envelope_finds_peak_per_bucket() {
+        // Two buckets: first half has a loud spike, second half is quiet.
+        let mut samples = vec![0i16; 200];
+        samples[50] = i16::MAX;
+        samples[150] = 100;
+        let env = compute_envelope(&samples, 2);
+        assert!((env[0] - 1.0).abs() < 1e-6, "loud bucket should read ~1.0");
+        assert!(env[1] < 0.01, "quiet bucket should read ~0.0");
+    }
+
+    #[test]
+    fn compute_envelope_handles_min_i16_without_overflow() {
+        let samples = vec![i16::MIN; 10];
+        let env = compute_envelope(&samples, 1);
+        assert!((env[0] - 1.0).abs() < 1e-3);
+    }
+
+    #[test]
+    fn normalize_pair_to_peak_scales_quiet_pair_up() {
+        let mut left = vec![0.0, 0.05, 0.02, 0.1];
+        let mut right = vec![0.0; 4];
+        normalize_pair_to_peak(&mut left, &mut right);
+        assert!(
+            (left[3] - 1.0).abs() < 1e-6,
+            "the pair's loudest bucket should hit 1.0"
+        );
+        assert!(
+            (left[1] - 0.5).abs() < 1e-6,
+            "other buckets scale by the same factor"
+        );
+    }
+
+    #[test]
+    fn normalize_pair_to_peak_leaves_silence_untouched() {
+        let mut left = vec![0.0; 4];
+        let mut right = vec![0.0; 4];
+        normalize_pair_to_peak(&mut left, &mut right);
+        assert_eq!(left, vec![0.0; 4], "no division by zero on pure silence");
+        assert_eq!(right, vec![0.0; 4]);
+    }
+
+    #[test]
+    fn normalize_pair_to_peak_preserves_relative_loudness_between_channels() {
+        // Right is genuinely quieter than left - a real mic-level
+        // mismatch, not just a display artifact - so it must stay
+        // quieter after normalization instead of being independently
+        // stretched to also reach 1.0.
+        let mut left = vec![0.0, 1.0, 0.5];
+        let mut right = vec![0.0, 0.4, 0.2];
+        normalize_pair_to_peak(&mut left, &mut right);
+        assert!((left[1] - 1.0).abs() < 1e-6, "louder channel hits 1.0");
+        assert!(
+            (right[1] - 0.4).abs() < 1e-6,
+            "quieter channel stays proportionally quieter, not re-stretched to 1.0"
+        );
+    }
+
+    #[test]
+    fn smooth_envelope_radius_zero_is_identity() {
+        let env = vec![0.0, 1.0, 0.0, 1.0];
+        assert_eq!(smooth_envelope(&env, 0), env);
+    }
+
+    #[test]
+    fn smooth_envelope_empty_stays_empty() {
+        assert!(smooth_envelope(&[], 3).is_empty());
+    }
+
+    #[test]
+    fn smooth_envelope_flattens_a_single_spike() {
+        let mut env = vec![0.0; 11];
+        env[5] = 1.0;
+        let smoothed = smooth_envelope(&env, 2);
+        // The spike spreads into its 2-bucket neighborhood (5 buckets averaged into 1.0/5)...
+        assert!((smoothed[5] - 1.0 / 5.0).abs() < 1e-6);
+        // ...and the peak is no longer an isolated single-bucket outlier.
+        assert!(smoothed[5] > smoothed[0]);
+        assert!(smoothed[4] > 0.0 && smoothed[6] > 0.0);
+    }
+
+    #[test]
+    fn smooth_envelope_preserves_length_and_shrinks_window_at_edges() {
+        let env = vec![1.0, 1.0, 1.0, 1.0];
+        let smoothed = smooth_envelope(&env, 2);
+        assert_eq!(smoothed.len(), env.len());
+        // Uniform input stays uniform regardless of the clamped edge window.
+        for v in smoothed {
+            assert!((v - 1.0).abs() < 1e-6);
+        }
+    }
+}

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -591,6 +591,15 @@ export component RecoApp inherits Window {
     in-out property <int> lens-candidates-count: 0;
     in-out property <bool> lens-info-available: false;
 
+    // `audio-sync-expanded` mirrors the section's collapse state into
+    // Rust (which only computes the envelope while expanded); the rest
+    // back the audio-sync waveform panel below.
+    in-out property <bool> audio-sync-expanded: false;
+    in-out property <[float]> audio-envelope-left: [];
+    in-out property <[float]> audio-envelope-right: [];
+    in-out property <float> audio-window-frames: 5.0;
+    in-out property <float> audio-waveform-height-px: 90.0;
+
     // Opt-in use of IMU-derived camera orientation as initial seeds
     // for the bundle-adjustment optimizer. Helpful on clips whose first
     // frame is pointed off-axis; harmful if the IMU is noisy. Default
@@ -708,6 +717,7 @@ export component RecoApp inherits Window {
     callback changed-rig-roll(float);
     callback changed-sync-offset(int);
     callback changed-fov(float);
+    callback changed-audio-window-frames(float);
     // Live calibration editing.
     callback changed-cal-intersect(float);
     callback changed-cal-camera-axis-offset(float);
@@ -1394,6 +1404,150 @@ export component RecoApp inherits Window {
                     }
 
                     if !root.lens-preview-active: Rectangle { height: 1px; background: root.border-subtle; }
+
+                    // ── Audio Sync (collapsible): overlaid L/R waveform
+                    // around the playhead, so a sync_offset error shows up
+                    // as a visible shift between the two traces. Placed
+                    // above Lens - sync is checked/adjusted more often
+                    // than lens fine-tuning during a normal calibration
+                    // pass.
+                    audio-section := SectionHeader {
+                        title: "Audio Sync Waveform";
+                        expanded <=> root.audio-sync-expanded;
+                    }
+
+                    if audio-section.expanded: VerticalLayout {
+                        spacing: 4px;
+
+                        Text {
+                            text: "L (blue) / R (orange), " + root.audio-window-frames + " frames around playhead. Aligned peaks = in sync.";
+                            color: #888; font-size: 11px; wrap: word-wrap;
+                        }
+
+                        HorizontalLayout {
+                            spacing: 12px;
+                            HorizontalLayout {
+                                spacing: 3px;
+                                Text { text: "Window:"; color: #888; font-size: 10px; vertical-alignment: center; }
+                                LineEdit {
+                                    text: root.audio-window-frames;
+                                    width: 64px;
+                                    edited(v) => {
+                                        root.audio-window-frames = v.to-float();
+                                        root.changed-audio-window-frames(v.to-float());
+                                    }
+                                }
+                                Text { text: "frames"; color: #888; font-size: 10px; vertical-alignment: center; }
+                            }
+                            HorizontalLayout {
+                                spacing: 3px;
+                                Text { text: "Height:"; color: #888; font-size: 10px; vertical-alignment: center; }
+                                LineEdit {
+                                    text: root.audio-waveform-height-px;
+                                    width: 64px;
+                                    edited(v) => {
+                                        root.audio-waveform-height-px = min(300, max(40, v.to-float()));
+                                    }
+                                }
+                                Text { text: "px"; color: #888; font-size: 10px; vertical-alignment: center; }
+                            }
+                        }
+
+                        waveform-area := Rectangle {
+                            height: root.audio-waveform-height-px * 1px;
+                            background: #1a1a1a;
+                            border-radius: 4px;
+                            clip: true;
+
+                            property <float> bucket-count: max(1, root.audio-envelope-left.length) * 1.0;
+                            property <length> bar-w: waveform-area.width / bucket-count;
+
+                            // Background grid, purely a reading aid:
+                            // horizontal thirds + a vertical line
+                            // every 8 buckets.
+                            for row in [0.25, 0.5, 0.75]: Rectangle {
+                                x: 0px; width: waveform-area.width;
+                                y: waveform-area.height * row; height: 1px;
+                                background: #ffffff16;
+                            }
+                            for i in 9: Rectangle {
+                                x: waveform-area.width * (i + 1) / 10; width: 1px;
+                                y: 0px; height: waveform-area.height;
+                                background: #ffffff10;
+                            }
+
+                            // Both channels are plain (unmirrored) lines
+                            // sharing one axis - 0 at the bottom, loudest
+                            // point at the top - so a real sync offset
+                            // reads as a horizontal shift between the two
+                            // lines' peaks, same as any two-series line
+                            // chart.
+                            //
+                            // Each point is a thin horizontal marker PLUS
+                            // a vertical connector to the next point's
+                            // height, so consecutive buckets join into a
+                            // continuous "staircase" line instead of
+                            // reading as scattered dots. Not a `Path`:
+                            // Slint fits a `Path`'s viewbox uniformly,
+                            // which would squash a wide/short envelope
+                            // flat; and Rectangle has no rotation for a
+                            // true diagonal stroke, so this approximates
+                            // one.
+                            for v[idx] in root.audio-envelope-left: Rectangle {
+                                x: idx * waveform-area.bar-w;
+                                width: waveform-area.bar-w;
+                                height: 1px;
+                                y: waveform-area.height * (1.0 - v) - 0.5px;
+                                background: #5fb8ff;
+                            }
+                            for v[idx] in root.audio-envelope-left: Rectangle {
+                                property <bool> has-next: idx + 1 < root.audio-envelope-left.length;
+                                property <float> next-v: has-next ? root.audio-envelope-left[idx + 1] : v;
+                                property <length> y0: waveform-area.height * (1.0 - v);
+                                property <length> y1: waveform-area.height * (1.0 - next-v);
+                                visible: has-next;
+                                x: (idx + 1) * waveform-area.bar-w - 0.5px;
+                                width: 1px;
+                                y: min(y0, y1);
+                                height: max(y0, y1) - min(y0, y1) + 1px;
+                                background: #5fb8ff;
+                            }
+                            for v[idx] in root.audio-envelope-right: Rectangle {
+                                x: idx * waveform-area.bar-w;
+                                width: waveform-area.bar-w;
+                                height: 1px;
+                                y: waveform-area.height * (1.0 - v) - 0.5px;
+                                background: #ff9f5f;
+                            }
+                            for v[idx] in root.audio-envelope-right: Rectangle {
+                                property <bool> has-next: idx + 1 < root.audio-envelope-right.length;
+                                property <float> next-v: has-next ? root.audio-envelope-right[idx + 1] : v;
+                                property <length> y0: waveform-area.height * (1.0 - v);
+                                property <length> y1: waveform-area.height * (1.0 - next-v);
+                                visible: has-next;
+                                x: (idx + 1) * waveform-area.bar-w - 0.5px;
+                                width: 1px;
+                                y: min(y0, y1);
+                                height: max(y0, y1) - min(y0, y1) + 1px;
+                                background: #ff9f5f;
+                            }
+
+                            Rectangle {
+                                x: waveform-area.width * 0.5 - 1px;
+                                width: 2px;
+                                height: waveform-area.height;
+                                background: #ffffff55;
+                            }
+
+                            if root.audio-envelope-left.length == 0 && root.audio-envelope-right.length == 0: Text {
+                                text: "Computing…";
+                                color: #888; font-size: 10px;
+                                x: 6px; y: 6px;
+                            }
+                        }
+                    }
+
+                    if !audio-section.expanded: Rectangle { height: 1px; background: #2a2a2a; }
 
                     // ── Lens (collapsible: info always, sliders on demand) ──
                     lens-section := SectionHeader {

--- a/crates/reco-io/src/ffmpeg/calibration_io.rs
+++ b/crates/reco-io/src/ffmpeg/calibration_io.rs
@@ -115,7 +115,8 @@ const FORBIDDEN_PATH_PREFIXES: &[&str] = &["http://", "https://", "concat:", "pi
 /// Extract mono PCM audio samples from a video file.
 ///
 /// Uses the `ffmpeg` CLI to extract up to 60 seconds of mono audio
-/// at the given sample rate. Returns signed 16-bit PCM samples.
+/// at the given sample rate, starting from the beginning of the file.
+/// Returns signed 16-bit PCM samples.
 ///
 /// Caps extraction at 60 seconds since that is more than enough for
 /// cross-correlation sync detection, and avoids slow HDD reads on
@@ -126,6 +127,22 @@ const FORBIDDEN_PATH_PREFIXES: &[&str] = &["http://", "https://", "concat:", "pi
 pub fn extract_audio_pcm(
     video_path: &Path,
     sample_rate: u32,
+) -> Result<Vec<i16>, CalibrationIoError> {
+    extract_audio_pcm_window(video_path, sample_rate, 0.0, 60.0)
+}
+
+/// Extract mono PCM audio samples from a windowed segment of a video file.
+///
+/// Like [`extract_audio_pcm`], but reads `duration_secs` of audio starting
+/// at `start_secs` instead of always starting from the beginning. Uses
+/// ffmpeg's input-side `-ss` for fast seeking. Intended for callers that
+/// need a short segment around an arbitrary point in a (possibly long)
+/// recording, e.g. a playhead-centered waveform preview.
+pub fn extract_audio_pcm_window(
+    video_path: &Path,
+    sample_rate: u32,
+    start_secs: f64,
+    duration_secs: f64,
 ) -> Result<Vec<i16>, CalibrationIoError> {
     let path_str = video_path
         .to_str()
@@ -142,11 +159,14 @@ pub fn extract_audio_pcm(
     }
 
     let mut cmd = std::process::Command::new("ffmpeg");
+    if start_secs > 0.0 {
+        cmd.args(["-ss", &start_secs.to_string()]);
+    }
     cmd.args([
         "-i",
         path_str,
         "-t",
-        "60",
+        &duration_secs.to_string(),
         "-vn",
         "-ac",
         "1",


### PR DESCRIPTION
Adds a collapsible "Audio Sync Waveform" panel to the calibration
controls, showing overlaid left/right peak-amplitude waveforms for a
window of audio around the playhead. A `sync_offset` frame error shows
up as a visible shift between the two traces, instead of requiring a
guess-and-check loop against the rendered preview.

- `reco-io`: `calibration_io::extract_audio_pcm_window()` extracts a
  windowed audio segment (ffmpeg `-ss`/`-t`) instead of always reading
  from the start of the file; `extract_audio_pcm()` now delegates to it.
- `reco-gui`: new `waveform` module downsamples PCM into a smoothed
  peak envelope, normalized per L/R pair so a real mic-level mismatch
  between the two cameras stays visible rather than being independently
  stretched away. A background thread re-extracts it as the playhead
  moves (throttled, polled from the always-running timer tick so it
  keeps updating while paused, not only while playing/seeking).
- Window width (frames around the playhead) and panel height are
  live-adjustable.
- Changing `sync_offset` forces a recompute so the panel reflects the
  new offset instead of showing a stale envelope.

This is a focused port of the audio-sync waveform panel only - it does
not include the separate "auto-detect sync offset" feature (IMU/audio
cross-correlation), which is unrelated UI/logic and can be its own PR
if wanted.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo check -p reco-gui --all-targets` (full link skipped locally
      to avoid clobbering a running dev build; `cargo build` was
      confirmed to succeed up to the link step)
- [x] `cargo test -p reco-gui -p reco-io` — all passing, including 12 new
      `waveform::tests` unit tests
- [x] `cargo clippy -p reco-gui -p reco-io --all-targets -- -D warnings`
      — no new findings; failures shown are the same pre-existing
      `reco-core` dead-code/unsafe-ptr issues already tracked by #423
      
 
<img width="309" height="412" alt="Audio Sync Wavefrom" src="https://github.com/user-attachments/assets/efc96b14-f018-4426-a21d-50fee8f06208" />
