### PR TITLE
refactor: N-ary FrameSet end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ reco-obs         OBS Studio source plugin (async-frame ingestion, BGRA, interact
 
 **Dependency direction:** consumers (`cli` / `gui` / `obs`) depend on the four library crates (`autocam`, `calibrate`, `detect`, `io`); all four depend on `reco-core`. `reco-control` is consumed by `cli` / `gui` / `obs`.
 
-Push-based is the canonical ingestion path: consumers call `StitchCore::submit_frame_yuv` / `submit_frame_bgra` per frame. Batch file processing (`StitchSession::run`) is a thin pull-adapter on top.
+Push-based is the canonical ingestion path: consumers call `StitchCore::submit_frame` with a per-camera `FrameSet` each frame (interactive consumers use the `submit_frame_*_at_pose` variants). Batch file processing (`StitchSession::run`) is a thin pull-adapter on top.
 
 ## Building
 

--- a/crates/reco-autocam/src/panners/field.rs
+++ b/crates/reco-autocam/src/panners/field.rs
@@ -1053,7 +1053,6 @@ impl Panner for FieldPanner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reco_core::geometry::CameraId;
 
     #[test]
     fn sanitized_orders_inverted_fov_and_no_panic() {
@@ -1121,7 +1120,7 @@ mod tests {
             confidence,
             state: TrackState::Tracking,
             age_frames: 5,
-            origin: CameraId::Left,
+            origin: 0,
         }
     }
 
@@ -1134,7 +1133,7 @@ mod tests {
             confidence: 0.8,
             state: TrackState::Tracking,
             age_frames: 1,
-            origin: CameraId::Left,
+            origin: 0,
         }
     }
 

--- a/crates/reco-autocam/src/panners/sweep.rs
+++ b/crates/reco-autocam/src/panners/sweep.rs
@@ -176,7 +176,7 @@ mod tests {
                 confidence: 1.0,
                 state: reco_core::detect::tracker::TrackState::Tracking,
                 age_frames: 1,
-                origin: reco_core::geometry::CameraId::Left,
+                origin: 0,
             }),
             players: Vec::new(),
         };

--- a/crates/reco-autocam/src/roi_filter.rs
+++ b/crates/reco-autocam/src/roi_filter.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 
 use reco_core::calibration::FieldRoi;
 use reco_core::detect::detector::{Detection, DetectorError, DetectorFrame, UnifiedDetector};
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 use reco_core::projection::point_in_polygon;
 
 /// Where on a detection's bounding box the ROI test samples.
@@ -80,8 +80,12 @@ fn filter_by_roi(
         .into_iter()
         .filter(|d| {
             let polygon = match d.camera {
-                CameraId::Left => &roi.left,
-                CameraId::Right => &roi.right,
+                0 => &roi.left,
+                1 => &roi.right,
+                // FieldRoi is pair-shaped until the schema v2 split;
+                // a camera with no defined polygon goes unfiltered,
+                // same as an empty polygon.
+                _ => return true,
             };
             if polygon.len() < 3 {
                 return true;
@@ -157,7 +161,7 @@ impl UnifiedDetector for RoiFilteredDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         let detections = self.inner.detect(camera, frame)?;
@@ -179,14 +183,14 @@ mod tests {
     use super::*;
     use reco_core::calibration::FieldRoi;
     use reco_core::detect::detector::Detection;
-    use reco_core::geometry::CameraId;
+    use reco_core::geometry::CameraIndex;
 
-    fn make_detection(camera: CameraId, cx: f32, cy: f32, w: f32, h: f32) -> Detection {
+    fn make_detection(camera: CameraIndex, cx: f32, cy: f32, w: f32, h: f32) -> Detection {
         make_detection_class(camera, 0, cx, cy, w, h)
     }
 
     fn make_detection_class(
-        camera: CameraId,
+        camera: CameraIndex,
         class_id: u16,
         cx: f32,
         cy: f32,
@@ -225,14 +229,14 @@ mod tests {
     #[test]
     fn detection_inside_roi_passes() {
         let roi = full_roi();
-        let det = make_detection(CameraId::Left, 0.5, 0.4, 0.1, 0.2);
+        let det = make_detection(0, 0.5, 0.4, 0.1, 0.2);
         assert_eq!(filter(vec![det], &roi).len(), 1);
     }
 
     #[test]
     fn detection_outside_roi_filtered() {
         let roi = small_roi();
-        let det = make_detection(CameraId::Left, 0.05, 0.05, 0.1, 0.2);
+        let det = make_detection(0, 0.05, 0.05, 0.1, 0.2);
         assert!(filter(vec![det], &roi).is_empty());
     }
 
@@ -242,7 +246,7 @@ mod tests {
             left: vec![],
             right: vec![],
         };
-        let det = make_detection(CameraId::Left, 0.5, 0.5, 0.1, 0.2);
+        let det = make_detection(0, 0.5, 0.5, 0.1, 0.2);
         assert_eq!(filter(vec![det], &roi).len(), 1);
     }
 
@@ -252,7 +256,7 @@ mod tests {
             left: vec![[0.0, 0.0], [1.0, 1.0]],
             right: vec![],
         };
-        let det = make_detection(CameraId::Left, 0.5, 0.5, 0.1, 0.2);
+        let det = make_detection(0, 0.5, 0.5, 0.1, 0.2);
         assert_eq!(filter(vec![det], &roi).len(), 1);
     }
 
@@ -262,8 +266,8 @@ mod tests {
             left: vec![[0.2, 0.2], [0.8, 0.2], [0.8, 0.8], [0.2, 0.8]],
             right: vec![[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]],
         };
-        let det_left = make_detection(CameraId::Left, 0.05, 0.05, 0.1, 0.2);
-        let det_right = make_detection(CameraId::Right, 0.05, 0.05, 0.1, 0.2);
+        let det_left = make_detection(0, 0.05, 0.05, 0.1, 0.2);
+        let det_right = make_detection(1, 0.05, 0.05, 0.1, 0.2);
         assert!(filter(vec![det_left], &roi).is_empty());
         assert_eq!(filter(vec![det_right], &roi).len(), 1);
     }
@@ -271,8 +275,8 @@ mod tests {
     #[test]
     fn mixed_detections_filter_correctly() {
         let roi = small_roi();
-        let inside = make_detection(CameraId::Left, 0.5, 0.4, 0.1, 0.2);
-        let outside = make_detection(CameraId::Left, 0.05, 0.05, 0.1, 0.2);
+        let inside = make_detection(0, 0.5, 0.4, 0.1, 0.2);
+        let outside = make_detection(0, 0.05, 0.05, 0.1, 0.2);
         let filtered = filter(vec![inside, outside], &roi);
         assert_eq!(filtered.len(), 1);
         assert!((filtered[0].center_x - 0.5).abs() < f32::EPSILON);
@@ -286,7 +290,7 @@ mod tests {
         // (0.5, 0.7), height 0.3 -> feet at y=0.85 outside, center
         // at y=0.7 inside. A ball class with Center anchor passes.
         let roi = small_roi();
-        let ball = make_detection_class(CameraId::Left, 0, 0.5, 0.7, 0.1, 0.3);
+        let ball = make_detection_class(0, 0, 0.5, 0.7, 0.1, 0.3);
         assert_eq!(filter(vec![ball], &roi).len(), 1);
     }
 
@@ -295,7 +299,7 @@ mod tests {
         // Same geometry as above but as a Player (class=1) with
         // Bottom anchor: feet at y=0.85 outside -> rejected.
         let roi = small_roi();
-        let player = make_detection_class(CameraId::Left, 1, 0.5, 0.7, 0.1, 0.3);
+        let player = make_detection_class(0, 1, 0.5, 0.7, 0.1, 0.3);
         let mut anchors = HashMap::new();
         anchors.insert(1u16, RoiAnchor::Bottom);
         let filtered = filter_by_roi(vec![player], &roi, &anchors, RoiAnchor::Center);
@@ -308,8 +312,8 @@ mod tests {
         // Center default + Bottom for players, ball survives and
         // player gets dropped.
         let roi = small_roi();
-        let ball = make_detection_class(CameraId::Left, 0, 0.5, 0.7, 0.1, 0.3);
-        let player = make_detection_class(CameraId::Left, 1, 0.5, 0.7, 0.1, 0.3);
+        let ball = make_detection_class(0, 0, 0.5, 0.7, 0.1, 0.3);
+        let player = make_detection_class(0, 1, 0.5, 0.7, 0.1, 0.3);
         let mut anchors = HashMap::new();
         anchors.insert(1u16, RoiAnchor::Bottom);
         let filtered = filter_by_roi(vec![ball, player], &roi, &anchors, RoiAnchor::Center);
@@ -322,7 +326,7 @@ mod tests {
         // Locks the public-API shape: builder method + lookup via
         // detect() path work together.
         let roi = small_roi();
-        let det = make_detection_class(CameraId::Left, 7, 0.5, 0.7, 0.1, 0.3);
+        let det = make_detection_class(0, 7, 0.5, 0.7, 0.1, 0.3);
         let mut anchors = HashMap::new();
         anchors.insert(7u16, RoiAnchor::Bottom);
         assert!(filter_by_roi(vec![det], &roi, &anchors, RoiAnchor::Center).is_empty());

--- a/crates/reco-autocam/src/trackers/ball.rs
+++ b/crates/reco-autocam/src/trackers/ball.rs
@@ -41,7 +41,7 @@
 
 use reco_core::detect::director::MappedDetection;
 use reco_core::detect::tracker::{TrackState, TrackedEntity, Tracker};
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 
 use crate::trackers::filters::{CoastStatus, Coaster};
 
@@ -91,7 +91,7 @@ pub struct BallTracker {
 struct LastKnown {
     yaw: f32,
     pitch: f32,
-    origin: CameraId,
+    origin: CameraIndex,
 }
 
 impl BallTracker {
@@ -349,7 +349,14 @@ mod tests {
     use super::*;
     use reco_core::geometry::Pose;
 
-    fn det(camera: CameraId, yaw: f32, pitch: f32, conf: f32, cx: f32, cy: f32) -> MappedDetection {
+    fn det(
+        camera: CameraIndex,
+        yaw: f32,
+        pitch: f32,
+        conf: f32,
+        cx: f32,
+        cy: f32,
+    ) -> MappedDetection {
         MappedDetection {
             camera,
             class_id: 0,
@@ -374,19 +381,19 @@ mod tests {
     #[test]
     fn first_detection_emits_tracking() {
         let mut t = BallTracker::new(0);
-        let d = det(CameraId::Left, 0.2, 0.1, 0.8, 0.5, 0.5);
+        let d = det(0, 0.2, 0.1, 0.8, 0.5, 0.5);
         let out = t.update(&[d], 0.0);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].state, TrackState::Tracking);
         assert_eq!(out[0].yaw, 0.2);
         assert_eq!(out[0].pitch, 0.1);
-        assert_eq!(out[0].origin, CameraId::Left);
+        assert_eq!(out[0].origin, 0);
     }
 
     #[test]
     fn non_matching_class_id_ignored() {
         let mut t = BallTracker::new(32); // sports ball
-        let d = det(CameraId::Left, 0.2, 0.1, 0.8, 0.5, 0.5);
+        let d = det(0, 0.2, 0.1, 0.8, 0.5, 0.5);
         // d has class_id=0, tracker wants 32 — should be ignored.
         let out = t.update(&[d], 0.0);
         assert!(out.is_empty());
@@ -395,7 +402,7 @@ mod tests {
     #[test]
     fn missing_position_ignored() {
         let mut t = BallTracker::new(0);
-        let mut d = det(CameraId::Left, 0.2, 0.1, 0.8, 0.5, 0.5);
+        let mut d = det(0, 0.2, 0.1, 0.8, 0.5, 0.5);
         d.position = None;
         let out = t.update(&[d], 0.0);
         assert!(out.is_empty());
@@ -405,7 +412,7 @@ mod tests {
     fn coast_then_reacquire() {
         let mut t = BallTracker::new(0).with_max_coast_frames(3);
         // Frame 1: acquire.
-        let d1 = det(CameraId::Left, 0.2, 0.1, 0.8, 0.5, 0.5);
+        let d1 = det(0, 0.2, 0.1, 0.8, 0.5, 0.5);
         let out1 = t.update(&[d1], 0.0);
         assert_eq!(out1[0].state, TrackState::Tracking);
         // Frames 2-3: no detection, coasting.
@@ -414,7 +421,7 @@ mod tests {
         let out3 = t.update(&[], 33.3);
         assert_eq!(out3[0].state, TrackState::Coasting);
         // Frame 4: reacquire — state back to Tracking.
-        let d4 = det(CameraId::Left, 0.21, 0.11, 0.7, 0.51, 0.51);
+        let d4 = det(0, 0.21, 0.11, 0.7, 0.51, 0.51);
         let out4 = t.update(&[d4], 50.0);
         assert_eq!(out4[0].state, TrackState::Tracking);
     }
@@ -422,7 +429,7 @@ mod tests {
     #[test]
     fn coast_then_lost() {
         let mut t = BallTracker::new(0).with_max_coast_frames(2);
-        let d = det(CameraId::Left, 0.2, 0.1, 0.8, 0.5, 0.5);
+        let d = det(0, 0.2, 0.1, 0.8, 0.5, 0.5);
         t.update(&[d], 0.0);
         t.update(&[], 16.6); // coast 1
         t.update(&[], 33.3); // coast 2
@@ -438,10 +445,10 @@ mod tests {
     fn max_jump_rejects_implausible_detection() {
         let mut t = BallTracker::new(0).with_max_jump_rad(0.1);
         // Acquire at yaw=0.
-        let d1 = det(CameraId::Left, 0.0, 0.0, 0.9, 0.5, 0.5);
+        let d1 = det(0, 0.0, 0.0, 0.9, 0.5, 0.5);
         t.update(&[d1], 0.0);
         // Big jump to yaw=1.0 — exceeds 0.1 gate.
-        let d2 = det(CameraId::Left, 1.0, 0.0, 0.9, 0.5, 0.5);
+        let d2 = det(0, 1.0, 0.0, 0.9, 0.5, 0.5);
         let out = t.update(&[d2], 16.6);
         // No fresh accepted — tracker coasts on the last known.
         assert_eq!(out[0].state, TrackState::Coasting);
@@ -452,17 +459,17 @@ mod tests {
     fn cross_camera_handoff_tracks() {
         let mut t = BallTracker::new(0).with_max_jump_rad(0.3);
         // Acquire on left at yaw=0.15.
-        let d1 = det(CameraId::Left, 0.15, 0.0, 0.8, 0.9, 0.5);
+        let d1 = det(0, 0.15, 0.0, 0.8, 0.9, 0.5);
         let out1 = t.update(&[d1], 0.0);
-        assert_eq!(out1[0].origin, CameraId::Left);
+        assert_eq!(out1[0].origin, 0);
         // Next frame: right camera reports the same ball at close yaw.
         // Even though pixel coords are totally different (ball now at
         // left edge of right frame), the panorama yaw distance (0.05)
         // is within max_jump — tracker must switch cameras.
-        let d2 = det(CameraId::Right, 0.20, 0.0, 0.75, 0.05, 0.5);
+        let d2 = det(1, 0.20, 0.0, 0.75, 0.05, 0.5);
         let out2 = t.update(&[d2], 16.6);
         assert_eq!(out2[0].state, TrackState::Tracking);
-        assert_eq!(out2[0].origin, CameraId::Right);
+        assert_eq!(out2[0].origin, 1);
     }
 
     #[test]
@@ -477,11 +484,11 @@ mod tests {
             confidence: 0.9,
             state: TrackState::Tracking,
             age_frames: 5,
-            origin: CameraId::Right,
+            origin: 1,
         };
         t.set_players(&[player]);
         // Ball at yaw=0.2 is 0.8 rad from player — rejected.
-        let d = det(CameraId::Left, 0.2, 0.0, 0.9, 0.5, 0.5);
+        let d = det(0, 0.2, 0.0, 0.9, 0.5, 0.5);
         let out = t.update(&[d], 0.0);
         assert!(out.is_empty());
     }
@@ -490,7 +497,7 @@ mod tests {
     fn player_anchor_no_op_when_no_players_set() {
         let mut t = BallTracker::new(0).with_player_anchor_rad(0.1);
         // No set_players() call — filter should not reject.
-        let d = det(CameraId::Left, 0.2, 0.0, 0.9, 0.5, 0.5);
+        let d = det(0, 0.2, 0.0, 0.9, 0.5, 0.5);
         let out = t.update(&[d], 0.0);
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].state, TrackState::Tracking);
@@ -514,7 +521,7 @@ mod tests {
             confidence: 0.9,
             state: TrackState::Tracking,
             age_frames: 3,
-            origin: CameraId::Right,
+            origin: 1,
         };
         let world = WorldState {
             ball: None,
@@ -523,7 +530,7 @@ mod tests {
         t.observe_world(&world);
         // A ball far from the (only) player must be rejected by the
         // anchor filter — proves observe_world propagated players.
-        let d = det(CameraId::Left, 0.2, 0.0, 0.9, 0.5, 0.5);
+        let d = det(0, 0.2, 0.0, 0.9, 0.5, 0.5);
         let out = t.update(&[d], 0.0);
         assert!(out.is_empty(), "observe_world did not populate anchors");
     }
@@ -542,11 +549,11 @@ mod tests {
             confidence: 0.9,
             state: TrackState::Tracking,
             age_frames: 1,
-            origin: CameraId::Right,
+            origin: 1,
         };
         t.set_players(&[player]);
         t.observe_world(&WorldState::default());
-        let d = det(CameraId::Left, 0.2, 0.0, 0.9, 0.5, 0.5);
+        let d = det(0, 0.2, 0.0, 0.9, 0.5, 0.5);
         let out = t.update(&[d], 0.0);
         assert_eq!(out.len(), 1, "empty world should reset anchors");
     }
@@ -555,13 +562,13 @@ mod tests {
     fn prefers_closer_candidate_over_higher_confidence() {
         let mut t = BallTracker::new(0).with_max_jump_rad(1.0);
         // Acquire at yaw=0.0.
-        let d0 = det(CameraId::Left, 0.0, 0.0, 0.9, 0.5, 0.5);
+        let d0 = det(0, 0.0, 0.0, 0.9, 0.5, 0.5);
         t.update(&[d0], 0.0);
         // Two candidates: one high-conf far (0.4 rad), one low-conf close (0.05 rad).
         // Score balances proximity against confidence (0.1-rad weight);
         // the close candidate wins because proximity dominates.
-        let far = det(CameraId::Left, 0.40, 0.0, 0.95, 0.5, 0.5);
-        let near = det(CameraId::Left, 0.05, 0.0, 0.55, 0.5, 0.5);
+        let far = det(0, 0.40, 0.0, 0.95, 0.5, 0.5);
+        let near = det(0, 0.05, 0.0, 0.55, 0.5, 0.5);
         let out = t.update(&[far, near], 16.6);
         assert_eq!(out.len(), 1);
         assert!(

--- a/crates/reco-autocam/src/trackers/class_provider.rs
+++ b/crates/reco-autocam/src/trackers/class_provider.rs
@@ -80,10 +80,10 @@ impl Tracker for ClassProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reco_core::geometry::CameraId;
+    use reco_core::geometry::CameraIndex;
     use reco_core::geometry::Pose;
 
-    fn det(camera: CameraId, yaw: f32, pitch: f32, conf: f32) -> MappedDetection {
+    fn det(camera: CameraIndex, yaw: f32, pitch: f32, conf: f32) -> MappedDetection {
         MappedDetection {
             camera,
             class_id: 0,
@@ -102,16 +102,16 @@ mod tests {
     fn emits_one_entity_per_in_class_detection() {
         let mut t = ClassProvider::new(0);
         let dets = vec![
-            det(CameraId::Left, 0.0, 0.0, 0.9),
-            det(CameraId::Left, 0.5, 0.0, 0.8),
-            det(CameraId::Right, -0.5, 0.0, 0.7),
+            det(0, 0.0, 0.0, 0.9),
+            det(0, 0.5, 0.0, 0.8),
+            det(1, -0.5, 0.0, 0.7),
         ];
         let out = t.update(&dets, 0.0);
         assert_eq!(out.len(), 3);
         assert!(out.iter().all(|e| e.state == TrackState::Tracking));
         // Positions and confidence pass straight through.
         assert!((out[0].yaw - 0.0).abs() < 1e-6 && (out[0].confidence - 0.9).abs() < 1e-6);
-        assert!((out[2].yaw + 0.5).abs() < 1e-6 && out[2].origin == CameraId::Right);
+        assert!((out[2].yaw + 0.5).abs() < 1e-6 && out[2].origin == 1);
     }
 
     #[test]
@@ -120,10 +120,7 @@ mod tests {
         // detections; the provider must be deterministic so entities
         // don't flicker without any coast state.
         let mut t = ClassProvider::new(0);
-        let dets = vec![
-            det(CameraId::Left, 0.1, 0.0, 0.9),
-            det(CameraId::Left, 0.2, 0.0, 0.9),
-        ];
+        let dets = vec![det(0, 0.1, 0.0, 0.9), det(0, 0.2, 0.0, 0.9)];
         let a = t.update(&dets, 0.0);
         let b = t.update(&dets, 16.7);
         assert_eq!(a.len(), b.len());
@@ -141,9 +138,9 @@ mod tests {
     #[test]
     fn only_configured_class_is_emitted() {
         let mut t = ClassProvider::new(0);
-        let mut other = det(CameraId::Left, 0.3, 0.0, 0.9);
+        let mut other = det(0, 0.3, 0.0, 0.9);
         other.class_id = 5;
-        let out = t.update(&[other, det(CameraId::Left, 0.1, 0.0, 0.9)], 0.0);
+        let out = t.update(&[other, det(0, 0.1, 0.0, 0.9)], 0.0);
         assert_eq!(out.len(), 1, "the class-5 detection is filtered out");
         assert!((out[0].yaw - 0.1).abs() < 1e-6);
     }
@@ -151,7 +148,7 @@ mod tests {
     #[test]
     fn detection_without_position_is_skipped() {
         let mut t = ClassProvider::new(0);
-        let mut no_pos = det(CameraId::Left, 0.3, 0.0, 0.9);
+        let mut no_pos = det(0, 0.3, 0.0, 0.9);
         no_pos.position = None;
         let out = t.update(&[no_pos], 0.0);
         assert!(out.is_empty());

--- a/crates/reco-autocam/src/wgpu_detector.rs
+++ b/crates/reco-autocam/src/wgpu_detector.rs
@@ -6,7 +6,7 @@
 //! inner detector with `DetectorFrame::PreprocessedChw`.
 
 use reco_core::detect::detector::{Detection, DetectorError, DetectorFrame, UnifiedDetector};
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 use reco_detect::wgpu_preprocess::WgpuPreprocessor;
 
 /// Detector wrapper that adds wgpu NV12 preprocessing.
@@ -49,7 +49,7 @@ impl UnifiedDetector for WgpuPreprocessingDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         match frame {

--- a/crates/reco-cli/examples/vram_leak_repro.rs
+++ b/crates/reco-cli/examples/vram_leak_repro.rs
@@ -67,7 +67,7 @@ fn main() {
     for run in 1..=runs {
         println!("[run {run}] before: {}", vram());
         let out = format!("vram_repro_run{run}.mp4");
-        let mut job = reco_io::StitchJob::new(left.as_str(), right.as_str(), cal.as_str(), &out)
+        let mut job = reco_io::StitchJob::new([left.as_str(), right.as_str()], cal.as_str(), &out)
             .resolution(1920, 1080)
             .max_frames(max_frames);
 

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -474,13 +474,13 @@ pub fn run_camera(
                     }
                 };
 
-                if let Some((r, b)) = awb.update(&*left_bytes, capture_width, capture_height) {
+                if let Some((r, b)) = awb.update(&left_bytes, capture_width, capture_height) {
                     isp.wb_r = r;
                     isp.wb_b = b;
                     demosaic_left.update_params(session.gpu(), &isp);
                     demosaic_right.update_params(session.gpu(), &isp);
                 }
-                ae.update(&*left_bytes, capture_width, capture_height);
+                ae.update(&left_bytes, capture_width, capture_height);
 
                 {
                     reco_core::profile_scope!("demosaic");
@@ -490,8 +490,8 @@ pub fn run_camera(
                             label: Some("bayer_demosaic"),
                         },
                     );
-                    demosaic_left.encode_demosaic(gpu, &mut encoder, &*left_bytes);
-                    demosaic_right.encode_demosaic(gpu, &mut encoder, &*right_bytes);
+                    demosaic_left.encode_demosaic(gpu, &mut encoder, &left_bytes);
+                    demosaic_right.encode_demosaic(gpu, &mut encoder, &right_bytes);
                     gpu.queue().submit(std::iter::once(encoder.finish()));
                 }
 
@@ -541,8 +541,7 @@ pub fn run_camera(
                 session.process_frame_gpu_rgba(
                     demosaic_left.output_texture(),
                     demosaic_right.output_texture(),
-                    pos.yaw,
-                    pos.pitch,
+                    pos,
                 )?;
                 frame_count += 1;
                 progress.report(frame_count);

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -569,10 +569,12 @@ pub fn run_camera(
 
             let mut source = GstreamerNvmmCameraSource::open(&cam_config)?;
 
-            // Allocate the NvBufSurfTransform detection surfaces. The model
-            // input is square; all shipped yolo26 engines use 1280x1280.
-            // Skipped when there is no detector (sweep / no model) - the
-            // detection arm then no-ops and the director still advances.
+            // Allocate the NvBufSurfTransform detection surfaces. The
+            // model input is square, but the size here ASSUMES a
+            // 1280x1280 engine: 640 builds ship too and get a
+            // mismatched letterbox from this constant. The size
+            // belongs to engine introspection (the ORT and Metal
+            // backends already read it from the model), not here.
             if ai_tracking {
                 let model_size = 1280u32;
                 session

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use reco_core::render::viewport::ViewportSize;
-use reco_core::source::FrameSet;
 use reco_io::gstreamer::camera::CameraConfig;
 
 use crate::helpers;
@@ -608,11 +607,12 @@ pub fn run_camera(
         anyhow::bail!("NVMM zero-copy is only available on Linux/Jetson");
     } else if use_nv12_capture {
         // NV12 path: skip nvvidconv format conversion, upload 2 planes
+        use reco_core::source::FrameSource;
         let mut source = reco_io::gstreamer::camera::GstreamerNv12CameraSource::open(&cam_config)?;
 
-        // Warm up: discard first frame (camera ISP + pipeline init)
-        if let Some((left, right)) = source.next_pair()? {
-            let frames = FrameSet::Nv12(vec![left, right]);
+        // Warm up: render the first frame outside the progress loop so
+        // camera ISP + GPU pipeline init don't skew the reported rate.
+        if let Some(frames) = source.next_frame()? {
             session.detect_and_update_director(&frames, start.elapsed())?;
             let pos = session.director_position();
             session.process_frame(&frames, pos)?;
@@ -622,15 +622,14 @@ pub fn run_camera(
         let progress = helpers::ProgressReporter::new(30);
 
         while frame_count < frame_limit && !interrupted.load(Ordering::Relaxed) {
-            let (left, right) = {
+            let frames = {
                 reco_core::profile_scope!("wait_capture");
-                match source.next_pair()? {
-                    Some(p) => p,
+                match source.next_frame()? {
+                    Some(f) => f,
                     None => break,
                 }
             };
 
-            let frames = FrameSet::Nv12(vec![left, right]);
             session.detect_and_update_director(&frames, start.elapsed())?;
             let pos = session.director_position();
             session.process_frame(&frames, pos)?;

--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use reco_core::render::viewport::ViewportSize;
-use reco_core::source::StereoFrame;
+use reco_core::source::FrameSet;
 use reco_io::gstreamer::camera::CameraConfig;
 
 use crate::helpers;
@@ -559,7 +559,7 @@ pub fn run_camera(
         // NvBufSurfTransform for detection. No CPU copies at all.
         //
         // Driven by the session's unified frame loop (`run` / `run_buffered`)
-        // through the `FrameSource` + `StereoFrame::NvmmResident` path - the
+        // through the `FrameSource` + `FrameSet::NvmmResident` path - the
         // same machinery the file-stitch path uses. So lookahead, centered
         // smoothing, and the VRAM pool all work here for free; the per-frame
         // import + NvBufSurfTransform happen inside the session's produce
@@ -611,18 +611,18 @@ pub fn run_camera(
         let mut source = reco_io::gstreamer::camera::GstreamerNv12CameraSource::open(&cam_config)?;
 
         // Warm up: discard first frame (camera ISP + pipeline init)
-        if let Some(pair) = source.next_pair()? {
-            let stereo = StereoFrame::Nv12(pair);
-            session.detect_and_update_director(&stereo, start.elapsed())?;
+        if let Some((left, right)) = source.next_pair()? {
+            let frames = FrameSet::Nv12(vec![left, right]);
+            session.detect_and_update_director(&frames, start.elapsed())?;
             let pos = session.director_position();
-            session.process_frame(&stereo, pos)?;
+            session.process_frame(&frames, pos)?;
             println!("Warmup complete, starting capture...");
         }
 
         let progress = helpers::ProgressReporter::new(30);
 
         while frame_count < frame_limit && !interrupted.load(Ordering::Relaxed) {
-            let pair = {
+            let (left, right) = {
                 reco_core::profile_scope!("wait_capture");
                 match source.next_pair()? {
                     Some(p) => p,
@@ -630,10 +630,10 @@ pub fn run_camera(
                 }
             };
 
-            let stereo = StereoFrame::Nv12(pair);
-            session.detect_and_update_director(&stereo, start.elapsed())?;
+            let frames = FrameSet::Nv12(vec![left, right]);
+            session.detect_and_update_director(&frames, start.elapsed())?;
             let pos = session.director_position();
-            session.process_frame(&stereo, pos)?;
+            session.process_frame(&frames, pos)?;
             frame_count += 1;
             progress.report(frame_count);
         }
@@ -724,14 +724,14 @@ impl reco_calibrate::live::LiveFramePairSource for Nv12CameraCalibSource {
                 return None;
             }
             match self.source.next_pair() {
-                Ok(Some(pair)) => {
+                Ok(Some((left, right))) => {
                     self.frame_count += 1;
                     if self.frame_count < self.fps && self.frame_count > 1 {
                         continue;
                     }
                     return Some((
-                        nv12_to_yuv(&pair.left, self.width, self.height),
-                        nv12_to_yuv(&pair.right, self.width, self.height),
+                        nv12_to_yuv(&left, self.width, self.height),
+                        nv12_to_yuv(&right, self.width, self.height),
                     ));
                 }
                 Ok(None) => return None,

--- a/crates/reco-cli/src/main.rs
+++ b/crates/reco-cli/src/main.rs
@@ -120,13 +120,12 @@ struct Cli {
 enum Commands {
     /// Stitch camera video files into a panoramic output.
     Stitch {
-        /// Path to the left camera video file (or the single
-        /// pre-stitched panorama for cylinder calibrations).
-        left: String,
-
-        /// Path to the right camera video file. Omit for single-input
-        /// (cylinder) calibrations.
-        right: Option<String>,
+        /// Input videos, one per camera in projection order (two for
+        /// L-shape calibrations, one pre-stitched panorama for the
+        /// cylinder). Chain multi-segment recordings per input with
+        /// `;` (e.g. `a1.mp4;a2.mp4 b1.mp4;b2.mp4`).
+        #[arg(required = true, num_args = 1..)]
+        inputs: Vec<String>,
 
         /// Path to the calibration JSON file.
         #[arg(short, long)]
@@ -777,8 +776,7 @@ fn main() -> anyhow::Result<()> {
 
     match cli.command {
         Commands::Stitch {
-            left,
-            right,
+            inputs,
             calibration,
             output,
             width,
@@ -809,8 +807,7 @@ fn main() -> anyhow::Result<()> {
             panner_preset,
         } => stitch::run_stitch(
             stitch::StitchArgs {
-                left: &left,
-                right: right.as_deref(),
+                inputs: &inputs,
                 calibration: &calibration,
                 output: &output,
                 width,

--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -53,12 +53,16 @@ const FRAME_SKIP_COUNT: usize = 30;
 /// Number of seconds to seek on `[`/`]` key press.
 const SEEK_STEP_SECS: f64 = 5.0;
 
-/// Extract a [`YuvData`] pair from a [`StereoFrame`](reco_core::source::StereoFrame).
+/// Extract a [`YuvData`] pair from a [`FrameSet`](reco_core::source::FrameSet).
 ///
-/// Panics if the frame is not `Yuv420p` (preview always uses CPU decode).
-fn unwrap_yuv_pair(frame: reco_core::source::StereoFrame) -> (YuvData, YuvData) {
+/// Panics if the set is not two-camera `Yuv420p` (preview always uses
+/// CPU decode of a stereo pair; its GPU render path is two-camera).
+fn unwrap_yuv_pair(frame: reco_core::source::FrameSet) -> (YuvData, YuvData) {
     match frame {
-        reco_core::source::StereoFrame::Yuv420p(pair) => (pair.left, pair.right),
+        reco_core::source::FrameSet::Yuv420p(cams) => match <[YuvData; 2]>::try_from(cams) {
+            Ok([left, right]) => (left, right),
+            Err(_) => panic!("preview expects two-camera Yuv420p sets"),
+        },
         _ => panic!("preview expects Yuv420p frames"),
     }
 }

--- a/crates/reco-cli/src/preview.rs
+++ b/crates/reco-cli/src/preview.rs
@@ -58,13 +58,10 @@ const SEEK_STEP_SECS: f64 = 5.0;
 /// Panics if the set is not two-camera `Yuv420p` (preview always uses
 /// CPU decode of a stereo pair; its GPU render path is two-camera).
 fn unwrap_yuv_pair(frame: reco_core::source::FrameSet) -> (YuvData, YuvData) {
-    match frame {
-        reco_core::source::FrameSet::Yuv420p(cams) => match <[YuvData; 2]>::try_from(cams) {
-            Ok([left, right]) => (left, right),
-            Err(_) => panic!("preview expects two-camera Yuv420p sets"),
-        },
-        _ => panic!("preview expects Yuv420p frames"),
-    }
+    let Some([left, right]) = frame.into_yuv_pair() else {
+        panic!("preview expects two-camera Yuv420p sets");
+    };
+    (left, right)
 }
 
 /// Configuration for the interactive preview window.

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -1,4 +1,5 @@
-//! Stitch subcommand: encode two video files into a panoramic output.
+//! Stitch subcommand: encode per-camera video files into a panoramic
+//! output.
 //!
 //! Uses `StitchJob` (Layer 3 API) for all cases, including autocam.
 //! The `on_session` callback wires up detection and direction when a
@@ -17,8 +18,8 @@ use std::sync::atomic::AtomicBool;
 /// across features.
 #[allow(dead_code)]
 pub struct StitchArgs<'a> {
-    pub left: &'a str,
-    pub right: Option<&'a str>,
+    /// Input videos, one per camera in projection order.
+    pub inputs: &'a [String],
     pub calibration: &'a str,
     pub output: &'a str,
     pub width: u32,
@@ -107,17 +108,11 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
             reco_io::stitch_job::InputPath::Single(std::path::PathBuf::from(s))
         }
     };
-    let mut job = match args.right {
-        Some(right) => reco_io::StitchJob::with_calibration(
-            to_input(args.left),
-            to_input(right),
-            cal,
-            args.output,
-        ),
-        // One input: the calibration must carry a mono topology
-        // (StitchJob::run rejects the mismatch with a typed error).
-        None => reco_io::StitchJob::mono_with_calibration(to_input(args.left), cal, args.output),
-    };
+    // Arity is not decided here: StitchJob::run validates the input
+    // count against the calibration's topology with a typed error.
+    let inputs: Vec<reco_io::stitch_job::InputPath> =
+        args.inputs.iter().map(|s| to_input(s)).collect();
+    let mut job = reco_io::StitchJob::with_calibration(inputs, cal, args.output);
     job = job
         .codec(parse_codec(args.codec))
         .quality(parse_quality(args.quality))

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -90,28 +90,14 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
     #[cfg_attr(not(feature = "autocam"), allow(unused_variables))]
     let field_roi = cal.field_roi.clone();
 
-    // Accept `a.mp4;b.mp4;c.mp4` to chain segments via the concat demuxer
-    // (mirrors the GUI's multi-segment selection). A single path stays Single.
-    let to_input = |s: &str| -> reco_io::stitch_job::InputPath {
-        let parts: Vec<std::path::PathBuf> = s
-            .split(';')
-            .filter(|p| !p.is_empty())
-            .map(std::path::PathBuf::from)
-            .collect();
-        if parts.len() > 1 {
-            log::info!(
-                "CLI input: {} segments, chaining via concat demuxer",
-                parts.len()
-            );
-            reco_io::stitch_job::InputPath::Chained(parts)
-        } else {
-            reco_io::stitch_job::InputPath::Single(std::path::PathBuf::from(s))
-        }
-    };
     // Arity is not decided here: StitchJob::run validates the input
     // count against the calibration's topology with a typed error.
-    let inputs: Vec<reco_io::stitch_job::InputPath> =
-        args.inputs.iter().map(|s| to_input(s)).collect();
+    // Each input accepts `a.mp4;b.mp4` segment chaining.
+    let inputs: Vec<reco_io::stitch_job::InputPath> = args
+        .inputs
+        .iter()
+        .map(|s| reco_io::stitch_job::InputPath::parse_segments(s))
+        .collect();
     let mut job = reco_io::StitchJob::with_calibration(inputs, cal, args.output);
     job = job
         .codec(parse_codec(args.codec))

--- a/crates/reco-core/README.md
+++ b/crates/reco-core/README.md
@@ -16,7 +16,7 @@ src/
   lens/        - KB4 fisheye model, undistortion, rig correction
   stitch/      - Projection-agnostic CPU/GPU stitch backends + agreement oracle
   calibration.rs - Calibration (lenses, topology, framing)
-  source.rs      - FrameSource trait, StereoFrame enum
+  source.rs      - FrameSource trait, FrameSet enum
   encoder.rs     - Encoder trait
   telemetry.rs   - Per-frame timing collection
 ```

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -1,8 +1,8 @@
 //! `StitchCore` - push-first canonical entry point for the stitching engine.
 //!
 //! Live sports production is the primary use case, so the canonical
-//! API is push-based: consumers call `StitchCore::submit_frame_yuv` /
-//! `submit_frame_bgra` whenever a new frame pair is ready, and the
+//! API is push-based: consumers call `StitchCore::submit_frame`
+//! whenever a new frame set is ready, and the
 //! core owns the render substrate, readback, detection, pose
 //! resolution, coverage, and the replay ring buffer.
 //!
@@ -569,8 +569,8 @@ impl StitchCore {
 
     /// Enable or disable constrained-look clamping.
     ///
-    /// When `true`, [`Self::submit_frame_yuv`] / `..._bgra` /
-    /// `submit_frame_*_at_pose` pass the director's (or caller's)
+    /// When `true`, [`Self::submit_frame`] and the
+    /// `submit_frame_*_at_pose` variants pass the director's (or caller's)
     /// pose through [`Self::safe_clamp`] before rendering.
     /// When `false`, the raw pose is used verbatim; the FOV max is
     /// still respected (pipeline-set) but coverage-based yaw/pitch
@@ -845,7 +845,6 @@ mod tests {
     #[test]
     fn engine_over_cpu_executor_pure_logic_works() {
         use crate::core::StitchCore;
-        use crate::render::planes::YuvPlanes;
         use crate::render::viewport::ViewportSize;
         use crate::stitch::{CpuExecutor, Executor, test_support::calib};
 
@@ -896,12 +895,13 @@ mod tests {
         // (no warmup), at the resized output dimensions.
         let y = vec![0u8; (w * h) as usize];
         let uv = vec![128u8; (w * h / 4) as usize];
-        let planes = YuvPlanes {
-            y: &y,
-            u: &uv,
-            v: &uv,
+        let cam = crate::source::YuvData {
+            y,
+            u: uv.clone(),
+            v: uv,
         };
-        match core.submit_frame_yuv(&planes, &planes) {
+        let frames = crate::source::FrameSet::Yuv420p(vec![cam.clone(), cam]);
+        match core.submit_frame(&frames) {
             Ok(crate::core::types::RenderOutcome::Rgba(bytes)) => {
                 assert_eq!(bytes.len(), 48 * 26 * 4);
             }
@@ -916,6 +916,10 @@ mod tests {
         // (the methods exist only when the gpu feature compiles them).
         #[cfg(feature = "gpu")]
         {
+            let crate::source::FrameSet::Yuv420p(cams) = &frames else {
+                unreachable!("constructed above");
+            };
+            let planes = cams[0].as_planes();
             assert!(matches!(
                 core.flush().unwrap_err(),
                 StitchCoreError::RequiresGpu
@@ -928,8 +932,50 @@ mod tests {
         }
     }
 
+    /// The FrameSet arity invariant: a set whose length does not match
+    /// the projection's camera count is rejected with a typed error at
+    /// the submit boundary (`check_camera_count` on the CPU stitch
+    /// path), never silently mis-sampled. This is the enforcement
+    /// artifact for the "len == camera_count" claim on [`FrameSet`].
+    #[test]
+    fn submit_frame_rejects_camera_count_mismatch() {
+        use crate::core::StitchCore;
+        use crate::render::viewport::ViewportSize;
+        use crate::stitch::{CpuExecutor, Executor, test_support::calib};
+
+        let (w, h) = (64u32, 36u32);
+        let executor = CpuExecutor::new(
+            calib(w, h), // L-shape: camera_count == 2
+            ViewportSize {
+                width: w,
+                height: h,
+            },
+            w,
+            h,
+            false,
+        )
+        .expect("cpu executor");
+        let mut core = StitchCore::new(Executor::Cpu(Box::new(executor))).expect("cpu engine");
+
+        let cam = crate::source::YuvData {
+            y: vec![0u8; (w * h) as usize],
+            u: vec![128u8; (w * h / 4) as usize],
+            v: vec![128u8; (w * h / 4) as usize],
+        };
+        let mono_set = crate::source::FrameSet::Yuv420p(vec![cam]);
+        // RenderOutcome borrows the core and is not Debug; unwrap by match.
+        let err = match core.submit_frame(&mono_set) {
+            Ok(_) => panic!("a 1-camera set on a 2-camera projection must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("2 camera(s) but 1 frame(s)"),
+            "expected the camera-count mismatch error, got: {err}"
+        );
+    }
+
     /// Engine-level executor agreement: the same submit API
-    /// (`submit_frame_nv12`) driven over a CPU engine and a GPU engine
+    /// (`submit_frame`, NV12 set) driven over a CPU engine and a GPU engine
     /// produces the same frame within the established oracle bounds.
     /// The Step-12 guarantee: swapping the executor does not change
     /// the picture.
@@ -938,7 +984,6 @@ mod tests {
     fn cpu_and_gpu_engines_agree_via_submit_nv12() {
         use crate::core::StitchCore;
         use crate::core::types::RenderOutcome;
-        use crate::render::planes::Nv12Planes;
         use crate::render::renderer::InputFormat;
         use crate::render::viewport::ViewportSize;
         use crate::stitch::test_support::{Agreement, AgreementBounds, calib, gpu_or_skip, nv12};
@@ -955,8 +1000,10 @@ mod tests {
         };
         let (ly, luv) = nv12(cam_w, cam_h, 0);
         let (ry, ruv) = nv12(cam_w, cam_h, 30);
-        let left = Nv12Planes { y: &ly, uv: &luv };
-        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let frames = crate::source::FrameSet::Nv12(vec![
+            crate::source::Nv12Data { y: ly, uv: luv },
+            crate::source::Nv12Data { y: ry, uv: ruv },
+        ]);
 
         let cpu_exec = CpuExecutor::new(calib(cam_w, cam_h), config.clone(), cam_w, cam_h, false)
             .expect("cpu executor");
@@ -973,10 +1020,7 @@ mod tests {
         let mut gpu_core = StitchCore::new(Executor::Gpu(Box::new(gpu_exec))).expect("gpu engine");
 
         // CPU: synchronous - the first submit yields the frame.
-        let cpu_rgba = match cpu_core
-            .submit_frame_nv12(&left, &right)
-            .expect("cpu submit")
-        {
+        let cpu_rgba = match cpu_core.submit_frame(&frames).expect("cpu submit") {
             RenderOutcome::Rgba(bytes) => bytes.to_vec(),
             RenderOutcome::Warmup => panic!("CPU submit is synchronous - no warmup"),
         };
@@ -986,9 +1030,7 @@ mod tests {
         // (same input, same resolved pose), so any yielded frame works.
         let mut gpu_rgba = None;
         for _ in 0..3 {
-            if let RenderOutcome::Rgba(bytes) = gpu_core
-                .submit_frame_nv12(&left, &right)
-                .expect("gpu submit")
+            if let RenderOutcome::Rgba(bytes) = gpu_core.submit_frame(&frames).expect("gpu submit")
             {
                 gpu_rgba = Some(bytes.to_vec());
                 break;
@@ -1010,7 +1052,6 @@ mod tests {
     fn resize_then_submit_yields_resized_frames() {
         use crate::core::StitchCore;
         use crate::core::types::RenderOutcome;
-        use crate::render::planes::Nv12Planes;
         use crate::render::renderer::InputFormat;
         use crate::render::viewport::ViewportSize;
         use crate::stitch::test_support::{calib, gpu_or_skip, nv12};
@@ -1035,20 +1076,20 @@ mod tests {
 
         let (ly, luv) = nv12(cam_w, cam_h, 0);
         let (ry, ruv) = nv12(cam_w, cam_h, 30);
-        let left = Nv12Planes { y: &ly, uv: &luv };
-        let right = Nv12Planes { y: &ry, uv: &ruv };
+        let frames = crate::source::FrameSet::Nv12(vec![
+            crate::source::Nv12Data { y: ly, uv: luv },
+            crate::source::Nv12Data { y: ry, uv: ruv },
+        ]);
 
         // Warm the ring at the original size, then resize.
-        let _ = core.submit_frame_nv12(&left, &right).expect("submit");
+        let _ = core.submit_frame(&frames).expect("submit");
         assert_eq!(core.resize(128, 72), Some((128, 72)));
 
         // The rebuilt ring delivers frames at the new size by the
         // third post-resize submit.
         let mut delivered = None;
         for _ in 0..3 {
-            if let RenderOutcome::Rgba(bytes) =
-                core.submit_frame_nv12(&left, &right).expect("submit")
-            {
+            if let RenderOutcome::Rgba(bytes) = core.submit_frame(&frames).expect("submit") {
                 delivered = Some(bytes.len());
                 break;
             }

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -1131,7 +1131,7 @@ mod tests {
         }
         fn detect(
             &mut self,
-            _camera: crate::geometry::CameraId,
+            _camera: crate::geometry::CameraIndex,
             _frame: &crate::detect::detector::DetectorFrame<'_>,
         ) -> Result<Vec<crate::detect::detector::Detection>, crate::detect::detector::DetectorError>
         {
@@ -1184,7 +1184,7 @@ mod tests {
         use crate::detect::detector::{
             ChromaFormat, Detection, DetectorError, DetectorFrame, RawFrame, UnifiedDetector,
         };
-        use crate::geometry::CameraId;
+        use crate::geometry::CameraIndex;
 
         struct RecordingDetector;
         impl UnifiedDetector for RecordingDetector {
@@ -1193,7 +1193,7 @@ mod tests {
             }
             fn detect(
                 &mut self,
-                camera: CameraId,
+                camera: CameraIndex,
                 frame: &DetectorFrame<'_>,
             ) -> Result<Vec<Detection>, DetectorError> {
                 match frame {
@@ -1227,11 +1227,11 @@ mod tests {
                 }),
             )
         };
-        core.run_detection_frames(&[frame(CameraId::Left), frame(CameraId::Right)]);
+        core.run_detection_frames(&[frame(0), frame(1)]);
 
         let dets = core.last_detections();
         assert_eq!(dets.len(), 2);
-        assert_eq!(dets[0].camera, CameraId::Left);
-        assert_eq!(dets[1].camera, CameraId::Right);
+        assert_eq!(dets[0].camera, 0);
+        assert_eq!(dets[1].camera, 1);
     }
 }

--- a/crates/reco-core/src/core/mod.rs
+++ b/crates/reco-core/src/core/mod.rs
@@ -916,17 +916,8 @@ mod tests {
         // (the methods exist only when the gpu feature compiles them).
         #[cfg(feature = "gpu")]
         {
-            let crate::source::FrameSet::Yuv420p(cams) = &frames else {
-                unreachable!("constructed above");
-            };
-            let planes = cams[0].as_planes();
             assert!(matches!(
                 core.flush().unwrap_err(),
-                StitchCoreError::RequiresGpu
-            ));
-            assert!(matches!(
-                core.render_yuv_at_pose(&planes, &planes, Pose::default())
-                    .unwrap_err(),
                 StitchCoreError::RequiresGpu
             ));
         }

--- a/crates/reco-core/src/core/pose.rs
+++ b/crates/reco-core/src/core/pose.rs
@@ -8,7 +8,7 @@
 use crate::detect::detector::{ChromaFormat, Detection, DetectorError, DetectorFrame, RawFrame};
 use crate::detect::director::MappedDetection;
 use crate::detect::tracker::WorldState;
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 use crate::geometry::Pose;
 use crate::projection;
 use crate::render::planes::YuvPlanes;
@@ -207,7 +207,7 @@ impl super::StitchCore {
     /// Errors are warned-and-dropped: a flaky inference call must not
     /// crash the render loop. `UnsupportedFrameKind` logs at debug -
     /// it is the expected answer while a caller probes backends.
-    pub fn run_detection_frames(&mut self, frames: &[(CameraId, DetectorFrame<'_>)]) {
+    pub fn run_detection_frames(&mut self, frames: &[(CameraIndex, DetectorFrame<'_>)]) {
         let Some(ref mut detector) = self.detector else {
             return;
         };
@@ -237,7 +237,7 @@ impl super::StitchCore {
     ) {
         self.run_detection_frames(&[
             (
-                CameraId::Left,
+                0,
                 DetectorFrame::Cpu(RawFrame {
                     y: left.y,
                     chroma: ChromaFormat::Yuv420p {
@@ -249,7 +249,7 @@ impl super::StitchCore {
                 }),
             ),
             (
-                CameraId::Right,
+                1,
                 DetectorFrame::Cpu(RawFrame {
                     y: right.y,
                     chroma: ChromaFormat::Yuv420p {
@@ -274,7 +274,7 @@ impl super::StitchCore {
     ) {
         self.run_detection_frames(&[
             (
-                CameraId::Left,
+                0,
                 DetectorFrame::Cpu(RawFrame {
                     y: left.y,
                     chroma: ChromaFormat::Nv12 { uv: left.uv },
@@ -283,7 +283,7 @@ impl super::StitchCore {
                 }),
             ),
             (
-                CameraId::Right,
+                1,
                 DetectorFrame::Cpu(RawFrame {
                     y: right.y,
                     chroma: ChromaFormat::Nv12 { uv: right.uv },

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -17,53 +17,155 @@ impl super::StitchCore {
     // Submit / render
     // -----------------------------------------------------------------
 
-    /// Submit a stereo YUV420P frame pair and render the current pose.
+    /// Submit a CPU-resident frame set and render the current pose.
     ///
-    /// Uses the director (if attached) and coverage clamping to pick
-    /// the viewport, renders, and reads back RGBA. The first two calls
-    /// produce [`RenderOutcome::Warmup`] while the triple-buffered
-    /// staging ring fills; from the third call onward every submit
-    /// yields RGBA bytes from two frames ago.
-    pub fn submit_frame_yuv(
+    /// The director-driven push entry for every CPU-resident format:
+    /// runs detection on schedule, ticks the director and coverage
+    /// clamping to pick the viewport, renders, and reads back RGBA.
+    /// On the GPU executor the first two calls produce
+    /// [`RenderOutcome::Warmup`] while the triple-buffered staging ring
+    /// fills; the CPU executor stitches synchronously.
+    ///
+    /// The set length is validated against the projection's camera
+    /// count by the executor (`check_camera_count` on the CPU arm; the
+    /// GPU render program is two-camera until the mono GPU pass lands,
+    /// so other lengths get a typed error there). Detection and the
+    /// stacked replay recorder consume two-camera sets only today -
+    /// other sets render without them (the detector warns once and
+    /// idles).
+    ///
+    /// GPU-resident variants (shared-texture slots, D3D11, NVMM,
+    /// Metal) are session-managed zero-copy paths, not push submits;
+    /// they get a typed error here.
+    pub fn submit_frame(
         &mut self,
-        left: &YuvPlanes<'_>,
-        right: &YuvPlanes<'_>,
+        frames: &crate::source::FrameSet,
     ) -> Result<RenderOutcome<'_>, StitchCoreError> {
+        use crate::source::FrameSet;
         self.anchor_session_start();
-
-        // Feed the stacked-video replay recorder before render so
-        // the recording captures the exact planes the pipeline will
-        // see. Errors inside the recorder are logged by the impl;
-        // never propagate them - a failing recorder must not break
-        // the live stitch output.
-        if let Some(ref mut recorder) = self.stacked_recorder {
-            let (src_w, src_h) = self.executor.source_info();
-            recorder.record_yuv(left, right, src_w, src_h);
+        match frames {
+            FrameSet::Yuv420p(cams) => {
+                // Feed the stacked-video replay recorder before render
+                // so the recording captures the exact planes the
+                // pipeline will see. Errors inside the recorder are
+                // logged by the impl; never propagate them - a failing
+                // recorder must not break the live stitch output. The
+                // stacked format is 2-tile, so only pair sets record.
+                if let [left, right] = cams.as_slice()
+                    && let Some(ref mut recorder) = self.stacked_recorder
+                {
+                    let (src_w, src_h) = self.executor.source_info();
+                    recorder.record_yuv(&left.as_planes(), &right.as_planes(), src_w, src_h);
+                }
+                let ran_detection = self.detect_yuv_set(cams);
+                let pose = self.resolve_current_pose(ran_detection);
+                match &self.executor {
+                    Executor::Cpu(_) => {
+                        let planes: Vec<YuvPlanes<'_>> =
+                            cams.iter().map(|c| c.as_planes()).collect();
+                        self.submit_cpu_yuv(&planes, pose)
+                    }
+                    #[cfg(feature = "gpu")]
+                    Executor::Gpu(_) => match cams.as_slice() {
+                        [left, right] => {
+                            self.submit_gpu_yuv(&left.as_planes(), &right.as_planes(), pose)
+                        }
+                        _ => Err(Self::mono_gpu_not_wired()),
+                    },
+                }
+            }
+            FrameSet::Nv12(cams) => {
+                // The stacked replay recorder is YUV420P-native and
+                // does not tap NV12 submits today.
+                let ran_detection = self.detect_nv12_set(cams);
+                let pose = self.resolve_current_pose(ran_detection);
+                match &self.executor {
+                    Executor::Cpu(_) => {
+                        let planes: Vec<crate::render::planes::Nv12Planes<'_>> =
+                            cams.iter().map(|c| c.as_planes()).collect();
+                        self.submit_cpu_nv12(&planes, pose)
+                    }
+                    #[cfg(feature = "gpu")]
+                    Executor::Gpu(_) => match cams.as_slice() {
+                        [left, right] => {
+                            self.submit_gpu_nv12(&left.as_planes(), &right.as_planes(), pose)
+                        }
+                        _ => Err(Self::mono_gpu_not_wired()),
+                    },
+                }
+            }
+            _ => Err(StitchCoreError::Config(
+                "GPU-resident frame sets are session-managed zero-copy paths; \
+                 submit_frame takes CPU-resident sets (YUV420P / NV12)"
+                    .into(),
+            )),
         }
+    }
 
-        // Detection first, so the director's `update` tick in
-        // resolve_current_pose sees the latest tracked objects. Skipped
-        // frames reuse last_detections so the director still has context.
-        let ran_detection = self.detection_due(self.frame_count);
-        if ran_detection {
-            let (src_w, src_h) = self.executor.source_info();
-            self.run_yuv_detection(left, right, src_w, src_h);
+    /// Run scheduled detection on a YUV420P set. Detection mapping is
+    /// two-camera only today; other set lengths warn once and idle.
+    /// Returns whether detection ran (feeds the director's
+    /// fresh-detection flag in `resolve_current_pose`).
+    fn detect_yuv_set(&mut self, cams: &[crate::source::YuvData]) -> bool {
+        if !self.detection_due(self.frame_count) {
+            return false;
         }
+        match cams {
+            [left, right] => {
+                let (src_w, src_h) = self.executor.source_info();
+                self.run_yuv_detection(&left.as_planes(), &right.as_planes(), src_w, src_h);
+                true
+            }
+            _ => {
+                self.warn_detection_unmapped();
+                false
+            }
+        }
+    }
 
-        let pose = self.resolve_current_pose(ran_detection);
-        match &self.executor {
-            Executor::Cpu(_) => self.submit_cpu_yuv(left, right, pose),
-            #[cfg(feature = "gpu")]
-            Executor::Gpu(_) => self.submit_gpu_yuv(left, right, pose),
+    /// NV12 counterpart of [`Self::detect_yuv_set`].
+    fn detect_nv12_set(&mut self, cams: &[crate::source::Nv12Data]) -> bool {
+        if !self.detection_due(self.frame_count) {
+            return false;
         }
+        match cams {
+            [left, right] => {
+                let (src_w, src_h) = self.executor.source_info();
+                self.run_nv12_detection(&left.as_planes(), &right.as_planes(), src_w, src_h);
+                true
+            }
+            _ => {
+                self.warn_detection_unmapped();
+                false
+            }
+        }
+    }
+
+    /// One-time warning when a detector is attached but the set shape
+    /// has no detection mapping (mono topologies).
+    fn warn_detection_unmapped(&mut self) {
+        if !self.mono_detection_warned {
+            self.mono_detection_warned = true;
+            log::warn!("detection is not supported on mono topologies yet; the detector idles");
+        }
+    }
+
+    /// Typed error for GPU submits of set shapes the two-camera GPU
+    /// program cannot render yet.
+    #[cfg(feature = "gpu")]
+    fn mono_gpu_not_wired() -> StitchCoreError {
+        StitchCoreError::Executor(crate::stitch::StitchError::InvalidConfig(
+            "the mono GPU pass is not wired yet; run mono topologies on the \
+             CPU executor"
+                .into(),
+        ))
     }
 
     /// CPU arm of the YUV submits: synchronous software stitch - RGBA
     /// immediately, no staging ring, no warmup.
     fn submit_cpu_yuv(
         &mut self,
-        left: &YuvPlanes<'_>,
-        right: &YuvPlanes<'_>,
+        planes: &[YuvPlanes<'_>],
         pose: Pose,
     ) -> Result<RenderOutcome<'_>, StitchCoreError> {
         // Infallible on wgpu-free builds (single-variant enum); the gpu
@@ -74,7 +176,24 @@ impl super::StitchCore {
             #[cfg(feature = "gpu")]
             Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
         };
-        let rgba = cpu.stitch_yuv(&[*left, *right], pose)?;
+        let rgba = cpu.stitch_yuv(planes, pose)?;
+        Ok(self.deliver_cpu_frame(rgba, pose))
+    }
+
+    /// NV12 counterpart of [`Self::submit_cpu_yuv`].
+    fn submit_cpu_nv12(
+        &mut self,
+        planes: &[crate::render::planes::Nv12Planes<'_>],
+        pose: Pose,
+    ) -> Result<RenderOutcome<'_>, StitchCoreError> {
+        // See submit_cpu_yuv for the wgpu-free lint note.
+        #[allow(clippy::infallible_destructuring_match)]
+        let cpu = match &self.executor {
+            Executor::Cpu(cpu) => cpu,
+            #[cfg(feature = "gpu")]
+            Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
+        };
+        let rgba = cpu.stitch_nv12(planes, pose)?;
         Ok(self.deliver_cpu_frame(rgba, pose))
     }
 
@@ -130,7 +249,7 @@ impl super::StitchCore {
 
     /// Submit a stereo YUV420P frame pair at an explicit pose.
     ///
-    /// Same full loop as [`Self::submit_frame_yuv`] - anchors the
+    /// Same full loop as [`Self::submit_frame`] - anchors the
     /// session-start clock, runs detection when
     /// `frame_count % detection_interval == 0`, renders, reads back
     /// RGBA, pushes into the replay buffer, increments frame_count -
@@ -148,7 +267,7 @@ impl super::StitchCore {
     ) -> Result<RenderOutcome<'_>, StitchCoreError> {
         self.anchor_session_start();
 
-        // Replay recording tap - see `submit_frame_yuv` for the
+        // Replay recording tap - see `submit_frame` for the
         // rationale (record-before-render so the file exactly
         // matches what the pipeline consumed).
         if let Some(ref mut recorder) = self.stacked_recorder {
@@ -159,13 +278,13 @@ impl super::StitchCore {
         // `submit_frame_yuv_at_pose` bypasses resolve_current_pose (caller
         // provides the pose directly), but detection still runs on the
         // schedule so directors stay populated for a later `current_pose()`
-        // peek or a regular `submit_frame_yuv` submit.
+        // peek or a regular `submit_frame` submit.
         if self.detection_due(self.frame_count) {
             let (src_w, src_h) = self.executor.source_info();
             self.run_yuv_detection(left, right, src_w, src_h);
         }
         match &self.executor {
-            Executor::Cpu(_) => self.submit_cpu_yuv(left, right, pose),
+            Executor::Cpu(_) => self.submit_cpu_yuv(&[*left, *right], pose),
             #[cfg(feature = "gpu")]
             Executor::Gpu(_) => self.submit_gpu_yuv(left, right, pose),
         }
@@ -215,7 +334,7 @@ impl super::StitchCore {
     /// current pose.
     ///
     /// Requires the core to have been built with `InputFormat::Bgra`.
-    /// See [`Self::submit_frame_yuv`] for return semantics.
+    /// See [`Self::submit_frame`] for return semantics.
     #[cfg(feature = "gpu")]
     pub fn submit_frame_bgra(
         &mut self,
@@ -266,49 +385,7 @@ impl super::StitchCore {
         })
     }
 
-    /// Submit a stereo NV12 frame pair and render the current pose.
-    ///
-    /// Works on both executors. The CPU arm stitches synchronously
-    /// (RGBA available immediately, no warmup); the GPU arm requires a
-    /// pipeline built with `InputFormat::Nv12` and follows the
-    /// triple-buffered readback semantics of
-    /// [`Self::submit_frame_yuv`]. NV12 is the native camera / NVDEC /
-    /// X5 format, so this is the day-1 submit path for live sources.
-    ///
-    /// The stacked replay recorder is YUV420P-native and does not tap
-    /// NV12 submits today.
-    pub fn submit_frame_nv12(
-        &mut self,
-        left: &crate::render::planes::Nv12Planes<'_>,
-        right: &crate::render::planes::Nv12Planes<'_>,
-    ) -> Result<RenderOutcome<'_>, StitchCoreError> {
-        self.anchor_session_start();
-
-        let ran_detection = self.detection_due(self.frame_count);
-        if ran_detection {
-            let (src_w, src_h) = self.executor.source_info();
-            self.run_nv12_detection(left, right, src_w, src_h);
-        }
-
-        let pose = self.resolve_current_pose(ran_detection);
-        match &self.executor {
-            Executor::Cpu(_) => {
-                // See submit_cpu_yuv for the wgpu-free lint note.
-                #[allow(clippy::infallible_destructuring_match)]
-                let cpu = match &self.executor {
-                    Executor::Cpu(cpu) => cpu,
-                    #[cfg(feature = "gpu")]
-                    Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
-                };
-                let rgba = cpu.stitch_nv12(&[*left, *right], pose)?;
-                Ok(self.deliver_cpu_frame(rgba, pose))
-            }
-            #[cfg(feature = "gpu")]
-            Executor::Gpu(_) => self.submit_gpu_nv12(left, right, pose),
-        }
-    }
-
-    /// GPU arm of [`Self::submit_frame_nv12`].
+    /// GPU arm of the NV12 submits.
     #[cfg(feature = "gpu")]
     fn submit_gpu_nv12(
         &mut self,
@@ -342,51 +419,6 @@ impl super::StitchCore {
             Some(bytes) => RenderOutcome::Rgba(bytes),
             None => RenderOutcome::Warmup,
         })
-    }
-
-    /// Submit a mono frame - a single pre-stitched panorama - and
-    /// render the current pose. The single-camera counterpart of
-    /// [`Self::submit_frame_yuv`] for mono topologies (the cylinder).
-    ///
-    /// Detection is not wired for mono topologies yet (the
-    /// detection-to-panorama mapping is L-shape-only); an attached
-    /// detector logs once and idles, and the panner runs without
-    /// detections. The stacked replay recorder (2-tile format) is
-    /// likewise skipped.
-    // TODO: wire mono detection + replay.
-    pub fn submit_frame_mono_yuv(
-        &mut self,
-        frame: &YuvPlanes<'_>,
-    ) -> Result<RenderOutcome<'_>, StitchCoreError> {
-        self.anchor_session_start();
-
-        if self.detection_due(self.frame_count) && !self.mono_detection_warned {
-            self.mono_detection_warned = true;
-            log::warn!("detection is not supported on mono topologies yet; the detector idles");
-        }
-
-        let pose = self.resolve_current_pose(false);
-        match &self.executor {
-            Executor::Cpu(_) => {
-                // See submit_cpu_yuv for the wgpu-free lint note.
-                #[allow(clippy::infallible_destructuring_match)]
-                let cpu = match &self.executor {
-                    Executor::Cpu(cpu) => cpu,
-                    #[cfg(feature = "gpu")]
-                    Executor::Gpu(_) => unreachable!("routed from the CPU arm"),
-                };
-                let rgba = cpu.stitch_yuv(&[*frame], pose)?;
-                Ok(self.deliver_cpu_frame(rgba, pose))
-            }
-            #[cfg(feature = "gpu")]
-            Executor::Gpu(_) => Err(StitchCoreError::Executor(
-                crate::stitch::StitchError::InvalidConfig(
-                    "the mono GPU pass is not wired yet; run mono topologies on the \
-                     CPU executor"
-                        .into(),
-                ),
-            )),
-        }
     }
 
     /// Store a CPU-stitched frame and hand out the borrowed outcome -
@@ -498,7 +530,7 @@ impl super::StitchCore {
     /// Does not run detection, does not tick the director, does not
     /// read back RGBA. Consumers that want the full `submit_*` loop
     /// (detection + director + readback) should call
-    /// [`Self::submit_frame_yuv`] instead.
+    /// [`Self::submit_frame`] instead.
     ///
     /// The caller is responsible for consuming the render by
     /// submitting the returned command buffer (directly or chained
@@ -553,24 +585,24 @@ impl super::StitchCore {
             .map_err(crate::stitch::StitchError::from)?)
     }
 
-    /// Render any [`StereoFrame`](crate::source::StereoFrame) variant
+    /// Render any [`FrameSet`](crate::source::FrameSet) variant
     /// (YUV / NV12 / GpuResident) at an explicit pose.
     ///
-    /// Thin wrapper over the pipeline's stereo-frame render that
+    /// Thin wrapper over the pipeline's frame-set render that
     /// converts the pipeline error into a `StitchCoreError`. The
     /// `MetalResident` variant is NOT handled here; use
     /// [`Self::render_imported_textures_at_pose`] after importing the
     /// `CVPixelBuffer` via `MetalTextureCache`.
     #[cfg(feature = "gpu")]
-    pub fn render_stereo_frame_at_pose(
+    pub fn render_frame_set_at_pose(
         &self,
-        frame: &crate::source::StereoFrame,
+        frames: &crate::source::FrameSet,
         pose: Pose,
     ) -> Result<wgpu::CommandBuffer, StitchCoreError> {
         let Executor::Gpu(gpu) = &self.executor else {
             return Err(StitchCoreError::RequiresGpu);
         };
-        Ok(gpu.pipeline.render_stereo_frame(frame, pose)?)
+        Ok(gpu.pipeline.render_frame_set(frames, pose)?)
     }
 
     /// Render from four pre-imported textures at an explicit pose.

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -42,9 +42,9 @@ impl super::StitchCore {
         frames: &crate::source::FrameSet,
     ) -> Result<RenderOutcome<'_>, StitchCoreError> {
         use crate::source::FrameSet;
-        self.anchor_session_start();
         match frames {
             FrameSet::Yuv420p(cams) => {
+                self.anchor_session_start();
                 // Feed the stacked-video replay recorder before render
                 // so the recording captures the exact planes the
                 // pipeline will see. Errors inside the recorder are
@@ -75,6 +75,7 @@ impl super::StitchCore {
                 }
             }
             FrameSet::Nv12(cams) => {
+                self.anchor_session_start();
                 // The stacked replay recorder is YUV420P-native and
                 // does not tap NV12 submits today.
                 let ran_detection = self.detect_nv12_set(cams);

--- a/crates/reco-core/src/core/render.rs
+++ b/crates/reco-core/src/core/render.rs
@@ -293,8 +293,14 @@ impl super::StitchCore {
     /// Submit a stereo BGRA frame pair at an explicit pose. See
     /// [`Self::submit_frame_yuv_at_pose`] for semantics.
     ///
-    /// Does not run detection (BGRA backends are not yet supported;
-    /// see [`Self::submit_frame_bgra`] for the rationale).
+    /// Does not run detection: YOLO backends today consume YUV or
+    /// NV12 `RawFrame` variants, and wrapping BGRA bytes as a YUV
+    /// frame would need a color-space conversion we are not paying
+    /// for. Consumers that want detection on BGRA sources (OBS
+    /// Browser Source, screen capture) attach a detector that
+    /// understands BGRA once such a backend exists; until then BGRA
+    /// submits tick the director with the last detections from any
+    /// earlier YUV submits.
     #[cfg(feature = "gpu")]
     pub fn submit_frame_bgra_at_pose(
         &mut self,
@@ -303,61 +309,6 @@ impl super::StitchCore {
         pose: Pose,
     ) -> Result<RenderOutcome<'_>, StitchCoreError> {
         self.anchor_session_start();
-        let Executor::Gpu(gpu) = &self.executor else {
-            return Err(StitchCoreError::RequiresGpu);
-        };
-        let cmd = gpu.pipeline.render_to_target_bgra(left, right, pose)?;
-        let captured_at = self.session_start.map(|s| s.elapsed()).unwrap_or_default();
-        let Executor::Gpu(gpu) = &self.executor else {
-            return Err(StitchCoreError::RequiresGpu);
-        };
-        let rgba = self
-            .readback
-            .as_mut()
-            .expect("gpu engine owns the readback ring")
-            .readback(gpu.pipeline.gpu(), gpu.pipeline.render_target(), cmd)?;
-        self.frame_count += 1;
-        if let (Some(replay), Some(bytes)) = (self.replay.as_mut(), rgba) {
-            replay.push(ReplayFrame {
-                rgba: bytes.to_vec(),
-                captured_at,
-                pose,
-            });
-        }
-        Ok(match rgba {
-            Some(bytes) => RenderOutcome::Rgba(bytes),
-            None => RenderOutcome::Warmup,
-        })
-    }
-
-    /// Submit a stereo packed-RGBA/BGRA frame pair and render the
-    /// current pose.
-    ///
-    /// Requires the core to have been built with `InputFormat::Bgra`.
-    /// See [`Self::submit_frame`] for return semantics.
-    #[cfg(feature = "gpu")]
-    pub fn submit_frame_bgra(
-        &mut self,
-        left: &BgraPlanes<'_>,
-        right: &BgraPlanes<'_>,
-    ) -> Result<RenderOutcome<'_>, StitchCoreError> {
-        self.anchor_session_start();
-
-        // BGRA detection path: YOLO backends today consume YUV or
-        // NV12 `RawFrame` variants. Wrapping BGRA bytes as a YUV
-        // frame would require a color-space conversion we're not
-        // paying for yet - consumers that want detection on BGRA
-        // sources (OBS Browser Source, screen capture) attach a
-        // detector that understands BGRA once such a backend exists.
-        // For now, BGRA submits tick the director with the last
-        // detections (potentially from earlier YUV submits) but do
-        // not run detection themselves.
-
-        // `fresh_detection = false`: BGRA submits never run detection by
-        // design (see comment above). Directors must see this frame as
-        // "reusing cached detections" even on interval ticks, otherwise
-        // hysteresis counters over-fire.
-        let pose = self.resolve_current_pose(false);
         let Executor::Gpu(gpu) = &self.executor else {
             return Err(StitchCoreError::RequiresGpu);
         };
@@ -524,45 +475,6 @@ impl super::StitchCore {
     // dispatch. They are also the render primitives for multi-output
     // consumers (record + stream, zero-copy compositor).
     // -----------------------------------------------------------------
-
-    /// Render a stereo YUV420P frame at an explicit pose.
-    ///
-    /// Does not run detection, does not tick the director, does not
-    /// read back RGBA. Consumers that want the full `submit_*` loop
-    /// (detection + director + readback) should call
-    /// [`Self::submit_frame`] instead.
-    ///
-    /// The caller is responsible for consuming the render by
-    /// submitting the returned command buffer (directly or chained
-    /// into further GPU work); the engine's readback and NV12
-    /// delivery paths do this internally.
-    #[cfg(feature = "gpu")]
-    pub fn render_yuv_at_pose(
-        &self,
-        left: &YuvPlanes<'_>,
-        right: &YuvPlanes<'_>,
-        pose: Pose,
-    ) -> Result<wgpu::CommandBuffer, StitchCoreError> {
-        let Executor::Gpu(gpu) = &self.executor else {
-            return Err(StitchCoreError::RequiresGpu);
-        };
-        Ok(gpu.pipeline.render_to_target(left, right, pose)?)
-    }
-
-    /// Render a stereo packed-RGBA/BGRA frame at an explicit pose.
-    /// See [`Self::render_yuv_at_pose`] for semantics.
-    #[cfg(feature = "gpu")]
-    pub fn render_bgra_at_pose(
-        &self,
-        left: &BgraPlanes<'_>,
-        right: &BgraPlanes<'_>,
-        pose: Pose,
-    ) -> Result<wgpu::CommandBuffer, StitchCoreError> {
-        let Executor::Gpu(gpu) = &self.executor else {
-            return Err(StitchCoreError::RequiresGpu);
-        };
-        Ok(gpu.pipeline.render_to_target_bgra(left, right, pose)?)
-    }
 
     /// Render from GPU-resident RGBA textures (e.g. Bayer demosaic output).
     ///

--- a/crates/reco-core/src/core/replay_management.rs
+++ b/crates/reco-core/src/core/replay_management.rs
@@ -253,7 +253,7 @@ impl super::StitchCore {
     /// Runs the GPU pack from the pipeline's internal plane
     /// textures. Used by CPU-upload submit paths where
     /// `queue.write_texture` has just populated the renderer's
-    /// own textures - fires from `submit_frame_yuv*` and from the
+    /// own textures - fires from the `submit_frame` push path and from the
     /// session's `process_frame` non-zero-copy branch. Zero-copy
     /// paths take [`Self::pack_gpu_stacked_replay_from_views`]
     /// instead because their source data lives in shared

--- a/crates/reco-core/src/core/types.rs
+++ b/crates/reco-core/src/core/types.rs
@@ -50,7 +50,7 @@ pub enum StitchCoreError {
 }
 
 /// Returned from every [`super::StitchCore::submit_frame`] /
-/// [`super::StitchCore::submit_frame_bgra`] call.
+/// `submit_frame_*_at_pose` call.
 ///
 /// On the GPU executor, readback is triple-buffered: the first two
 /// calls produce [`RenderOutcome::Warmup`] while the staging ring

--- a/crates/reco-core/src/core/types.rs
+++ b/crates/reco-core/src/core/types.rs
@@ -49,7 +49,7 @@ pub enum StitchCoreError {
     StackedPacker(#[from] PackerError),
 }
 
-/// Returned from every [`super::StitchCore::submit_frame_yuv`] /
+/// Returned from every [`super::StitchCore::submit_frame`] /
 /// [`super::StitchCore::submit_frame_bgra`] call.
 ///
 /// On the GPU executor, readback is triple-buffered: the first two
@@ -99,7 +99,7 @@ pub struct ReplayFrame {
 /// # Semantics
 ///
 /// - `record_yuv` fires after every successful YUV submit via
-///   [`super::StitchCore::submit_frame_yuv`] and
+///   [`super::StitchCore::submit_frame`] and
 ///   [`super::StitchCore::submit_frame_yuv_at_pose`]. It sees the tight
 ///   (no-stride) YUV420P planes the render consumed, so the
 ///   recorded replay exactly matches what the stitch pipeline saw.

--- a/crates/reco-core/src/detect/detector.rs
+++ b/crates/reco-core/src/detect/detector.rs
@@ -12,7 +12,7 @@
 //! they must run on the original camera frames before stitching.
 //! The slight wide-angle distortion is negligible for detection accuracy.
 
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 
 /// Raw camera frame data for detection.
 ///
@@ -58,7 +58,7 @@ pub enum ChromaFormat<'a> {
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct Detection {
     /// Which camera this detection came from.
-    pub camera: CameraId,
+    pub camera: CameraIndex,
 
     /// Detection class index from the model (e.g. 0 = "ball", 1 = "person").
     /// Map to a human-readable label via the detector's `class_names()`.
@@ -323,7 +323,7 @@ pub trait UnifiedDetector: Send {
     ///   the call.
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError>;
 
@@ -396,7 +396,7 @@ mod tests {
 
         fn detect(
             &mut self,
-            camera: CameraId,
+            camera: CameraIndex,
             frame: &DetectorFrame<'_>,
         ) -> Result<Vec<Detection>, DetectorError> {
             match frame {
@@ -432,11 +432,9 @@ mod tests {
         let mut det: Box<dyn UnifiedDetector> = Box::new(FakeDetector {
             labels: vec!["ball".into()],
         });
-        let out = det
-            .detect(CameraId::Left, &DetectorFrame::Cpu(raw))
-            .unwrap();
+        let out = det.detect(0, &DetectorFrame::Cpu(raw)).unwrap();
         assert_eq!(out.len(), 1);
-        assert_eq!(out[0].camera, CameraId::Left);
+        assert_eq!(out[0].camera, 0);
     }
 
     #[test]
@@ -456,7 +454,7 @@ mod tests {
             width: 2,
             height: 2,
         };
-        assert!(det.detect(CameraId::Left, &DetectorFrame::Cpu(raw)).is_ok());
+        assert!(det.detect(0, &DetectorFrame::Cpu(raw)).is_ok());
     }
 
     #[test]

--- a/crates/reco-core/src/detect/director.rs
+++ b/crates/reco-core/src/detect/director.rs
@@ -13,7 +13,7 @@
 //! trait is gone; only these value types remain. Rename deferred to
 //! avoid a repo-wide import churn.
 
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 use crate::geometry::Pose;
 
 /// A detection mapped to panorama coordinates.
@@ -27,7 +27,7 @@ use crate::geometry::Pose;
 #[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct MappedDetection {
     /// Which camera this detection came from.
-    pub camera: CameraId,
+    pub camera: CameraIndex,
 
     /// Detection class index from the model (e.g. 0 = "ball", 1 = "person").
     /// Map to a human-readable label via the detector's `class_names()`.

--- a/crates/reco-core/src/detect/panner.rs
+++ b/crates/reco-core/src/detect/panner.rs
@@ -231,7 +231,7 @@ mod tests {
     use super::*;
     use crate::calibration::{Calibration, Framing, Lens};
     use crate::detect::tracker::{TrackState, TrackedEntity, WorldState};
-    use crate::geometry::CameraId;
+
     use crate::projection::LShape;
 
     /// A fixture calibration shaped like the v1 test JSON without
@@ -285,7 +285,7 @@ mod tests {
                 confidence: 0.9,
                 state: TrackState::Tracking,
                 age_frames: 5,
-                origin: CameraId::Left,
+                origin: 0,
             }),
             players: vec![],
         };

--- a/crates/reco-core/src/detect/tracker.rs
+++ b/crates/reco-core/src/detect/tracker.rs
@@ -33,7 +33,7 @@
 //!   future tracker variants ship in `reco-autocam::trackers`.
 
 use super::director::MappedDetection;
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 
 /// A tri-valued lifecycle flag attached to every [`TrackedEntity`].
 ///
@@ -99,7 +99,7 @@ pub struct TrackedEntity {
     /// Which camera observed the most recent accepted measurement.
     /// Diagnostic field only — downstream logic should route through
     /// [`yaw`](Self::yaw) / [`pitch`](Self::pitch), not by origin.
-    pub origin: CameraId,
+    pub origin: CameraIndex,
 }
 
 /// The merged per-frame output of every registered tracker.
@@ -214,7 +214,7 @@ mod tests {
             confidence: 0.9,
             state: TrackState::Tracking,
             age_frames: 1,
-            origin: CameraId::Left,
+            origin: 0,
         }
     }
 

--- a/crates/reco-core/src/geometry/mod.rs
+++ b/crates/reco-core/src/geometry/mod.rs
@@ -19,7 +19,7 @@ mod virtual_camera;
 // until a consumer demonstrates the need.
 pub use matrices::{FAR_PLANE, NEAR_PLANE, view_matrix};
 pub use rig_correction::{resolve_render_pose, world_to_render_pose};
-pub use types::{CameraId, Pose};
+pub use types::{CameraIndex, Pose};
 pub use virtual_camera::VirtualCamera;
 
 #[cfg(feature = "gpu")]

--- a/crates/reco-core/src/geometry/types.rs
+++ b/crates/reco-core/src/geometry/types.rs
@@ -1,7 +1,7 @@
 //! The pose and source-identity currency every layer shares.
 //!
 //! `Pose` travels from human input and AI directors through
-//! the clamp and orient stages into the render; `CameraId` names which
+//! the clamp and orient stages into the render; `CameraIndex` names which
 //! source a detection or sample came from. Both live in the geometry
 //! leaf so no layer has to import another layer's domain to talk about
 //! a pose.
@@ -53,20 +53,11 @@ impl Default for Pose {
     }
 }
 
-/// Which camera produced this frame.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub enum CameraId {
-    /// Left camera (plane in X-Z space).
-    Left,
-    /// Right camera (plane in X-Y space).
-    Right,
-}
-
-impl std::fmt::Display for CameraId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Left => f.write_str("L"),
-            Self::Right => f.write_str("R"),
-        }
-    }
-}
+/// Which camera produced a frame or detection: the index into
+/// `calibration.lenses`, in projection order (the L-shape's camera 0
+/// is the X-Z plane, camera 1 the X-Y plane).
+///
+/// A plain index, not an enum: the calibration document is the
+/// authority on how many cameras exist, and serialized forms (the
+/// events JSONL) carry the same integer.
+pub type CameraIndex = usize;

--- a/crates/reco-core/src/lib.rs
+++ b/crates/reco-core/src/lib.rs
@@ -30,7 +30,7 @@
 //! ## Modularity
 //!
 //! The crate defines traits for pluggable components:
-//! - [`source::FrameSource`] — delivers stereo frame pairs (files, cameras, streams)
+//! - [`source::FrameSource`] — delivers per-camera frame sets (files, cameras, streams)
 //! - [`detect::detector::UnifiedDetector`] — detects objects in raw frames (e.g. ball tracking)
 //! - [`detect::tracker::Tracker`] — turns detections into stable tracked entities
 //! - [`detect::panner::Panner`] — turns the tracked world state into a viewport pose

--- a/crates/reco-core/src/projection/coverage.rs
+++ b/crates/reco-core/src/projection/coverage.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::FRAC_PI_2;
 
 use crate::calibration::Calibration;
-use crate::geometry::CameraId;
+
 use crate::projection::l_shape::PlaneScene;
 
 use crate::geometry::VirtualCamera;
@@ -149,8 +149,8 @@ impl CoverageBoundary {
         let mut left_points: Vec<(f32, f32)> = Vec::new();
         let mut right_points: Vec<(f32, f32)> = Vec::new();
 
-        for &camera in &[CameraId::Left, CameraId::Right] {
-            let points = if camera == CameraId::Left {
+        for &camera in &[0, 1] {
+            let points = if camera == 0 {
                 &mut left_points
             } else {
                 &mut right_points

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -301,6 +301,7 @@ fn plane_uv_to_world(uv: (f64, f64), camera: CameraIndex, scene: &PlaneScene) ->
     // Reachable only with a lens-validated index (the caller resolved
     // `lenses[camera]` first), so on the two-camera L-shape this is a
     // binary choice.
+    debug_assert!(camera < 2, "the L-shape mapping is two-camera");
     let model = if camera == 0 {
         scene.model_matrix_left()
     } else {

--- a/crates/reco-core/src/projection/mod.rs
+++ b/crates/reco-core/src/projection/mod.rs
@@ -28,7 +28,7 @@ pub use l_shape::{DEFAULT_BLEND_WIDTH, LShape};
 pub use geometry::point_in_polygon;
 
 use crate::calibration::{Calibration, Framing, Lens};
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 use crate::geometry::Pose;
 use crate::geometry::VirtualCamera;
 use crate::stitch::{BlendRule, SurfaceMap};
@@ -47,7 +47,7 @@ use nalgebra::{Point3, Vector3};
 // to keep in sync. The trait dispatches the CPU surface maps, the GPU
 // program descriptor, coverage construction and the virtual-camera
 // basis; the detection-side forward maps (`camera_to_panorama`) are
-// the next fold-in - their `CameraId`/`Pose` currency already lives in
+// the next fold-in - their `CameraIndex`/`Pose` currency already lives in
 // the geometry leaf, so nothing blocks the move.
 
 /// One frame's geometry question, bundled: the document, the output
@@ -142,17 +142,17 @@ const CONVERGENCE_EPS: f64 = 1e-10;
 ///
 /// ```rust
 /// use reco_core::projection::camera_to_panorama;
-/// use reco_core::geometry::CameraId;
+/// use reco_core::geometry::CameraIndex;
 /// use reco_core::calibration::Calibration;
 ///
 /// # fn example(cal: &Calibration) {
-/// if let Some(pos) = camera_to_panorama(CameraId::Left, 0.5, 0.5, cal) {
+/// if let Some(pos) = camera_to_panorama(0, 0.5, 0.5, cal) {
 ///     println!("Center of left camera maps to yaw={:.3}, pitch={:.3}", pos.yaw, pos.pitch);
 /// }
 /// # }
 /// ```
 pub fn camera_to_panorama(
-    camera: CameraId,
+    camera: CameraIndex,
     norm_x: f32,
     norm_y: f32,
     calibration: &Calibration,
@@ -165,16 +165,15 @@ pub fn camera_to_panorama(
 /// [`camera_to_panorama`] against an already-derived plane scene - the
 /// coverage sampler maps thousands of edge points against one scene.
 pub(crate) fn camera_to_panorama_in_scene(
-    camera: CameraId,
+    camera: CameraIndex,
     norm_x: f32,
     norm_y: f32,
     calibration: &Calibration,
     scene: &PlaneScene,
 ) -> Option<Pose> {
-    let params = match camera {
-        CameraId::Left => &calibration.lenses[0],
-        CameraId::Right => &calibration.lenses[1],
-    };
+    // The index doubles as the lens lookup; out-of-range cameras map
+    // to None like any other unmappable input.
+    let params = calibration.lenses.get(camera)?;
 
     // Step 1: Inverse fisheye - camera pixel [0,1] -> plane UV (extended space)
     let plane_uv = inverse_fisheye(norm_x as f64, norm_y as f64, params)?;
@@ -289,7 +288,7 @@ fn inverse_fisheye(dist_x: f64, dist_y: f64, params: &Lens) -> Option<(f64, f64)
 }
 
 /// Convert a plane UV (in extended shader space) to a 3D world point.
-fn plane_uv_to_world(uv: (f64, f64), camera: CameraId, scene: &PlaneScene) -> Point3<f32> {
+fn plane_uv_to_world(uv: (f64, f64), camera: CameraIndex, scene: &PlaneScene) -> Point3<f32> {
     // Extended UV -> texture UV [0,1]
     let tex_u = ((uv.0 + 0.5) / 2.0) as f32;
     let tex_v = ((uv.1 + 0.5) / 2.0) as f32;
@@ -299,9 +298,13 @@ fn plane_uv_to_world(uv: (f64, f64), camera: CameraId, scene: &PlaneScene) -> Po
     let local_y = (0.5 - tex_v) / scene.plane_aspect;
 
     let local_point = nalgebra::Vector4::new(local_x, local_y, 0.0, 1.0);
-    let model = match camera {
-        CameraId::Left => scene.model_matrix_left(),
-        CameraId::Right => scene.model_matrix_right(),
+    // Reachable only with a lens-validated index (the caller resolved
+    // `lenses[camera]` first), so on the two-camera L-shape this is a
+    // binary choice.
+    let model = if camera == 0 {
+        scene.model_matrix_left()
+    } else {
+        scene.model_matrix_right()
     };
 
     let world = model * local_point;
@@ -381,7 +384,7 @@ mod tests {
         let cx = cal.lenses[0].cx as f32 / cal.lenses[0].width as f32;
         let cy = cal.lenses[0].cy as f32 / cal.lenses[0].height as f32;
 
-        let pos = camera_to_panorama(CameraId::Left, cx, cy, &cal);
+        let pos = camera_to_panorama(0, cx, cy, &cal);
         assert!(pos.is_some(), "optical center should map successfully");
         let pos = pos.unwrap();
         // The optical center should produce a valid yaw/pitch (no NaN)
@@ -393,8 +396,8 @@ mod tests {
     fn left_camera_left_edge_yaw_differs_from_center() {
         let cal = test_calibration();
 
-        let center = camera_to_panorama(CameraId::Left, 0.5, 0.5, &cal).unwrap();
-        let left_edge = camera_to_panorama(CameraId::Left, 0.1, 0.5, &cal).unwrap();
+        let center = camera_to_panorama(0, 0.5, 0.5, &cal).unwrap();
+        let left_edge = camera_to_panorama(0, 0.1, 0.5, &cal).unwrap();
 
         // The left edge of the left camera image maps to a different
         // part of the panorama than the center; this test just
@@ -414,8 +417,8 @@ mod tests {
     fn right_camera_produces_different_yaw_than_left() {
         let cal = test_calibration();
 
-        let left_center = camera_to_panorama(CameraId::Left, 0.5, 0.5, &cal).unwrap();
-        let right_center = camera_to_panorama(CameraId::Right, 0.5, 0.5, &cal).unwrap();
+        let left_center = camera_to_panorama(0, 0.5, 0.5, &cal).unwrap();
+        let right_center = camera_to_panorama(1, 0.5, 0.5, &cal).unwrap();
 
         // The two cameras face different directions, so their centers
         // should map to different yaw values

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -41,7 +41,7 @@ pub enum PipelineError {
     #[error("this topology has no GPU plane scene; the mono GPU pass is not wired yet")]
     NoPlaneScene,
 
-    /// Wrong StereoFrame variant for this render method.
+    /// Wrong FrameSet variant for this render method.
     #[error("unsupported frame variant: {reason}")]
     UnsupportedFrameVariant {
         /// Description of the mismatch.
@@ -459,47 +459,42 @@ impl StitchPipeline {
         self.render_to_target_gpu(pose)
     }
 
-    /// Process a CPU-resident stereo frame and return the render command buffer.
+    /// Process a CPU-resident frame set and return the render command buffer.
     ///
     /// Handles YUV420P vs NV12 format differences internally.
     /// For GPU-resident frames, use [`Self::render_gpu_frame`] instead.
-    pub fn render_stereo_frame(
+    ///
+    /// The GPU render program is two-camera (the mono GPU pass is not
+    /// wired yet), so any other set length gets a typed error here.
+    pub fn render_frame_set(
         &self,
-        frame: &crate::source::StereoFrame,
+        frames: &crate::source::FrameSet,
         pose: Pose,
     ) -> Result<wgpu::CommandBuffer, PipelineError> {
-        use crate::source::StereoFrame;
-        match frame {
-            StereoFrame::Yuv420p(pair) => {
-                let left = YuvPlanes {
-                    y: &pair.left.y,
-                    u: &pair.left.u,
-                    v: &pair.left.v,
-                };
-                let right = YuvPlanes {
-                    y: &pair.right.y,
-                    u: &pair.right.u,
-                    v: &pair.right.v,
-                };
-                self.render_to_target(&left, &right, pose)
-            }
-            StereoFrame::Nv12(pair) => {
-                let left = Nv12Planes {
-                    y: &pair.left.y,
-                    uv: &pair.left.uv,
-                };
-                let right = Nv12Planes {
-                    y: &pair.right.y,
-                    uv: &pair.right.uv,
-                };
-                self.render_to_target_nv12(&left, &right, pose)
-            }
-            StereoFrame::GpuResident { .. } => Err(PipelineError::UnsupportedFrameVariant {
+        use crate::source::FrameSet;
+        match frames {
+            FrameSet::Yuv420p(cams) => match cams.as_slice() {
+                [left, right] => self.render_to_target(&left.as_planes(), &right.as_planes(), pose),
+                _ => Err(PipelineError::UnsupportedFrameVariant {
+                    reason: "the GPU render program is two-camera; the mono GPU pass \
+                             is not wired yet",
+                }),
+            },
+            FrameSet::Nv12(cams) => match cams.as_slice() {
+                [left, right] => {
+                    self.render_to_target_nv12(&left.as_planes(), &right.as_planes(), pose)
+                }
+                _ => Err(PipelineError::UnsupportedFrameVariant {
+                    reason: "the GPU render program is two-camera; the mono GPU pass \
+                             is not wired yet",
+                }),
+            },
+            FrameSet::GpuResident { .. } => Err(PipelineError::UnsupportedFrameVariant {
                 reason: "GpuResident frames must use render_gpu_frame()",
             }),
             #[allow(unreachable_patterns)]
             _ => Err(PipelineError::UnsupportedFrameVariant {
-                reason: "unsupported StereoFrame variant for CPU render path",
+                reason: "unsupported FrameSet variant for CPU render path",
             }),
         }
     }

--- a/crates/reco-core/src/render/pipeline.rs
+++ b/crates/reco-core/src/render/pipeline.rs
@@ -494,7 +494,8 @@ impl StitchPipeline {
             }),
             #[allow(unreachable_patterns)]
             _ => Err(PipelineError::UnsupportedFrameVariant {
-                reason: "unsupported FrameSet variant for CPU render path",
+                reason: "GPU-resident FrameSet variants use their platform render \
+                         paths, not the CPU-upload render",
             }),
         }
     }

--- a/crates/reco-core/src/session/detection_dispatch.rs
+++ b/crates/reco-core/src/session/detection_dispatch.rs
@@ -11,7 +11,7 @@
 use super::StitchSession;
 use crate::core::StitchCore;
 use crate::detect::detector::DetectorFrame;
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 use crate::session::types::SessionError;
 use crate::source::FrameSet;
 
@@ -22,13 +22,13 @@ fn cpu_frames<'a>(
     frame: &'a FrameSet,
     width: u32,
     height: u32,
-) -> Option<[(CameraId, DetectorFrame<'a>); 2]> {
+) -> Option<[(CameraIndex, DetectorFrame<'a>); 2]> {
     use crate::detect::detector::{ChromaFormat, RawFrame};
     match frame {
         FrameSet::Yuv420p(cams) => match cams.as_slice() {
             [left, right] => Some([
                 (
-                    CameraId::Left,
+                    0,
                     DetectorFrame::Cpu(RawFrame {
                         y: &left.y,
                         chroma: ChromaFormat::Yuv420p {
@@ -40,7 +40,7 @@ fn cpu_frames<'a>(
                     }),
                 ),
                 (
-                    CameraId::Right,
+                    1,
                     DetectorFrame::Cpu(RawFrame {
                         y: &right.y,
                         chroma: ChromaFormat::Yuv420p {
@@ -57,7 +57,7 @@ fn cpu_frames<'a>(
         FrameSet::Nv12(cams) => match cams.as_slice() {
             [left, right] => Some([
                 (
-                    CameraId::Left,
+                    0,
                     DetectorFrame::Cpu(RawFrame {
                         y: &left.y,
                         chroma: ChromaFormat::Nv12 { uv: &left.uv },
@@ -66,7 +66,7 @@ fn cpu_frames<'a>(
                     }),
                 ),
                 (
-                    CameraId::Right,
+                    1,
                     DetectorFrame::Cpu(RawFrame {
                         y: &right.y,
                         chroma: ChromaFormat::Nv12 { uv: &right.uv },
@@ -90,14 +90,14 @@ pub(super) fn cuda_nv12_frames(
     right_slot: u8,
     left_rotation: i32,
     right_rotation: i32,
-) -> [(CameraId, DetectorFrame<'static>); 2] {
+) -> [(CameraIndex, DetectorFrame<'static>); 2] {
     use crate::detect::detector::GpuNv12Frame;
     let ls = left_slot as usize;
     let rs = right_slot as usize;
     let is_10bit = left_buf.pixel_format == crate::render::renderer::GpuPixelFormat::P010;
     [
         (
-            CameraId::Left,
+            0,
             DetectorFrame::Cuda(GpuNv12Frame {
                 y_ptr: left_buf.y_ptr[ls],
                 uv_ptr: left_buf.uv_ptr[ls],
@@ -110,7 +110,7 @@ pub(super) fn cuda_nv12_frames(
             }),
         ),
         (
-            CameraId::Right,
+            1,
             DetectorFrame::Cuda(GpuNv12Frame {
                 y_ptr: right_buf.y_ptr[rs],
                 uv_ptr: right_buf.uv_ptr[rs],
@@ -138,10 +138,10 @@ pub(super) fn wgpu_nv12_frames<'a>(
     height: u32,
     left_rotation: i32,
     right_rotation: i32,
-) -> [(CameraId, DetectorFrame<'a>); 2] {
+) -> [(CameraIndex, DetectorFrame<'a>); 2] {
     [
         (
-            CameraId::Left,
+            0,
             DetectorFrame::WgpuNv12 {
                 y_view: left_y,
                 uv_view: left_uv,
@@ -151,7 +151,7 @@ pub(super) fn wgpu_nv12_frames<'a>(
             },
         ),
         (
-            CameraId::Right,
+            1,
             DetectorFrame::WgpuNv12 {
                 y_view: right_y,
                 uv_view: right_uv,
@@ -170,10 +170,10 @@ pub(super) fn metal_frames(
     right_cvpb: crate::interop::metal::CVPixelBufferRef,
     width: u32,
     height: u32,
-) -> [(CameraId, DetectorFrame<'static>); 2] {
+) -> [(CameraIndex, DetectorFrame<'static>); 2] {
     [
         (
-            CameraId::Left,
+            0,
             DetectorFrame::Metal {
                 cv_pixel_buffer: left_cvpb,
                 width,
@@ -181,7 +181,7 @@ pub(super) fn metal_frames(
             },
         ),
         (
-            CameraId::Right,
+            1,
             DetectorFrame::Metal {
                 cv_pixel_buffer: right_cvpb,
                 width,
@@ -357,7 +357,7 @@ impl StitchSession {
         self.detect_and_update_director_with(elapsed, |core| {
             core.run_detection_frames(&[
                 (
-                    CameraId::Left,
+                    0,
                     DetectorFrame::Rgba {
                         data: left_rgba,
                         width,
@@ -365,7 +365,7 @@ impl StitchSession {
                     },
                 ),
                 (
-                    CameraId::Right,
+                    1,
                     DetectorFrame::Rgba {
                         data: right_rgba,
                         width,
@@ -392,7 +392,7 @@ impl StitchSession {
         self.detect_and_update_director_with(elapsed, |core| {
             core.run_detection_frames(&[
                 (
-                    CameraId::Left,
+                    0,
                     DetectorFrame::CudaRgba {
                         ptr: left_ptr,
                         pitch: left_pitch,
@@ -401,7 +401,7 @@ impl StitchSession {
                     },
                 ),
                 (
-                    CameraId::Right,
+                    1,
                     DetectorFrame::CudaRgba {
                         ptr: right_ptr,
                         pitch: right_pitch,
@@ -427,7 +427,7 @@ impl StitchSession {
             crate::profile_scope!("detect_preletterboxed_total");
             core.run_detection_frames(&[
                 (
-                    CameraId::Left,
+                    0,
                     DetectorFrame::CudaRgbaLetterboxed {
                         ptr: left_ptr,
                         src_width,
@@ -435,7 +435,7 @@ impl StitchSession {
                     },
                 ),
                 (
-                    CameraId::Right,
+                    1,
                     DetectorFrame::CudaRgbaLetterboxed {
                         ptr: right_ptr,
                         src_width,

--- a/crates/reco-core/src/session/detection_dispatch.rs
+++ b/crates/reco-core/src/session/detection_dispatch.rs
@@ -13,63 +13,70 @@ use crate::core::StitchCore;
 use crate::detect::detector::DetectorFrame;
 use crate::geometry::CameraId;
 use crate::session::types::SessionError;
-use crate::source::StereoFrame;
+use crate::source::FrameSet;
 
-/// Per-camera CPU frames for a CPU-resident stereo pair; `None` for
-/// GPU-resident variants (their arms build residency-specific frames).
+/// Per-camera CPU frames for a CPU-resident two-camera set; `None` for
+/// GPU-resident variants (their arms build residency-specific frames)
+/// and for set shapes without a detection mapping (mono).
 fn cpu_frames<'a>(
-    frame: &'a StereoFrame,
+    frame: &'a FrameSet,
     width: u32,
     height: u32,
 ) -> Option<[(CameraId, DetectorFrame<'a>); 2]> {
     use crate::detect::detector::{ChromaFormat, RawFrame};
     match frame {
-        StereoFrame::Yuv420p(pair) => Some([
-            (
-                CameraId::Left,
-                DetectorFrame::Cpu(RawFrame {
-                    y: &pair.left.y,
-                    chroma: ChromaFormat::Yuv420p {
-                        u: &pair.left.u,
-                        v: &pair.left.v,
-                    },
-                    width,
-                    height,
-                }),
-            ),
-            (
-                CameraId::Right,
-                DetectorFrame::Cpu(RawFrame {
-                    y: &pair.right.y,
-                    chroma: ChromaFormat::Yuv420p {
-                        u: &pair.right.u,
-                        v: &pair.right.v,
-                    },
-                    width,
-                    height,
-                }),
-            ),
-        ]),
-        StereoFrame::Nv12(pair) => Some([
-            (
-                CameraId::Left,
-                DetectorFrame::Cpu(RawFrame {
-                    y: &pair.left.y,
-                    chroma: ChromaFormat::Nv12 { uv: &pair.left.uv },
-                    width,
-                    height,
-                }),
-            ),
-            (
-                CameraId::Right,
-                DetectorFrame::Cpu(RawFrame {
-                    y: &pair.right.y,
-                    chroma: ChromaFormat::Nv12 { uv: &pair.right.uv },
-                    width,
-                    height,
-                }),
-            ),
-        ]),
+        FrameSet::Yuv420p(cams) => match cams.as_slice() {
+            [left, right] => Some([
+                (
+                    CameraId::Left,
+                    DetectorFrame::Cpu(RawFrame {
+                        y: &left.y,
+                        chroma: ChromaFormat::Yuv420p {
+                            u: &left.u,
+                            v: &left.v,
+                        },
+                        width,
+                        height,
+                    }),
+                ),
+                (
+                    CameraId::Right,
+                    DetectorFrame::Cpu(RawFrame {
+                        y: &right.y,
+                        chroma: ChromaFormat::Yuv420p {
+                            u: &right.u,
+                            v: &right.v,
+                        },
+                        width,
+                        height,
+                    }),
+                ),
+            ]),
+            _ => None,
+        },
+        FrameSet::Nv12(cams) => match cams.as_slice() {
+            [left, right] => Some([
+                (
+                    CameraId::Left,
+                    DetectorFrame::Cpu(RawFrame {
+                        y: &left.y,
+                        chroma: ChromaFormat::Nv12 { uv: &left.uv },
+                        width,
+                        height,
+                    }),
+                ),
+                (
+                    CameraId::Right,
+                    DetectorFrame::Cpu(RawFrame {
+                        y: &right.y,
+                        chroma: ChromaFormat::Nv12 { uv: &right.uv },
+                        width,
+                        height,
+                    }),
+                ),
+            ]),
+            _ => None,
+        },
         _ => None,
     }
 }
@@ -209,17 +216,14 @@ impl StitchSession {
     /// advance the panner.
     pub(crate) fn detect_and_track_only(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         elapsed: std::time::Duration,
         produce_index: u64,
     ) -> Result<crate::detect::tracker::WorldState, SessionError> {
         if self.core.detection_due(produce_index) {
             match frame {
                 #[cfg(target_os = "linux")]
-                StereoFrame::GpuResident {
-                    left_slot,
-                    right_slot,
-                } => {
+                FrameSet::GpuResident { slots } => {
                     if self.core.detector_needs_cuda_frames() {
                         let bufs = self.core.executor.gpu().and_then(|g| g.cuda_buf_info());
                         if let Some((left_buf, right_buf)) = bufs {
@@ -227,8 +231,8 @@ impl StitchSession {
                             let frames = cuda_nv12_frames(
                                 &left_buf,
                                 &right_buf,
-                                *left_slot,
-                                *right_slot,
+                                slots[0],
+                                slots[1],
                                 self.left_rotation,
                                 self.right_rotation,
                             );
@@ -236,8 +240,8 @@ impl StitchSession {
                         }
                     } else if let Some(views) = self.shared_views() {
                         crate::profile_scope!("detect_wgpu_nv12");
-                        let ls = *left_slot as usize;
-                        let rs = *right_slot as usize;
+                        let ls = slots[0] as usize;
+                        let rs = slots[1] as usize;
                         let (w, h) = self.core.source_info();
                         let frames = wgpu_nv12_frames(
                             &views[ls * 2],
@@ -253,7 +257,7 @@ impl StitchSession {
                     }
                 }
                 #[cfg(target_os = "windows")]
-                StereoFrame::D3d11Resident { .. } => {
+                FrameSet::D3d11Resident(..) => {
                     let views = self
                         .gpu_exec_ref()
                         .d3d11_slots(produce_index)
@@ -275,13 +279,13 @@ impl StitchSession {
                     }
                 }
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
-                StereoFrame::MetalResident { left, right } => {
+                FrameSet::MetalResident([left, right]) => {
                     let frames =
                         metal_frames(left.as_ptr(), right.as_ptr(), left.width(), left.height());
                     self.core.run_detection_frames(&frames);
                 }
                 #[cfg(target_os = "linux")]
-                StereoFrame::NvmmResident { left, right } => {
+                FrameSet::NvmmResident([left, right]) => {
                     crate::profile_scope!("detect_preletterboxed_total");
                     if let Some(frames) = self.gpu_exec().nvmm_detector_frames(left, right) {
                         self.core.run_detection_frames(&frames);
@@ -304,7 +308,7 @@ impl StitchSession {
     /// Allocate the NVMM detection surfaces for the Jetson zero-copy path.
     ///
     /// Call once before [`run`](Self::run) when feeding a
-    /// `StereoFrame::NvmmResident` source (mirrors
+    /// `FrameSet::NvmmResident` source (mirrors
     /// [`setup_gpu_source`](Self::setup_gpu_source) for the desktop GPU
     /// path). `model_size` is the detector's square input dimension (e.g.
     /// 1280); `src_width`/`src_height` are the capture resolution, used to
@@ -322,10 +326,10 @@ impl StitchSession {
             .map_err(SessionError::ZeroCopy)
     }
 
-    /// Run detection on a CPU-resident stereo frame (YUV420P / NV12).
+    /// Run detection on a CPU-resident frame set (YUV420P / NV12).
     pub fn detect_and_update_director(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         elapsed: std::time::Duration,
     ) -> Result<(), SessionError> {
         let (w, h) = self.core.source_info();

--- a/crates/reco-core/src/session/frame_buffer.rs
+++ b/crates/reco-core/src/session/frame_buffer.rs
@@ -3,18 +3,18 @@
 //! Holds N decoded frames with their detection metadata so the
 //! panner can see future WorldStates when deciding the current
 //! frame's viewport position. Works for both CPU-resident frames
-//! (`StereoFrame::Yuv420p` / `Nv12`) and GPU-resident frames, where
+//! (`FrameSet::Yuv420p` / `Nv12`) and GPU-resident frames, where
 //! the pixels live in the VRAM pool and `vram_slot` indexes them.
 
 use std::collections::VecDeque;
 
 use crate::detect::director::MappedDetection;
 use crate::detect::tracker::WorldState;
-use crate::source::StereoFrame;
+use crate::source::FrameSet;
 
 /// A single buffered frame: decoded pixels + detection metadata.
 pub(crate) struct BufferedFrame {
-    pub frame: StereoFrame,
+    pub frame: FrameSet,
     pub world_state: WorldState,
     pub detections: Vec<MappedDetection>,
     pub elapsed_ms: f64,
@@ -84,16 +84,16 @@ mod tests {
 
     fn make_frame(ball_yaw: f32) -> BufferedFrame {
         BufferedFrame {
-            frame: StereoFrame::Nv12(crate::source::Nv12FramePair {
-                left: crate::source::Nv12Data {
+            frame: FrameSet::Nv12(vec![
+                crate::source::Nv12Data {
                     y: vec![128; 4],
                     uv: vec![128; 2],
                 },
-                right: crate::source::Nv12Data {
+                crate::source::Nv12Data {
                     y: vec![128; 4],
                     uv: vec![128; 2],
                 },
-            }),
+            ]),
             world_state: WorldState {
                 ball: Some(TrackedEntity {
                     id: 0,

--- a/crates/reco-core/src/session/frame_buffer.rs
+++ b/crates/reco-core/src/session/frame_buffer.rs
@@ -103,7 +103,7 @@ mod tests {
                     confidence: 0.9,
                     state: TrackState::Tracking,
                     age_frames: 1,
-                    origin: crate::geometry::CameraId::Left,
+                    origin: 0,
                 }),
                 players: vec![],
             },

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -1,12 +1,12 @@
 //! Per-frame render and encode methods for [`StitchSession`].
 //!
-//! These methods are called once per frame to render a stereo pair,
+//! These methods are called once per frame to render a frame set,
 //! convert to NV12, and fan out to attached sinks.
 
 use super::StitchSession;
 use crate::geometry::Pose;
 use crate::session::types::{FrameLoopContext, SessionError};
-use crate::source::StereoFrame;
+use crate::source::FrameSet;
 
 impl StitchSession {
     /// Get the current viewport position from the director, or default.
@@ -23,7 +23,7 @@ impl StitchSession {
     /// Full per-frame pipeline: detect, pose, render, replay, telemetry.
     ///
     /// Dispatches to the correct detection and render path per
-    /// [`StereoFrame`] variant. Every variant gets the same five stages;
+    /// [`FrameSet`] variant. Every variant gets the same five stages;
     /// the dispatch inside each stage takes platform shortcuts (CUDA
     /// shared textures, Metal IOSurface import, D3D11 staging, etc.).
     ///
@@ -35,7 +35,7 @@ impl StitchSession {
     )]
     pub(crate) fn process_frame_any(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         elapsed: std::time::Duration,
         decode_time: std::time::Duration,
         frame_t0: std::time::Instant,
@@ -52,21 +52,14 @@ impl StitchSession {
             let detect_t0 = std::time::Instant::now();
             let ran_detection = match frame {
                 #[cfg(target_os = "linux")]
-                StereoFrame::GpuResident {
-                    left_slot,
-                    right_slot,
-                } => {
+                FrameSet::GpuResident { slots } => {
                     if self.core.detector_needs_cuda_frames() {
                         if self.frame_count == 0 {
                             log::info!("GpuResident detection: CUDA path (TensorRT/ORT-CUDA)");
                         }
                         if let Some((left_buf, right_buf)) = &ctx.gpu_buf_info {
                             self.detect_and_update_director_gpu(
-                                left_buf,
-                                right_buf,
-                                *left_slot,
-                                *right_slot,
-                                elapsed,
+                                left_buf, right_buf, slots[0], slots[1], elapsed,
                             )?;
                             due
                         } else {
@@ -85,8 +78,8 @@ impl StitchSession {
                                 "GpuResident detection: wgpu shared texture views (ORT/wgpu preprocess)"
                             );
                         }
-                        let ls = *left_slot as usize;
-                        let rs = *right_slot as usize;
+                        let ls = slots[0] as usize;
+                        let rs = slots[1] as usize;
                         if due {
                             crate::profile_scope!("detect_wgpu_nv12");
                             let (w, h) = self.core.source_info();
@@ -115,7 +108,7 @@ impl StitchSession {
                     }
                 }
                 #[cfg(target_os = "linux")]
-                StereoFrame::NvmmResident { left, right } => {
+                FrameSet::NvmmResident([left, right]) => {
                     // Immediate (non-lookahead) NVMM detection: letterbox via
                     // NvBufSurfTransform, then detect. (The buffered path runs
                     // detection during produce and skips this whole step.)
@@ -129,7 +122,7 @@ impl StitchSession {
                     due
                 }
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
-                StereoFrame::MetalResident { left, right } => {
+                FrameSet::MetalResident([left, right]) => {
                     self.detect_and_update_director_metal(
                         left.as_ptr(),
                         right.as_ptr(),
@@ -140,7 +133,7 @@ impl StitchSession {
                     due
                 }
                 #[cfg(target_os = "windows")]
-                StereoFrame::D3d11Resident { .. } => {
+                FrameSet::D3d11Resident(..) => {
                     let left_slot = self.frame_count as usize % 2;
                     let right_slot = left_slot + 2;
                     if let Some(views) = self.gpu_exec_ref().d3d11_views(left_slot, right_slot) {
@@ -184,14 +177,11 @@ impl StitchSession {
         let render_t0 = std::time::Instant::now();
         match frame {
             #[cfg(target_os = "linux")]
-            StereoFrame::GpuResident {
-                left_slot,
-                right_slot,
-            } => {
-                self.render_gpu_resident(*left_slot, *right_slot, pos)?;
+            FrameSet::GpuResident { slots } => {
+                self.render_gpu_resident(slots[0], slots[1], pos)?;
             }
             #[cfg(target_os = "linux")]
-            StereoFrame::NvmmResident { left, right } => {
+            FrameSet::NvmmResident([left, right]) => {
                 if self.current_vram_slot.is_some() {
                     // Buffered path: the frame was already imported + copied
                     // into the pool slot during produce; render from it. The
@@ -203,12 +193,7 @@ impl StitchSession {
                 }
             }
             #[cfg(target_os = "windows")]
-            StereoFrame::D3d11Resident {
-                left_texture,
-                left_slice,
-                right_texture,
-                right_slice,
-            } => {
+            FrameSet::D3d11Resident([left, right]) => {
                 if let Some(staging_slot) = self.current_vram_slot {
                     // Buffered path: staging was done during produce.
                     // Render from the pre-staged slot.
@@ -222,10 +207,10 @@ impl StitchSession {
                         .poll(wgpu::PollType::wait_indefinitely());
                     let staging_t0 = std::time::Instant::now();
                     let first = self.stage_d3d11_frames(
-                        *left_texture,
-                        *left_slice,
-                        *right_texture,
-                        *right_slice,
+                        left.texture,
+                        left.slice,
+                        right.texture,
+                        right.slice,
                     )?;
                     upload_time = staging_t0.elapsed();
                     if first {
@@ -272,19 +257,19 @@ impl StitchSession {
         feature = "profiling",
         tracing::instrument(skip_all, name = "session_process_frame")
     )]
-    pub fn process_frame(&mut self, frame: &StereoFrame, pose: Pose) -> Result<(), SessionError> {
+    pub fn process_frame(&mut self, frame: &FrameSet, pose: Pose) -> Result<(), SessionError> {
         #[cfg(any(target_os = "macos", target_os = "ios"))]
-        if let StereoFrame::MetalResident { left, right } = frame {
+        if let FrameSet::MetalResident([left, right]) = frame {
             return self.process_metal_frame(left, right, pose);
         }
 
-        let render_buf = self.core.render_stereo_frame_at_pose(frame, pose)?;
+        let render_buf = self.core.render_frame_set_at_pose(frame, pose)?;
         self.submit_render_output(render_buf)?;
-        // GPU stacked-replay pack tap (M7). `render_stereo_frame_at_pose`
+        // GPU stacked-replay pack tap (M7). `render_frame_set_at_pose`
         // has just populated the renderer's internal plane textures
         // via `queue.write_texture`, so the packer's pipeline-view
         // path can read them. No-op when the packer isn't enabled.
-        // Zero-copy `StereoFrame::GpuResident` goes through
+        // Zero-copy `FrameSet::GpuResident` goes through
         // `step_gpu_with_bufs` (Linux) which taps the pack with
         // external views instead.
         self.core.pack_replay_from_pipeline();
@@ -601,7 +586,7 @@ impl StitchSession {
     /// Returns the slot index for rendering, or None for CPU frames.
     pub(crate) fn copy_to_vram_pool(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
         self.copy_to_vram_pool_platform(frame, produce_index)
@@ -618,16 +603,11 @@ impl StitchSession {
     /// No-op on platforms that do not use the GPU decode slot-free
     /// channel (Windows D3D11 stages into a persistent pool; macOS
     /// imports CVPixelBuffers).
-    pub(crate) fn release_gpu_decode_slot(&self, frame: &StereoFrame) {
+    pub(crate) fn release_gpu_decode_slot(&self, frame: &FrameSet) {
         #[cfg(target_os = "linux")]
         {
-            if let StereoFrame::GpuResident {
-                left_slot,
-                right_slot,
-            } = frame
-            {
-                self.gpu_exec_ref()
-                    .release_decode_slots(*left_slot, *right_slot);
+            if let FrameSet::GpuResident { slots } = frame {
+                self.gpu_exec_ref().release_decode_slots(slots[0], slots[1]);
             }
         }
         #[cfg(not(target_os = "linux"))]
@@ -639,24 +619,21 @@ impl StitchSession {
     #[cfg(target_os = "linux")]
     fn copy_to_vram_pool_platform(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         _produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
         // NVMM zero-copy: import the DMA-buf as Vulkan textures and copy
         // them into a VRAM pool slot - the same import-then-copy pattern
         // as the macOS Metal arm, just sourced from an NvBufSurface fd
         // instead of a CVPixelBuffer.
-        if let StereoFrame::NvmmResident { left, right } = frame {
+        if let FrameSet::NvmmResident([left, right]) = frame {
             return self
                 .gpu_exec()
                 .stage_nvmm_to_pool(left, right)
                 .map_err(SessionError::ZeroCopy);
         }
         let (ls, rs) = match frame {
-            StereoFrame::GpuResident {
-                left_slot,
-                right_slot,
-            } => (*left_slot as usize, *right_slot as usize),
+            FrameSet::GpuResident { slots } => (slots[0] as usize, slots[1] as usize),
             _ => return Ok(None),
         };
         // The decode slot is NOT released here. Detection reads it
@@ -671,16 +648,10 @@ impl StitchSession {
     #[cfg(target_os = "windows")]
     fn copy_to_vram_pool_platform(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
-        if let StereoFrame::D3d11Resident {
-            left_texture,
-            left_slice,
-            right_texture,
-            right_slice,
-        } = frame
-        {
+        if let FrameSet::D3d11Resident([left, right]) = frame {
             let needs_cuda = self.core.detector_needs_cuda_frames();
             let lookahead_frames = self.lookahead_frames;
             let pixel_format = self.gpu_pixel_format;
@@ -693,10 +664,10 @@ impl StitchSession {
                 .expect("staging pool created above");
             self.gpu_exec()
                 .stage_d3d11_frames(
-                    *left_texture,
-                    *left_slice,
-                    *right_texture,
-                    *right_slice,
+                    left.texture,
+                    left.slice,
+                    right.texture,
+                    right.slice,
                     left_slot,
                     right_slot,
                 )
@@ -709,10 +680,10 @@ impl StitchSession {
     #[cfg(any(target_os = "macos", target_os = "ios"))]
     fn copy_to_vram_pool_platform(
         &mut self,
-        frame: &StereoFrame,
+        frame: &FrameSet,
         _produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
-        if let StereoFrame::MetalResident { left, right } = frame {
+        if let FrameSet::MetalResident([left, right]) = frame {
             // SAFETY: RetainedCVPixelBuffer guarantees the pointers are valid.
             let [ly, lu, ry, ru] =
                 unsafe { self.gpu_exec().import_metal(left.as_ptr(), right.as_ptr()) }
@@ -735,7 +706,7 @@ impl StitchSession {
     )))]
     fn copy_to_vram_pool_platform(
         &mut self,
-        _frame: &StereoFrame,
+        _frame: &FrameSet,
         _produce_index: u64,
     ) -> Result<Option<usize>, SessionError> {
         Ok(None)

--- a/crates/reco-core/src/session/frame_processing.rs
+++ b/crates/reco-core/src/session/frame_processing.rs
@@ -248,7 +248,7 @@ impl StitchSession {
         Ok(())
     }
 
-    /// Render a single CPU-resident stereo frame and deliver it to the sinks.
+    /// Render a single CPU-resident frame set and deliver it to the sinks.
     ///
     /// Handles YUV420P and NV12 input formats. For GPU-resident frames
     /// (zero-copy path), use [`submit_render_output`](Self::submit_render_output)

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -554,6 +554,14 @@ impl StitchSession {
                 self.lookahead_frames
             );
         }
+        // The CPU loop skips the GPU-source configuration entirely, but
+        // color range is a per-source property the software stitch
+        // consumes too - without this, full-range sources rendered with
+        // the limited-range conversion.
+        if source.is_full_range() {
+            self.core.set_full_range(true);
+            log::info!("CPU stitch: full-range YUV source, using full-range conversion");
+        }
         let (nv12_w, nv12_h) = self.nv12_delivery_dims();
         let render_w = self.core.executor.viewport_size().width;
         log::info!(

--- a/crates/reco-core/src/session/run_loop.rs
+++ b/crates/reco-core/src/session/run_loop.rs
@@ -546,8 +546,6 @@ impl StitchSession {
         interrupted: &AtomicBool,
         on_progress: &mut Option<ProgressCallback>,
     ) -> Result<u64, SessionError> {
-        use crate::source::StereoFrame;
-
         let start = std::time::Instant::now();
         if self.lookahead_frames > 0 {
             log::warn!(
@@ -584,30 +582,7 @@ impl StitchSession {
             }
 
             let stitch_t0 = std::time::Instant::now();
-            let outcome = match &frame {
-                StereoFrame::Mono(yuv) => self.core.submit_frame_mono_yuv(&yuv.as_planes())?,
-                StereoFrame::Yuv420p(pair) => self
-                    .core
-                    .submit_frame_yuv(&pair.left.as_planes(), &pair.right.as_planes())?,
-                StereoFrame::Nv12(pair) => {
-                    let left = crate::render::planes::Nv12Planes {
-                        y: &pair.left.y,
-                        uv: &pair.left.uv,
-                    };
-                    let right = crate::render::planes::Nv12Planes {
-                        y: &pair.right.y,
-                        uv: &pair.right.uv,
-                    };
-                    self.core.submit_frame_nv12(&left, &right)?
-                }
-                _ => {
-                    return Err(SessionError::Config(
-                        "the CPU session consumes CPU-resident frames only (YUV420P / \
-                         NV12); zero-copy sources need the GPU executor"
-                            .into(),
-                    ));
-                }
-            };
+            let outcome = self.core.submit_frame(&frame)?;
             let crate::core::types::RenderOutcome::Rgba(rgba) = outcome else {
                 unreachable!("the CPU executor stitches synchronously - no warmup");
             };

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -16,7 +16,7 @@ use crate::detect::detector::{Detection, DetectorError, DetectorFrame, UnifiedDe
 use crate::detect::director::MappedDetection;
 use crate::detect::panner::{PanContext, Panner};
 use crate::detect::tracker::{TrackState, TrackedEntity, Tracker, WorldState};
-use crate::geometry::CameraId;
+use crate::geometry::CameraIndex;
 use crate::geometry::Pose;
 use crate::projection::LShape;
 use crate::render::viewport::ViewportSize;
@@ -122,7 +122,7 @@ impl UnifiedDetector for MockDetector {
 
     fn detect(
         &mut self,
-        _camera: CameraId,
+        _camera: CameraIndex,
         _frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
@@ -169,7 +169,7 @@ impl Tracker for MockTracker {
             confidence: 1.0,
             state: TrackState::Tracking,
             age_frames: 1,
-            origin: CameraId::Left,
+            origin: 0,
         }]
     }
 
@@ -326,7 +326,7 @@ fn tracker_receives_detections() {
     let call_count = Arc::new(AtomicU64::new(0));
     let canned = vec![
         Detection {
-            camera: CameraId::Left,
+            camera: 0,
             class_id: 0,
             confidence: 0.9,
             center_x: 0.5,
@@ -335,7 +335,7 @@ fn tracker_receives_detections() {
             height: 0.1,
         },
         Detection {
-            camera: CameraId::Right,
+            camera: 1,
             class_id: 1,
             confidence: 0.8,
             center_x: 0.3,
@@ -391,7 +391,7 @@ fn tracker_receives_detections() {
 fn detection_interval_respected() {
     let call_count = Arc::new(AtomicU64::new(0));
     let canned = vec![Detection {
-        camera: CameraId::Left,
+        camera: 0,
         class_id: 0,
         confidence: 0.9,
         center_x: 0.5,
@@ -514,7 +514,7 @@ fn compute_frame_limit_negative_fps_uses_fallback() {
 fn push_and_pull_share_one_ai_brain() {
     const FRAMES: u64 = 6;
     let canned = vec![Detection {
-        camera: CameraId::Left,
+        camera: 0,
         class_id: 0,
         confidence: 0.9,
         center_x: 0.5,

--- a/crates/reco-core/src/session/tests.rs
+++ b/crates/reco-core/src/session/tests.rs
@@ -21,7 +21,7 @@ use crate::geometry::Pose;
 use crate::projection::LShape;
 use crate::render::viewport::ViewportSize;
 use crate::sink::{OutputFrame, OutputSink, SinkError, SinkInput};
-use crate::source::{FramePair, FrameSource, SourceError, SourceInfo, StereoFrame, YuvData};
+use crate::source::{FrameSet, FrameSource, SourceError, SourceInfo, YuvData};
 
 // ─── Helpers ───────────────────────────────────────────────────────────
 
@@ -52,7 +52,7 @@ fn test_calibration() -> Calibration {
 }
 
 /// Create a valid YUV420P stereo frame pair of solid gray.
-fn solid_frame() -> StereoFrame {
+fn solid_frame() -> FrameSet {
     let y_size = (W * H) as usize;
     let uv_size = ((W / 2) * (H / 2)) as usize;
     let yuv = YuvData {
@@ -60,10 +60,7 @@ fn solid_frame() -> StereoFrame {
         u: vec![128u8; uv_size],
         v: vec![128u8; uv_size],
     };
-    StereoFrame::Yuv420p(FramePair {
-        left: yuv.clone(),
-        right: yuv,
-    })
+    FrameSet::Yuv420p(vec![yuv.clone(), yuv])
 }
 
 // ─── MockSource ────────────────────────────────────────────────────────
@@ -92,7 +89,7 @@ impl FrameSource for MockSource {
         }
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         if self.remaining == 0 {
             return Ok(None);
         }
@@ -505,7 +502,7 @@ fn compute_frame_limit_negative_fps_uses_fallback() {
 
 /// The one-AI-stack guard, in two halves. (1) Entry-point parity:
 /// the same scripted detector + tracker + panner, fed the same frames
-/// through `StitchCore::submit_frame_yuv` and `StitchSession::run`,
+/// through `StitchCore::submit_frame` and `StitchSession::run`,
 /// must see identical inputs in identical order - frame indices,
 /// previous-pose threading, detector call counts. (2) The pull side
 /// must have driven the ENGINE's stack, observed through the core's
@@ -593,20 +590,8 @@ fn push_and_pull_share_one_ai_brain() {
     }));
 
     for _ in 0..FRAMES {
-        let StereoFrame::Yuv420p(pair) = solid_frame() else {
-            unreachable!("solid_frame is YUV420P")
-        };
-        let left = crate::render::planes::YuvPlanes {
-            y: &pair.left.y,
-            u: &pair.left.u,
-            v: &pair.left.v,
-        };
-        let right = crate::render::planes::YuvPlanes {
-            y: &pair.right.y,
-            u: &pair.right.u,
-            v: &pair.right.v,
-        };
-        core.submit_frame_yuv(&left, &right).expect("submit");
+        let frames = solid_frame();
+        core.submit_frame(&frames).expect("submit");
     }
 
     let pull = pull_log.lock().unwrap();
@@ -739,11 +724,8 @@ fn cpu_session_rejects_gpu_resident_frames() {
                 total_frames: None,
             }
         }
-        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
-            Ok(Some(StereoFrame::GpuResident {
-                left_slot: 0,
-                right_slot: 0,
-            }))
+        fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
+            Ok(Some(FrameSet::GpuResident { slots: [0, 0] }))
         }
     }
 
@@ -752,9 +734,14 @@ fn cpu_session_rejects_gpu_resident_frames() {
     let err = session
         .run(&mut ResidentSource, u64::MAX, &interrupted, None)
         .expect_err("resident frames must be rejected on the CPU executor");
+    // The rejection is the engine's: `submit_frame` refuses resident
+    // sets with a typed config error, which the session wraps.
     assert!(
-        matches!(err, SessionError::Config(_)),
-        "expected a typed config error, got: {err}"
+        matches!(
+            err,
+            SessionError::Core(crate::core::types::StitchCoreError::Config(_))
+        ),
+        "expected the engine's typed config error, got: {err}"
     );
 }
 
@@ -763,7 +750,7 @@ fn cpu_session_rejects_gpu_resident_frames() {
 ///
 /// Doubles as the minimal mono-consumer example: a calibration built
 /// from `Lens::flat` + `Cylinder` + a zero `Framing`, a
-/// `FrameSource` yielding `StereoFrame::Mono`, and a plain session
+/// `FrameSource` yielding a one-camera `FrameSet`, and a plain session
 /// run on the CPU executor - no GPU context is created on this path.
 #[test]
 fn mono_cylinder_session_runs_end_to_end_without_gpu() {
@@ -778,18 +765,18 @@ fn mono_cylinder_session_runs_end_to_end_without_gpu() {
                 total_frames: None,
             }
         }
-        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+        fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
             if self.0 == 0 {
                 return Ok(None);
             }
             self.0 -= 1;
             let y_size = (W * H) as usize;
             let uv_size = ((W / 2) * (H / 2)) as usize;
-            Ok(Some(StereoFrame::Mono(YuvData {
+            Ok(Some(FrameSet::Yuv420p(vec![YuvData {
                 y: vec![128u8; y_size],
                 u: vec![128u8; uv_size],
                 v: vec![128u8; uv_size],
-            })))
+            }])))
         }
     }
 

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -348,6 +348,21 @@ pub enum FrameSet {
     NvmmResident([NvmmPlaneInfo; 2]),
 }
 
+impl FrameSet {
+    /// Consume a two-camera YUV420P set into its per-camera payloads.
+    ///
+    /// `None` for any other shape - the interactive stereo consumers
+    /// (CLI preview, GUI playback) that retain decoded frames are
+    /// two-camera CPU paths by construction and use this instead of
+    /// re-deriving the downcast.
+    pub fn into_yuv_pair(self) -> Option<[YuvData; 2]> {
+        match self {
+            Self::Yuv420p(cams) => <[YuvData; 2]>::try_from(cams).ok(),
+            _ => None,
+        }
+    }
+}
+
 /// Metadata about the frame source.
 #[derive(Debug, Clone)]
 pub struct SourceInfo {
@@ -388,7 +403,7 @@ pub trait FrameSource: Send {
     /// Source metadata (dimensions, frame rate).
     fn info(&self) -> SourceInfo;
 
-    /// Get the next stereo frame, or `None` if the source is exhausted.
+    /// Get the next frame set, or `None` if the source is exhausted.
     ///
     /// For live sources (cameras), this blocks until a frame is available.
     /// For file sources, returns `None` at end of file.
@@ -434,6 +449,10 @@ pub trait FrameSource: Send {
     /// The session applies rotation automatically: the CPU path handles it
     /// via buffer reversal in the decoder, while the GPU zero-copy path
     /// uses a shader UV flip.
+    ///
+    /// Pair-shaped on purpose for now: the session consumes rotation
+    /// for GPU-resident sources only, which are two-camera; the
+    /// accessors go per-camera when the FrameSource seam does.
     fn left_rotation(&self) -> i32 {
         0
     }

--- a/crates/reco-core/src/source.rs
+++ b/crates/reco-core/src/source.rs
@@ -2,7 +2,7 @@
 //!
 //! The pipeline doesn't care where frames come from - video files,
 //! live cameras, network streams, or test patterns. Each source
-//! implements [`FrameSource`] and delivers stereo frame pairs in
+//! implements [`FrameSource`] and delivers per-camera frame sets in
 //! YUV420P or NV12 format.
 //!
 //! ## Implementations (in `reco-io`)
@@ -197,8 +197,8 @@ impl YuvFrame {
 
 /// Owned YUV420P plane data (without dimensions).
 ///
-/// Used internally when dimensions are tracked separately
-/// (e.g. in [`FramePair`] where both frames share dimensions).
+/// Used when dimensions are tracked separately - all cameras in a
+/// [`FrameSet`] share the dimensions carried by [`SourceInfo`].
 #[derive(Debug, Clone)]
 pub struct YuvData {
     /// Y (luma) plane, full resolution.
@@ -233,29 +233,29 @@ pub struct Nv12Data {
     pub uv: Vec<u8>,
 }
 
-/// A stereo frame pair from the source.
-///
-/// Contains left and right camera data as YUV420P planes (CPU-resident).
-/// Both frames must have the same dimensions.
-#[derive(Debug, Clone)]
-pub struct FramePair {
-    /// Left camera YUV420P data.
-    pub left: YuvData,
-    /// Right camera YUV420P data.
-    pub right: YuvData,
+impl Nv12Data {
+    /// Borrow as pipeline-ready plane references.
+    pub fn as_planes(&self) -> crate::render::planes::Nv12Planes<'_> {
+        crate::render::planes::Nv12Planes {
+            y: &self.y,
+            uv: &self.uv,
+        }
+    }
 }
 
-/// A stereo NV12 frame pair from the source.
+/// One camera's D3D11VA decoded frame: an array texture plus the slice
+/// index within the decode pool.
 ///
-/// Contains left and right camera data as NV12 planes (CPU-resident).
-/// NV12 is the native output of NVIDIA ISP (nvarguscamerasrc) and NVDEC,
-/// so this avoids an NV12 -> I420 conversion on capture.
-#[derive(Debug, Clone)]
-pub struct Nv12FramePair {
-    /// Left camera NV12 data.
-    pub left: Nv12Data,
-    /// Right camera NV12 data.
-    pub right: Nv12Data,
+/// Non-owning - the pointer is only valid while the source pins the
+/// underlying decode slice alive (until the session has staged the
+/// frame into shared textures).
+#[cfg(target_os = "windows")]
+#[derive(Debug, Clone, Copy)]
+pub struct D3d11CameraFrame {
+    /// D3D11 array texture pointer (ID3D11Texture2D*).
+    pub texture: *mut std::ffi::c_void,
+    /// Array slice index within the D3D11VA decode pool.
+    pub slice: usize,
 }
 
 /// Per-camera metadata for an NVMM zero-copy frame (Jetson).
@@ -294,65 +294,58 @@ pub struct NvmmPlaneInfo {
 #[cfg(target_os = "linux")]
 unsafe impl Send for NvmmPlaneInfo {}
 
-/// A stereo frame in any supported format.
+/// One time instant's frames from every camera, in projection order
+/// (index `i` pairs with `calibration.lenses[i]`).
 ///
-/// Sources produce whichever format is most efficient for their backend:
+/// Residency - where the pixel data lives - is a set-level property:
+/// every source decides its backend once at open (one decode path, one
+/// shared texture pool for all cameras), so one variant covers the
+/// whole set and a mixed-residency set is unrepresentable.
+///
+/// Sources produce whichever variant is most efficient for their backend:
 /// - File decode (CPU path): `Yuv420p`
 /// - Jetson ISP / NVDEC NV12: `Nv12`
 /// - CUDA/Vulkan zero-copy shared textures: `GpuResident`
 /// - VideoToolbox/Metal zero-copy: `MetalResident`
+/// - Windows D3D11VA zero-copy: `D3d11Resident`
 /// - Jetson NVMM zero-copy (DMA-buf + NvBufSurface): `NvmmResident`
+///
+/// CPU variants carry one entry per camera; the stitch boundary
+/// rejects a length that does not match the projection's camera count
+/// (`check_camera_count` in `stitch::cpu`, mirrored by the submit
+/// dispatch). Platform zero-copy variants are pinned to two cameras by
+/// type - their decode channels and texture pools are pair-shaped by
+/// design and guarded, not generalized.
 #[non_exhaustive]
-pub enum StereoFrame {
-    /// A single pre-stitched panorama frame for mono topologies (the
-    /// cylinder): CPU-resident YUV420P planes of the one source.
-    Mono(YuvData),
+pub enum FrameSet {
     /// CPU-resident YUV420P planes (3 planes per camera).
-    Yuv420p(FramePair),
+    Yuv420p(Vec<YuvData>),
     /// CPU-resident NV12 planes (2 planes per camera).
-    Nv12(Nv12FramePair),
-    /// GPU-resident: data already written to shared textures by the source.
-    /// The `u8` values are double-buffer slot indices that the pipeline
-    /// uses to select the correct bind group.
+    Nv12(Vec<Nv12Data>),
+    /// GPU-resident: data already written to shared textures by the
+    /// source. Values are double-buffer slot indices (0 or 1), one per
+    /// camera, that the pipeline uses to select the correct bind group.
     GpuResident {
-        /// Left camera double-buffer slot index (0 or 1).
-        left_slot: u8,
-        /// Right camera double-buffer slot index (0 or 1).
-        right_slot: u8,
+        /// Per-camera double-buffer slot indices.
+        slots: [u8; 2],
     },
-    /// macOS zero-copy: retained CVPixelBuffers from VideoToolbox decode.
-    /// The session imports these as Metal textures each frame.
+    /// macOS zero-copy: retained CVPixelBuffers from VideoToolbox
+    /// decode, one per camera. The session imports these as Metal
+    /// textures each frame.
     #[cfg(any(target_os = "macos", target_os = "ios"))]
-    MetalResident {
-        /// Left camera retained pixel buffer.
-        left: crate::interop::metal::RetainedCVPixelBuffer,
-        /// Right camera retained pixel buffer.
-        right: crate::interop::metal::RetainedCVPixelBuffer,
-    },
-    /// Windows D3D11VA zero-copy: decoded frame still on D3D11 GPU memory.
-    /// The session stages these into shared NV12 textures for wgpu rendering.
+    MetalResident([crate::interop::metal::RetainedCVPixelBuffer; 2]),
+    /// Windows D3D11VA zero-copy: decoded frames still on D3D11 GPU
+    /// memory, one per camera. The session stages these into shared
+    /// NV12 textures for wgpu rendering.
     #[cfg(target_os = "windows")]
-    D3d11Resident {
-        /// D3D11 array texture pointer (ID3D11Texture2D*) for left camera.
-        left_texture: *mut std::ffi::c_void,
-        /// Array slice index within the D3D11VA decode pool for left camera.
-        left_slice: usize,
-        /// D3D11 array texture pointer (ID3D11Texture2D*) for right camera.
-        right_texture: *mut std::ffi::c_void,
-        /// Array slice index within the D3D11VA decode pool for right camera.
-        right_slice: usize,
-    },
-    /// Jetson NVMM zero-copy: NV12 frames in NvBufSurface DMA-buf memory.
-    /// The session imports the DMA-buf as Vulkan textures for rendering
-    /// (copied into the VRAM pool) and runs `NvBufSurfTransform` on the
-    /// surface pointer for detection. Produced by the NVMM camera source.
+    D3d11Resident([D3d11CameraFrame; 2]),
+    /// Jetson NVMM zero-copy: NV12 frames in NvBufSurface DMA-buf
+    /// memory, one per camera. The session imports the DMA-bufs as
+    /// Vulkan textures for rendering (copied into the VRAM pool) and
+    /// runs `NvBufSurfTransform` on the surface pointers for detection.
+    /// Produced by the NVMM camera source.
     #[cfg(target_os = "linux")]
-    NvmmResident {
-        /// Left camera NVMM plane metadata.
-        left: NvmmPlaneInfo,
-        /// Right camera NVMM plane metadata.
-        right: NvmmPlaneInfo,
-    },
+    NvmmResident([NvmmPlaneInfo; 2]),
 }
 
 /// Metadata about the frame source.
@@ -373,11 +366,11 @@ pub struct SourceInfo {
     pub total_frames: Option<u64>,
 }
 
-/// Trait for stereo frame sources.
+/// Trait for frame sources.
 ///
-/// A frame source delivers stereo frame pairs to the pipeline in whatever
-/// format is most efficient for the backend. The pipeline handles format
-/// differences internally via [`StereoFrame`].
+/// A frame source delivers one [`FrameSet`] per time instant to the
+/// pipeline in whatever format is most efficient for the backend. The
+/// pipeline handles format differences internally via the set's variant.
 ///
 /// Implementations handle their own threading (e.g. dedicated capture
 /// threads with bounded channels). The pipeline calls [`Self::next_frame`]
@@ -399,7 +392,7 @@ pub trait FrameSource: Send {
     ///
     /// For live sources (cameras), this blocks until a frame is available.
     /// For file sources, returns `None` at end of file.
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError>;
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError>;
 
     /// Non-blocking attempt to get the next frame.
     ///
@@ -408,14 +401,14 @@ pub trait FrameSource: Send {
     /// that need to poll without blocking the UI thread.
     ///
     /// Default implementation delegates to [`Self::next_frame`] (blocking).
-    fn try_next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn try_next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         self.next_frame()
     }
 
     /// Whether this source delivers GPU-resident frames.
     ///
     /// When `true`, [`next_frame`](Self::next_frame) may return
-    /// [`StereoFrame::GpuResident`] or `StereoFrame::MetalResident`.
+    /// [`FrameSet::GpuResident`] or `FrameSet::MetalResident`.
     /// The session uses this to configure GPU bind groups and select
     /// the optimal render path automatically.
     fn is_gpu_resident(&self) -> bool {

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -138,7 +138,7 @@ impl CpuExecutor {
         self.calib.topology.projection()
     }
 
-    /// Stitch one NV12 frame pair to RGBA at the configured output
+    /// Stitch one NV12 frame set to RGBA at the configured output
     /// size. `&self` on purpose: the CPU stitch is stateless per call
     /// (the [`StitchExecutor`] trait's `&mut self` accommodates the
     /// GPU arm's readback ring).
@@ -158,7 +158,7 @@ impl CpuExecutor {
         )
     }
 
-    /// Stitch one YUV420P frame pair to RGBA at the configured output
+    /// Stitch one YUV420P frame set to RGBA at the configured output
     /// size. The CPU kernel is format-flexible per call (unlike the
     /// GPU pipeline, which fixes its input format at construction);
     /// the [`StitchExecutor`] trait covers the NV12 contract, this

--- a/crates/reco-core/src/stitch/executor.rs
+++ b/crates/reco-core/src/stitch/executor.rs
@@ -513,12 +513,11 @@ impl GpuExecutor {
         right: &crate::source::NvmmPlaneInfo,
     ) -> Option<
         [(
-            crate::geometry::CameraId,
+            crate::geometry::CameraIndex,
             crate::detect::detector::DetectorFrame<'static>,
         ); 2],
     > {
         use crate::detect::detector::DetectorFrame;
-        use crate::geometry::CameraId;
 
         let (det_left, det_right) = self.residency.nvmm_det.as_mut()?;
         unsafe {
@@ -533,7 +532,7 @@ impl GpuExecutor {
         }
         Some([
             (
-                CameraId::Left,
+                0,
                 DetectorFrame::CudaRgbaLetterboxed {
                     ptr: det_left.data_ptr,
                     src_width: left.width,
@@ -541,7 +540,7 @@ impl GpuExecutor {
                 },
             ),
             (
-                CameraId::Right,
+                1,
                 DetectorFrame::CudaRgbaLetterboxed {
                     ptr: det_right.data_ptr,
                     src_width: right.width,

--- a/crates/reco-detect/src/detectors/cpu.rs
+++ b/crates/reco-detect/src/detectors/cpu.rs
@@ -21,7 +21,7 @@ use ort::value::TensorRef;
 use reco_core::detect::detector::{
     ChromaFormat, Detection, DetectorError, DetectorFrame, RawFrame, UnifiedDetector,
 };
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 
 use super::{postprocess, postprocess_balldet};
 
@@ -215,7 +215,7 @@ impl CpuYoloDetector {
     /// vec for backwards compatibility.
     fn detect_raw(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &RawFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         reco_core::profile_scope!("yolo_detect");
@@ -298,7 +298,7 @@ impl CpuYoloDetector {
 
     fn detect_preprocessed(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         data: &[f32],
         input_size: u32,
         src_width: u32,
@@ -367,7 +367,7 @@ impl UnifiedDetector for CpuYoloDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         // `DetectorFrame` is `#[non_exhaustive]`, so we pattern-match

--- a/crates/reco-detect/src/detectors/metal.rs
+++ b/crates/reco-detect/src/detectors/metal.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 use crate::coreml_inference::CoreMlModel;
 use crate::metal_compute::MetalPreprocessPipeline;
 use reco_core::detect::detector::{Detection, DetectorError, DetectorFrame, UnifiedDetector};
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 use reco_core::gpu::GpuContext;
 use reco_core::interop::metal::CVPixelBufferRef;
 
@@ -218,7 +218,7 @@ impl UnifiedDetector for MetalYoloDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         // Metal-residency backend: matches `Metal { cv_pixel_buffer,

--- a/crates/reco-detect/src/detectors/mod.rs
+++ b/crates/reco-detect/src/detectors/mod.rs
@@ -17,7 +17,7 @@ pub mod trt;
 use std::path::Path;
 
 use reco_core::detect::detector::Detection;
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 
 /// Parse YOLO end-to-end NMS output `[1, N, 6]` into detections.
 ///
@@ -29,7 +29,7 @@ use reco_core::geometry::CameraId;
 pub fn postprocess(
     data: &[f32],
     n: usize,
-    camera: CameraId,
+    camera: CameraIndex,
     confidence_threshold: f32,
     scale: f32,
     pad_x: f32,
@@ -127,7 +127,7 @@ pub fn postprocess(
 pub fn postprocess_balldet(
     data: &[f32],
     n: usize,
-    camera: CameraId,
+    camera: CameraIndex,
     confidence_threshold: f32,
     scale: f32,
     pad_x: f32,
@@ -236,7 +236,6 @@ pub fn read_labels_file(path: impl AsRef<Path>) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use reco_core::geometry::CameraId;
 
     /// Build a synthetic [1, N, 6] flat tensor with the given detections.
     /// Each detection is [x1, y1, x2, y2, confidence, class_id].
@@ -266,7 +265,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -295,7 +294,7 @@ mod tests {
         let dets = postprocess(
             &data,
             2,
-            CameraId::Right,
+            1,
             0.10,
             scale(),
             pad_x(),
@@ -316,7 +315,7 @@ mod tests {
         let dets = postprocess(
             &data,
             0,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -338,7 +337,7 @@ mod tests {
         let dets = postprocess(
             &data,
             2,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -358,7 +357,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -377,7 +376,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -399,7 +398,7 @@ mod tests {
         let dets = postprocess(
             &data,
             0,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -417,7 +416,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -440,7 +439,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -471,7 +470,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -491,7 +490,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -511,7 +510,7 @@ mod tests {
             let dets = postprocess(
                 &data,
                 1,
-                CameraId::Left,
+                0,
                 0.10,
                 scale(),
                 pad_x(),
@@ -532,7 +531,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -550,7 +549,7 @@ mod tests {
         let dets = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -568,7 +567,7 @@ mod tests {
         let dets_left = postprocess(
             &data,
             1,
-            CameraId::Left,
+            0,
             0.10,
             scale(),
             pad_x(),
@@ -579,7 +578,7 @@ mod tests {
         let dets_right = postprocess(
             &data,
             1,
-            CameraId::Right,
+            1,
             0.10,
             scale(),
             pad_x(),
@@ -588,15 +587,15 @@ mod tests {
             FRAME_H,
         );
 
-        assert_eq!(dets_left[0].camera, CameraId::Left);
-        assert_eq!(dets_right[0].camera, CameraId::Right);
+        assert_eq!(dets_left[0].camera, 0);
+        assert_eq!(dets_right[0].camera, 1);
     }
 
     #[test]
     fn postprocess_balldet_decodes_cxcywh_with_conf_in_col5() {
         // [cx, cy, w, h, obj=1, conf]; scale=1, no pad, 1000x1000 frame.
         let data = vec![500.0, 250.0, 40.0, 40.0, 1.0, 0.90];
-        let dets = postprocess_balldet(&data, 1, CameraId::Left, 0.25, 1.0, 0.0, 0.0, 1000, 1000);
+        let dets = postprocess_balldet(&data, 1, 0, 0.25, 1.0, 0.0, 0.0, 1000, 1000);
         assert_eq!(dets.len(), 1);
         assert_eq!(dets[0].class_id, 0, "single ball class");
         assert!((dets[0].confidence - 0.90).abs() < 1e-6, "conf from col 5");
@@ -613,7 +612,7 @@ mod tests {
             505.0, 252.0, 40.0, 40.0, 1.0, 0.80, // overlaps -> NMS-dropped
             100.0, 100.0, 30.0, 30.0, 1.0, 0.70, // far -> kept
         ];
-        let dets = postprocess_balldet(&data, 4, CameraId::Left, 0.25, 1.0, 0.0, 0.0, 1000, 1000);
+        let dets = postprocess_balldet(&data, 4, 0, 0.25, 1.0, 0.0, 0.0, 1000, 1000);
         assert_eq!(dets.len(), 2, "low-conf filtered + overlap NMS-deduped");
         assert!(
             (dets[0].confidence - 0.90).abs() < 1e-6,

--- a/crates/reco-detect/src/detectors/ncnn.rs
+++ b/crates/reco-detect/src/detectors/ncnn.rs
@@ -22,7 +22,7 @@ use std::path::Path;
 use reco_core::detect::detector::{
     ChromaFormat, Detection, DetectorError, DetectorFrame, RawFrame, UnifiedDetector,
 };
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 
 // ── NCNN C API FFI ──────────────────────────────────────────────────
 
@@ -256,7 +256,7 @@ impl NcnnYoloDetector {
     }
 
     /// Parse YOLO output and apply NMS.
-    fn postprocess(&self, output: *const c_void, camera: CameraId) -> Vec<Detection> {
+    fn postprocess(&self, output: *const c_void, camera: CameraIndex) -> Vec<Detection> {
         let w = unsafe { ncnn_mat_get_w(output) } as usize;
         let h = unsafe { ncnn_mat_get_h(output) } as usize;
         let data = unsafe { std::slice::from_raw_parts(ncnn_mat_get_data(output), w * h) };
@@ -360,7 +360,7 @@ impl NcnnYoloDetector {
     /// compatibility.
     fn detect_raw(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &RawFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         reco_core::profile_scope!("ncnn_yolo_detect");
@@ -415,7 +415,7 @@ impl UnifiedDetector for NcnnYoloDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         // CPU-residency backend: accept only `Cpu(_)`; anything else

--- a/crates/reco-detect/src/detectors/ort_gpu.rs
+++ b/crates/reco-detect/src/detectors/ort_gpu.rs
@@ -26,7 +26,7 @@ use ort::value::{Shape, TensorRefMut};
 use reco_core::detect::detector::{
     Detection, DetectorError, DetectorFrame, GpuNv12Frame, UnifiedDetector,
 };
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 use reco_core::interop::cuda::{
     CUdeviceptr, cuda_ensure_context, cuda_mem_alloc, cuda_mem_free, cuda_memset_d8,
 };
@@ -230,7 +230,7 @@ impl OrtGpuDetector {
     /// original error text verbatim.
     fn detect_gpu_raw(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &GpuNv12Frame,
     ) -> Result<Vec<Detection>, DetectorError> {
         let GpuNv12Frame {
@@ -395,7 +395,7 @@ impl UnifiedDetector for OrtGpuDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         // CUDA-residency backend: accept `Cuda(GpuNv12Frame)` and

--- a/crates/reco-detect/src/detectors/trt/mod.rs
+++ b/crates/reco-detect/src/detectors/trt/mod.rs
@@ -29,7 +29,7 @@ use reco_core::detect::detector::ChromaFormat;
 use reco_core::detect::detector::{
     Detection, DetectorError, DetectorFrame, GpuNv12Frame, UnifiedDetector,
 };
-use reco_core::geometry::CameraId;
+use reco_core::geometry::CameraIndex;
 use reco_core::interop::cuda::{
     CUdeviceptr, cuda_ensure_context, cuda_mem_alloc, cuda_mem_free, cuda_memcpy_dtoh,
     cuda_memcpy_htod_2d, cuda_memset_d8, cuda_synchronize,
@@ -314,7 +314,7 @@ impl TrtGpuDetector {
     /// telemetry dashboards can still break down failures by origin.
     fn detect_gpu_raw(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &GpuNv12Frame,
     ) -> Result<Vec<Detection>, DetectorError> {
         let GpuNv12Frame {
@@ -458,7 +458,7 @@ impl TrtGpuDetector {
     /// Assumes `self.tensor_f32` is populated with the normalized input.
     fn run_inference_and_postprocess(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         source_width: u32,
         source_height: u32,
     ) -> Result<Vec<Detection>, DetectorError> {
@@ -538,7 +538,7 @@ impl UnifiedDetector for TrtGpuDetector {
 
     fn detect(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         frame: &DetectorFrame<'_>,
     ) -> Result<Vec<Detection>, DetectorError> {
         // CUDA-residency backend: accept `Cuda(GpuNv12Frame)` for
@@ -599,7 +599,7 @@ impl TrtGpuDetector {
     /// to use the zero-copy [`DetectorFrame::Cuda`] route.
     fn detect_cpu_nv12_upload(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         y_host: &[u8],
         uv_host: &[u8],
         width: u32,
@@ -674,7 +674,7 @@ impl TrtGpuDetector {
     /// NPP C4 resize + CUDA normalize only, no upload.
     fn detect_gpu_rgba(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         rgba_ptr: CUdeviceptr,
         width: u32,
         height: u32,
@@ -736,7 +736,7 @@ impl TrtGpuDetector {
     /// Only normalize + inference remain.
     fn detect_preletterboxed(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         rgba_ptr: CUdeviceptr,
         src_width: u32,
         src_height: u32,
@@ -764,7 +764,7 @@ impl TrtGpuDetector {
     /// ignored), TRT inference. No CPU conversion, no intermediate buffer.
     fn detect_cpu_rgba_upload(
         &mut self,
-        camera: CameraId,
+        camera: CameraIndex,
         rgba_host: &[u8],
         width: u32,
         height: u32,

--- a/crates/reco-gui/FRICTION.md
+++ b/crates/reco-gui/FRICTION.md
@@ -20,16 +20,6 @@ A lightweight `reco_io::probe_duration(path)` would remove one.
 
 **Impact**: Low. Blocked on Slint upstream exposing the adapter reference.
 
-### N12. YuvPlanes hand-constructed in every render call site
-
-**Impact**: Low. A `YuvData::planes()` returning `YuvPlanes<'_>` would
-remove per-call boilerplate across GUI and CLI.
-
-### N13. StereoFrame::into_yuv420p is missing
-
-**Impact**: Low. `as_yuv420p()` returning `Option<(YuvPlanes, YuvPlanes)>`
-would centralize the destructure done in 5+ sites.
-
 ### N16. Recording lags preview and drops frames during panning
 
 **Impact**: High. NV12 readback runs on the UI thread, stalling the

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -147,7 +147,7 @@ pub fn run_export(
 
     use reco_core::source::FrameSource;
     if let Ok(source) =
-        reco_io::adapters::FfmpegFileSource::open_from_inputs(&left, &right, 0, false)
+        reco_io::adapters::FfmpegFileSource::open_inputs(&[left.clone(), right.clone()], 0, false)
         && let Some(full_total) = source.total_frames()
     {
         let fps = reco_io::adapters::FfmpegFileSource::frame_rate(left.first_path())
@@ -189,8 +189,7 @@ pub fn run_export(
     }
 
     let mut job = reco_io::StitchJob::with_calibration(
-        left.clone(),
-        right.clone(),
+        [left.clone(), right.clone()],
         cal,
         effective_output.clone(),
     )

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1748,17 +1748,13 @@ fn main() -> anyhow::Result<()> {
                             reco_io::stitch_job::InputPath::Chained(all)
                         }
                         None => {
-                            if paths.len() == 1 {
-                                reco_io::stitch_job::InputPath::Single(
-                                    paths.into_iter().next().unwrap(),
-                                )
-                            } else {
+                            if paths.len() > 1 {
                                 log::info!(
                                     "Left: {} segments selected, chaining via concat demuxer",
                                     paths.len()
                                 );
-                                reco_io::stitch_job::InputPath::Chained(paths)
                             }
+                            reco_io::stitch_job::InputPath::from_segments(paths)
                         }
                     }
                 };
@@ -1834,17 +1830,13 @@ fn main() -> anyhow::Result<()> {
                             reco_io::stitch_job::InputPath::Chained(all)
                         }
                         None => {
-                            if paths.len() == 1 {
-                                reco_io::stitch_job::InputPath::Single(
-                                    paths.into_iter().next().unwrap(),
-                                )
-                            } else {
+                            if paths.len() > 1 {
                                 log::info!(
                                     "Right: {} segments selected, chaining via concat demuxer",
                                     paths.len()
                                 );
-                                reco_io::stitch_job::InputPath::Chained(paths)
                             }
+                            reco_io::stitch_job::InputPath::from_segments(paths)
                         }
                     }
                 };
@@ -4342,13 +4334,8 @@ fn run_autoload(
         spec.right.len(),
         spec.cal.display()
     );
-    let make_input = |paths: &[PathBuf]| {
-        if paths.len() == 1 {
-            reco_io::stitch_job::InputPath::Single(paths[0].clone())
-        } else {
-            reco_io::stitch_job::InputPath::Chained(paths.to_vec())
-        }
-    };
+    let make_input =
+        |paths: &[PathBuf]| reco_io::stitch_job::InputPath::from_segments(paths.to_vec());
     {
         let mut s = state.borrow_mut();
         s.left_input = Some(make_input(&spec.left));

--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -4065,6 +4065,11 @@ fn main() -> anyhow::Result<()> {
                                 ),
                                 reco_io::stitch_job::StitchError::Session(
                                     reco_core::session::types::SessionError::Config(detail),
+                                )
+                                | reco_io::stitch_job::StitchError::Session(
+                                    reco_core::session::types::SessionError::Core(
+                                        reco_core::core::types::StitchCoreError::Config(detail),
+                                    ),
                                 ) => ("Export failed", detail.clone()),
                                 other => (
                                     "Export failed",

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -75,7 +75,8 @@ impl Playback {
         right: &InputPath,
         sync_offset: i64,
     ) -> Result<(), SourceError> {
-        let source = FfmpegFileSource::open_from_inputs(left, right, sync_offset, false)?;
+        let source =
+            FfmpegFileSource::open_inputs(&[left.clone(), right.clone()], sync_offset, false)?;
         let info = source.info();
         let fps = info.fps;
         self.total_frames = source.total_frames();

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -106,7 +106,16 @@ impl Playback {
         match source.next_frame()? {
             Some(stereo) => {
                 let (left, right) = match stereo {
-                    reco_core::source::StereoFrame::Yuv420p(pair) => (pair.left, pair.right),
+                    reco_core::source::FrameSet::Yuv420p(cams) => {
+                        match <[reco_core::source::YuvData; 2]>::try_from(cams) {
+                            Ok([left, right]) => (left, right),
+                            Err(_) => {
+                                return Err(SourceError::Read {
+                                    reason: "GUI preview expects two-camera Yuv420p sets".into(),
+                                });
+                            }
+                        }
+                    }
                     _ => {
                         return Err(SourceError::Read {
                             reason: "GUI preview expects Yuv420p frames".into(),
@@ -168,7 +177,16 @@ impl Playback {
         match source.try_next_frame()? {
             Some(stereo) => {
                 let (left, right) = match stereo {
-                    reco_core::source::StereoFrame::Yuv420p(pair) => (pair.left, pair.right),
+                    reco_core::source::FrameSet::Yuv420p(cams) => {
+                        match <[reco_core::source::YuvData; 2]>::try_from(cams) {
+                            Ok([left, right]) => (left, right),
+                            Err(_) => {
+                                return Err(SourceError::Read {
+                                    reason: "GUI preview expects two-camera Yuv420p sets".into(),
+                                });
+                            }
+                        }
+                    }
                     _ => {
                         return Err(SourceError::Read {
                             reason: "GUI preview expects Yuv420p frames".into(),

--- a/crates/reco-gui/src/playback.rs
+++ b/crates/reco-gui/src/playback.rs
@@ -106,22 +106,10 @@ impl Playback {
 
         match source.next_frame()? {
             Some(stereo) => {
-                let (left, right) = match stereo {
-                    reco_core::source::FrameSet::Yuv420p(cams) => {
-                        match <[reco_core::source::YuvData; 2]>::try_from(cams) {
-                            Ok([left, right]) => (left, right),
-                            Err(_) => {
-                                return Err(SourceError::Read {
-                                    reason: "GUI preview expects two-camera Yuv420p sets".into(),
-                                });
-                            }
-                        }
-                    }
-                    _ => {
-                        return Err(SourceError::Read {
-                            reason: "GUI preview expects Yuv420p frames".into(),
-                        });
-                    }
+                let Some([left, right]) = stereo.into_yuv_pair() else {
+                    return Err(SourceError::Read {
+                        reason: "GUI preview expects two-camera Yuv420p sets".into(),
+                    });
                 };
                 self.current_frame = Some(StereoYuv { left, right });
                 self.frame_index += 1;
@@ -177,22 +165,10 @@ impl Playback {
         // Non-blocking: returns None if no frame decoded yet.
         match source.try_next_frame()? {
             Some(stereo) => {
-                let (left, right) = match stereo {
-                    reco_core::source::FrameSet::Yuv420p(cams) => {
-                        match <[reco_core::source::YuvData; 2]>::try_from(cams) {
-                            Ok([left, right]) => (left, right),
-                            Err(_) => {
-                                return Err(SourceError::Read {
-                                    reason: "GUI preview expects two-camera Yuv420p sets".into(),
-                                });
-                            }
-                        }
-                    }
-                    _ => {
-                        return Err(SourceError::Read {
-                            reason: "GUI preview expects Yuv420p frames".into(),
-                        });
-                    }
+                let Some([left, right]) = stereo.into_yuv_pair() else {
+                    return Err(SourceError::Read {
+                        reason: "GUI preview expects two-camera Yuv420p sets".into(),
+                    });
                 };
                 self.current_frame = Some(StereoYuv { left, right });
                 self.frame_index += 1;

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -6,7 +6,7 @@
 //! plumbing lives here.
 
 use reco_core::sink::{OutputFrame, OutputSink, PixelFormat, SinkError, SinkInput};
-use reco_core::source::{FramePair, SourceError, SourceInfo, StereoFrame, YuvData};
+use reco_core::source::{FrameSet, SourceError, SourceInfo, YuvData};
 
 #[cfg(feature = "ffmpeg")]
 use crate::ffmpeg;
@@ -62,7 +62,7 @@ fn input_duration_secs(input: &crate::stitch_job::InputPath) -> Option<f64> {
 /// - Negative offset: skip N frames from the **left** video (left started first)
 #[cfg(feature = "ffmpeg")]
 pub struct FfmpegFileSource {
-    rx: std::sync::mpsc::Receiver<FramePair>,
+    rx: std::sync::mpsc::Receiver<FrameSet>,
     info: SourceInfo,
     decode_backend: ffmpeg::decoder::DecodeBackend,
     /// GPU pixel format (NV12 8-bit or P010 10-bit).
@@ -346,11 +346,11 @@ impl FfmpegFileSource {
         sync_offset: i64,
         seek_secs: Option<f64>,
         software_decode: bool,
-    ) -> std::sync::mpsc::Receiver<FramePair> {
+    ) -> std::sync::mpsc::Receiver<FrameSet> {
         let left_rx = Self::spawn_single_decoder_at(left, "left", seek_secs, software_decode);
         let right_rx = Self::spawn_single_decoder_at(right, "right", seek_secs, software_decode);
 
-        let (tx, rx) = std::sync::mpsc::sync_channel::<FramePair>(4);
+        let (tx, rx) = std::sync::mpsc::sync_channel::<FrameSet>(4);
 
         std::thread::Builder::new()
             .name("decode_pair".into())
@@ -376,7 +376,7 @@ impl FfmpegFileSource {
                 }
 
                 while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
-                    if tx.send(FramePair { left, right }).is_err() {
+                    if tx.send(FrameSet::Yuv420p(vec![left, right])).is_err() {
                         break;
                     }
                 }
@@ -405,11 +405,11 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
         self.pixel_format
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match self.rx.recv() {
-            Ok(pair) => {
+            Ok(frames) => {
                 self.current_frame += 1;
-                Ok(Some(StereoFrame::Yuv420p(pair)))
+                Ok(Some(frames))
             }
             Err(_) => {
                 self.exhausted = true;
@@ -418,11 +418,11 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
         }
     }
 
-    fn try_next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn try_next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match self.rx.try_recv() {
-            Ok(pair) => {
+            Ok(frames) => {
                 self.current_frame += 1;
-                Ok(Some(StereoFrame::Yuv420p(pair)))
+                Ok(Some(frames))
             }
             Err(std::sync::mpsc::TryRecvError::Empty) => Ok(None),
             Err(std::sync::mpsc::TryRecvError::Disconnected) => {
@@ -573,7 +573,7 @@ pub fn create_encoder(
 /// Single-video source for mono topologies (pre-stitched panoramas).
 ///
 /// Decodes one file on a background thread and delivers
-/// [`StereoFrame::Mono`] frames - the single-input dual of
+/// one-camera [`FrameSet`]s - the single-input dual of
 /// [`FfmpegFileSource`] for cylinder calibrations.
 #[cfg(feature = "ffmpeg")]
 pub struct FfmpegMonoSource {
@@ -631,14 +631,14 @@ impl reco_core::source::FrameSource for FfmpegMonoSource {
         self.info.clone()
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         if self.exhausted {
             return Ok(None);
         }
         match self.rx.recv() {
             Ok(yuv) => {
                 self.current_frame += 1;
-                Ok(Some(StereoFrame::Mono(yuv)))
+                Ok(Some(FrameSet::Yuv420p(vec![yuv])))
             }
             Err(_) => {
                 self.exhausted = true;

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -210,14 +210,10 @@ impl FfmpegFileSource {
         self.pixel_format
     }
 
-    /// Camera 0 stream rotation from metadata (0, 90, 180, 270 degrees).
-    pub fn left_rotation(&self) -> i32 {
-        self.rotations[0]
-    }
-
-    /// Camera 1 stream rotation from metadata (0 for single-input jobs).
-    pub fn right_rotation(&self) -> i32 {
-        self.rotations.get(1).copied().unwrap_or(0)
+    /// One camera's stream rotation from metadata (0, 90, 180, 270
+    /// degrees), 0 for cameras this job does not have.
+    pub fn rotation(&self, camera: reco_core::geometry::CameraIndex) -> i32 {
+        self.rotations.get(camera).copied().unwrap_or(0)
     }
 
     /// Whether this source's decode backend supports zero-copy GPU transfer.
@@ -413,11 +409,11 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
     }
 
     fn left_rotation(&self) -> i32 {
-        FfmpegFileSource::left_rotation(self)
+        self.rotation(0)
     }
 
     fn right_rotation(&self) -> i32 {
-        FfmpegFileSource::right_rotation(self)
+        self.rotation(1)
     }
 
     fn gpu_pixel_format(&self) -> reco_core::render::renderer::GpuPixelFormat {

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -468,7 +468,7 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
         // the final target. This method is blocking for strategy 1 and
         // semi-blocking for strategy 2 (spawns threads, returns before
         // first frame is decoded).
-        if frame > self.current_frame {
+        if frame >= self.current_frame {
             let skip = frame - self.current_frame;
             let max_forward = (self.info.fps * 10.0) as u64;
             if skip <= max_forward {

--- a/crates/reco-io/src/adapters.rs
+++ b/crates/reco-io/src/adapters.rs
@@ -48,18 +48,20 @@ fn input_duration_secs(input: &crate::stitch_job::InputPath) -> Option<f64> {
     }
 }
 
-/// Stereo file source backed by two FFmpeg decoders.
+/// File source backed by one FFmpeg decoder per camera.
 ///
-/// Opens two video files (left + right camera) and delivers synchronized
-/// YUV420P frame pairs. Each decoder runs in its own thread; frames are
-/// paired after applying a temporal sync offset.
+/// Opens one video per camera (projection order) and delivers
+/// synchronized YUV420P [`FrameSet`]s. Each decoder runs in its own
+/// thread; a zip thread assembles the per-camera frames after applying
+/// the temporal sync offset.
 ///
 /// ## Sync Offset
 ///
-/// When cameras don't start recording at the same instant, a frame offset
-/// aligns them temporally. Use [`Self::open_with_offset`]:
-/// - Positive offset: skip N frames from the **right** video (right started first)
-/// - Negative offset: skip N frames from the **left** video (left started first)
+/// When cameras don't start recording at the same instant, a frame
+/// offset aligns them temporally (defined between exactly two cameras;
+/// see [`Self::open_with_offset`]):
+/// - Positive offset: skip N frames from camera 1 (it started first)
+/// - Negative offset: skip N frames from camera 0 (it started first)
 #[cfg(feature = "ffmpeg")]
 pub struct FfmpegFileSource {
     rx: std::sync::mpsc::Receiver<FrameSet>,
@@ -67,11 +69,10 @@ pub struct FfmpegFileSource {
     decode_backend: ffmpeg::decoder::DecodeBackend,
     /// GPU pixel format (NV12 8-bit or P010 10-bit).
     pixel_format: reco_core::render::renderer::GpuPixelFormat,
-    /// Rotation from stream metadata (0, 90, 180, 270).
-    left_rotation: i32,
-    right_rotation: i32,
-    left_input: crate::stitch_job::InputPath,
-    right_input: crate::stitch_job::InputPath,
+    /// Per-camera rotation from stream metadata (0, 90, 180, 270),
+    /// in projection order.
+    rotations: Vec<i32>,
+    inputs: Vec<crate::stitch_job::InputPath>,
     sync_offset: i64,
     /// Software decode forced at open; seek respawns must reuse it.
     software_decode: bool,
@@ -103,53 +104,54 @@ impl FfmpegFileSource {
         right_path: &std::path::Path,
         sync_offset: i64,
     ) -> Result<Self, SourceError> {
-        Self::open_from_inputs(
-            &crate::stitch_job::InputPath::Single(left_path.to_path_buf()),
-            &crate::stitch_job::InputPath::Single(right_path.to_path_buf()),
+        Self::open_inputs(
+            &[
+                crate::stitch_job::InputPath::Single(left_path.to_path_buf()),
+                crate::stitch_job::InputPath::Single(right_path.to_path_buf()),
+            ],
             sync_offset,
             false,
         )
     }
 
-    /// Open from `InputPath` to support chained multi-segment files.
+    /// Open from a per-camera `InputPath` list in projection order.
     ///
     /// Accepts `InputPath` to support chained multi-segment files
-    /// (GoPro/DJI auto-split). Probing uses the first segment.
-    pub fn open_from_inputs(
-        left: &crate::stitch_job::InputPath,
-        right: &crate::stitch_job::InputPath,
+    /// (GoPro/DJI auto-split). Format, fps, and decode backend are
+    /// probed from input 0's first segment; rotation is probed per
+    /// input. The frame-count estimate uses the shortest input.
+    pub fn open_inputs(
+        inputs: &[crate::stitch_job::InputPath],
         sync_offset: i64,
         software_decode: bool,
     ) -> Result<Self, SourceError> {
-        let left_probe_path = left.first_path();
-        let right_probe_path = right.first_path();
+        let [first, ..] = inputs else {
+            return Err(SourceError::Init {
+                path: "(none)".into(),
+                reason: "at least one input video is required".into(),
+            });
+        };
+        for input in inputs {
+            reco_core::source::validate_input_path(input.first_path())?;
+        }
 
-        reco_core::source::validate_input_path(left_probe_path)?;
-        reco_core::source::validate_input_path(right_probe_path)?;
-
-        let probe = ffmpeg::decoder::VideoDecoder::open(left_probe_path).map_err(|e| {
-            SourceError::Init {
-                path: left_probe_path.display().to_string(),
+        let probe_path = first.first_path();
+        let probe =
+            ffmpeg::decoder::VideoDecoder::open(probe_path).map_err(|e| SourceError::Init {
+                path: probe_path.display().to_string(),
                 reason: format!("{e}"),
-            }
-        })?;
+            })?;
         let fps_r = probe.frame_rate();
         let fps = probe.fps();
-        let left_dur = input_duration_secs(left);
-        let right_dur = input_duration_secs(right);
-        let effective_dur = match (left_dur, right_dur) {
-            (Some(l), Some(r)) => {
-                if (l - r).abs() > 1.0 {
-                    log::info!(
-                        "Duration mismatch: left={l:.1}s, right={r:.1}s, using shorter ({:.1}s)",
-                        l.min(r)
-                    );
-                }
-                Some(l.min(r))
-            }
-            (Some(d), None) | (None, Some(d)) => Some(d),
-            (None, None) => None,
-        };
+        let durations: Vec<Option<f64>> = inputs.iter().map(input_duration_secs).collect();
+        let effective_dur = durations.iter().flatten().copied().reduce(f64::min);
+        if let (Some(min), Some(max)) = (
+            effective_dur,
+            durations.iter().flatten().copied().reduce(f64::max),
+        ) && max - min > 1.0
+        {
+            log::info!("Duration mismatch across inputs: {min:.1}s..{max:.1}s, using shortest");
+        }
         let total_frame_count = effective_dur.map(|dur| (dur * fps) as u64);
         let info = SourceInfo {
             width: probe.width(),
@@ -160,35 +162,33 @@ impl FfmpegFileSource {
         };
         let decode_backend = probe.backend();
         let pixel_format = probe.pixel_format();
-        let left_rotation = probe.rotation();
+        let first_rotation = probe.rotation();
         drop(probe);
 
-        let right_rotation = ffmpeg::decoder::VideoDecoder::open(right_probe_path)
-            .map(|d| d.rotation())
-            .unwrap_or_else(|e| {
-                log::warn!("Failed to probe right video for rotation ({e}), assuming 0 degrees");
-                0
-            });
+        let rotations: Vec<i32> = std::iter::once(first_rotation)
+            .chain(inputs[1..].iter().map(|input| {
+                ffmpeg::decoder::VideoDecoder::open(input.first_path())
+                    .map(|d| d.rotation())
+                    .unwrap_or_else(|e| {
+                        log::warn!(
+                            "Failed to probe {} for rotation ({e}), assuming 0 degrees",
+                            input.first_path().display()
+                        );
+                        0
+                    })
+            }))
+            .collect();
 
-        let left_owned = left.clone();
-        let right_owned = right.clone();
-        let rx = Self::spawn_decode_pipeline_from_inputs(
-            left_owned.clone(),
-            right_owned.clone(),
-            sync_offset,
-            None,
-            software_decode,
-        );
+        let inputs = inputs.to_vec();
+        let rx = Self::spawn_decode_pipeline(inputs.clone(), sync_offset, None, software_decode);
 
         Ok(Self {
             rx,
             info,
             decode_backend,
             pixel_format,
-            left_rotation,
-            right_rotation,
-            left_input: left_owned,
-            right_input: right_owned,
+            rotations,
+            inputs,
             sync_offset,
             software_decode,
             total_frame_count,
@@ -210,14 +210,14 @@ impl FfmpegFileSource {
         self.pixel_format
     }
 
-    /// Left stream rotation from metadata (0, 90, 180, 270 degrees).
+    /// Camera 0 stream rotation from metadata (0, 90, 180, 270 degrees).
     pub fn left_rotation(&self) -> i32 {
-        self.left_rotation
+        self.rotations[0]
     }
 
-    /// Right stream rotation from metadata.
+    /// Camera 1 stream rotation from metadata (0 for single-input jobs).
     pub fn right_rotation(&self) -> i32 {
-        self.right_rotation
+        self.rotations.get(1).copied().unwrap_or(0)
     }
 
     /// Whether this source's decode backend supports zero-copy GPU transfer.
@@ -254,7 +254,7 @@ impl FfmpegFileSource {
 
     fn spawn_single_decoder_at(
         input: crate::stitch_job::InputPath,
-        label: &'static str,
+        label: String,
         seek_secs: Option<f64>,
         software_decode: bool,
     ) -> std::sync::mpsc::Receiver<YuvData> {
@@ -340,48 +340,67 @@ impl FfmpegFileSource {
         rx
     }
 
-    fn spawn_decode_pipeline_from_inputs(
-        left: crate::stitch_job::InputPath,
-        right: crate::stitch_job::InputPath,
+    fn spawn_decode_pipeline(
+        inputs: Vec<crate::stitch_job::InputPath>,
         sync_offset: i64,
         seek_secs: Option<f64>,
         software_decode: bool,
     ) -> std::sync::mpsc::Receiver<FrameSet> {
-        let left_rx = Self::spawn_single_decoder_at(left, "left", seek_secs, software_decode);
-        let right_rx = Self::spawn_single_decoder_at(right, "right", seek_secs, software_decode);
+        let rxs: Vec<_> = inputs
+            .into_iter()
+            .enumerate()
+            .map(|(i, input)| {
+                Self::spawn_single_decoder_at(input, format!("cam{i}"), seek_secs, software_decode)
+            })
+            .collect();
 
         let (tx, rx) = std::sync::mpsc::sync_channel::<FrameSet>(4);
 
         std::thread::Builder::new()
-            .name("decode_pair".into())
+            .name("decode_zip".into())
             .spawn(move || {
-                // Apply sync offset: skip frames from the camera that started first.
-                if sync_offset > 0 {
-                    // Right started first — skip N right frames.
-                    for _ in 0..sync_offset {
-                        if right_rx.recv().is_err() {
-                            return;
+                // Temporal alignment is defined between exactly two
+                // cameras (positive = camera 1 started first, negative
+                // = camera 0). Other arities have no alignment pair.
+                if let [cam0_rx, cam1_rx] = rxs.as_slice() {
+                    if sync_offset > 0 {
+                        for _ in 0..sync_offset {
+                            if cam1_rx.recv().is_err() {
+                                return;
+                            }
                         }
-                    }
-                    log::debug!("Sync offset: skipped {sync_offset} right frames");
-                } else if sync_offset < 0 {
-                    // Left started first — skip N left frames.
-                    let skip = sync_offset.unsigned_abs();
-                    for _ in 0..skip {
-                        if left_rx.recv().is_err() {
-                            return;
+                        log::debug!("Sync offset: skipped {sync_offset} camera-1 frames");
+                    } else if sync_offset < 0 {
+                        let skip = sync_offset.unsigned_abs();
+                        for _ in 0..skip {
+                            if cam0_rx.recv().is_err() {
+                                return;
+                            }
                         }
+                        log::debug!("Sync offset: skipped {skip} camera-0 frames");
                     }
-                    log::debug!("Sync offset: skipped {skip} left frames");
+                } else if sync_offset != 0 {
+                    log::info!(
+                        "Sync offset {sync_offset} ignored: alignment is defined for \
+                         two-camera jobs, this job has {}",
+                        rxs.len()
+                    );
                 }
 
-                while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
-                    if tx.send(FrameSet::Yuv420p(vec![left, right])).is_err() {
+                'zip: loop {
+                    let mut cams = Vec::with_capacity(rxs.len());
+                    for rx in &rxs {
+                        match rx.recv() {
+                            Ok(frame) => cams.push(frame),
+                            Err(_) => break 'zip,
+                        }
+                    }
+                    if tx.send(FrameSet::Yuv420p(cams)).is_err() {
                         break;
                     }
                 }
             })
-            .expect("spawn pairing thread");
+            .expect("spawn decode zip thread");
 
         rx
     }
@@ -394,11 +413,11 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
     }
 
     fn left_rotation(&self) -> i32 {
-        self.left_rotation
+        FfmpegFileSource::left_rotation(self)
     }
 
     fn right_rotation(&self) -> i32 {
-        self.right_rotation
+        FfmpegFileSource::right_rotation(self)
     }
 
     fn gpu_pixel_format(&self) -> reco_core::render::renderer::GpuPixelFormat {
@@ -469,9 +488,8 @@ impl reco_core::source::FrameSource for FfmpegFileSource {
         // Drop old receiver - disconnects current decode threads which
         // exit on the next send() failure. Spawns fresh decoders that
         // seek to the target keyframe and skip to the exact PTS.
-        self.rx = Self::spawn_decode_pipeline_from_inputs(
-            self.left_input.clone(),
-            self.right_input.clone(),
+        self.rx = Self::spawn_decode_pipeline(
+            self.inputs.clone(),
             self.sync_offset,
             Some(secs),
             self.software_decode,
@@ -566,130 +584,6 @@ pub fn create_encoder(
     let encoder = FfmpegFileEncoder::new(path, width, height, fps, &enc_config)?;
     let name = encoder.encoder_name().to_string();
     Ok((encoder, name))
-}
-
-// -- FFmpeg Mono Source --
-
-/// Single-video source for mono topologies (pre-stitched panoramas).
-///
-/// Decodes one file on a background thread and delivers
-/// one-camera [`FrameSet`]s - the single-input dual of
-/// [`FfmpegFileSource`] for cylinder calibrations.
-#[cfg(feature = "ffmpeg")]
-pub struct FfmpegMonoSource {
-    rx: std::sync::mpsc::Receiver<YuvData>,
-    info: SourceInfo,
-    input: crate::stitch_job::InputPath,
-    software_decode: bool,
-    current_frame: u64,
-    exhausted: bool,
-}
-
-#[cfg(feature = "ffmpeg")]
-impl FfmpegMonoSource {
-    /// Open a mono source. `software_decode` forces the software
-    /// decoder (the `--cpu` path).
-    pub fn open(
-        input: &crate::stitch_job::InputPath,
-        software_decode: bool,
-    ) -> Result<Self, SourceError> {
-        let probe_path = input.first_path();
-        reco_core::source::validate_input_path(probe_path)?;
-        let probe =
-            ffmpeg::decoder::VideoDecoder::open(probe_path).map_err(|e| SourceError::Init {
-                path: probe_path.display().to_string(),
-                reason: format!("{e}"),
-            })?;
-        let fps_r = probe.frame_rate();
-        let fps = probe.fps();
-        let total_frames = input_duration_secs(input).map(|dur| (dur * fps) as u64);
-        let info = SourceInfo {
-            width: probe.width(),
-            height: probe.height(),
-            fps,
-            fps_rational: Some((fps_r.0, fps_r.1)),
-            total_frames,
-        };
-        drop(probe);
-
-        let rx =
-            FfmpegFileSource::spawn_single_decoder_at(input.clone(), "mono", None, software_decode);
-        Ok(Self {
-            rx,
-            info,
-            input: input.clone(),
-            software_decode,
-            current_frame: 0,
-            exhausted: false,
-        })
-    }
-}
-
-#[cfg(feature = "ffmpeg")]
-impl reco_core::source::FrameSource for FfmpegMonoSource {
-    fn info(&self) -> SourceInfo {
-        self.info.clone()
-    }
-
-    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
-        if self.exhausted {
-            return Ok(None);
-        }
-        match self.rx.recv() {
-            Ok(yuv) => {
-                self.current_frame += 1;
-                Ok(Some(FrameSet::Yuv420p(vec![yuv])))
-            }
-            Err(_) => {
-                self.exhausted = true;
-                Ok(None)
-            }
-        }
-    }
-
-    fn total_frames(&self) -> Option<u64> {
-        self.info.total_frames
-    }
-
-    fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
-        self.seek(self.current_frame + count)?;
-        Ok(count)
-    }
-
-    fn seek(&mut self, frame: u64) -> Result<(), SourceError> {
-        // Same two strategies as `FfmpegFileSource::seek`: a short
-        // forward seek drains the already-running decoder; anything
-        // else respawns it at the target keyframe. Decode-and-discard
-        // for a large `start_time` would decode the entire prefix.
-        if frame >= self.current_frame {
-            let skip = frame - self.current_frame;
-            let max_forward = (self.info.fps * 10.0) as u64;
-            if skip <= max_forward {
-                for _ in 0..skip {
-                    match self.rx.recv() {
-                        Ok(_) => self.current_frame += 1,
-                        Err(_) => {
-                            self.exhausted = true;
-                            break;
-                        }
-                    }
-                }
-                return Ok(());
-            }
-        }
-
-        let secs = frame as f64 / self.info.fps;
-        log::debug!("mono seek to frame {frame} ({secs:.1}s)");
-        self.rx = FfmpegFileSource::spawn_single_decoder_at(
-            self.input.clone(),
-            "mono",
-            Some(secs),
-            self.software_decode,
-        );
-        self.current_frame = frame;
-        self.exhausted = false;
-        Ok(())
-    }
 }
 
 // -- FFmpeg File Encoder --

--- a/crates/reco-io/src/gstreamer/camera.rs
+++ b/crates/reco-io/src/gstreamer/camera.rs
@@ -12,9 +12,7 @@
 use gstreamer as gst;
 use gstreamer::prelude::*;
 use gstreamer_app as gst_app;
-use reco_core::source::{
-    FramePair, Nv12Data, Nv12FramePair, SourceError, SourceInfo, StereoFrame, YuvData,
-};
+use reco_core::source::{FrameSet, Nv12Data, SourceError, SourceInfo, YuvData};
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -382,10 +380,10 @@ fn spawn_nv12_capture_thread(
 /// Stereo camera source using GStreamer (I420 output).
 ///
 /// Each camera runs in its own thread pulling frames from appsink.
-/// A pairing thread zips left+right into `FramePair`s and sends
-/// them through a bounded channel.
+/// A pairing thread zips left+right into a [`FrameSet`] and sends
+/// it through a bounded channel.
 pub struct GstreamerCameraSource {
-    rx: mpsc::Receiver<FramePair>,
+    rx: mpsc::Receiver<FrameSet>,
     info: SourceInfo,
 }
 
@@ -412,13 +410,13 @@ impl GstreamerCameraSource {
             config.fps,
         );
 
-        let (tx, rx) = mpsc::sync_channel::<FramePair>(2);
+        let (tx, rx) = mpsc::sync_channel::<FrameSet>(2);
 
         std::thread::Builder::new()
             .name("capture_pair".into())
             .spawn(move || {
                 while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
-                    if tx.send(FramePair { left, right }).is_err() {
+                    if tx.send(FrameSet::Yuv420p(vec![left, right])).is_err() {
                         break;
                     }
                 }
@@ -449,9 +447,9 @@ impl reco_core::source::FrameSource for GstreamerCameraSource {
         self.info.clone()
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match self.rx.recv() {
-            Ok(pair) => Ok(Some(StereoFrame::Yuv420p(pair))),
+            Ok(frames) => Ok(Some(frames)),
             Err(_) => Ok(None),
         }
     }
@@ -466,7 +464,7 @@ impl reco_core::source::FrameSource for GstreamerCameraSource {
 ///
 /// Implements graceful shutdown via `Drop` to avoid Argus teardown crashes.
 pub struct GstreamerNv12CameraSource {
-    rx: mpsc::Receiver<Nv12FramePair>,
+    rx: mpsc::Receiver<(Nv12Data, Nv12Data)>,
     info: SourceInfo,
     stop: Arc<AtomicBool>,
 }
@@ -498,13 +496,13 @@ impl GstreamerNv12CameraSource {
             stop.clone(),
         );
 
-        let (tx, rx) = mpsc::sync_channel::<Nv12FramePair>(2);
+        let (tx, rx) = mpsc::sync_channel::<(Nv12Data, Nv12Data)>(2);
 
         std::thread::Builder::new()
             .name("capture_pair".into())
             .spawn(move || {
                 while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
-                    if tx.send(Nv12FramePair { left, right }).is_err() {
+                    if tx.send((left, right)).is_err() {
                         break;
                     }
                 }
@@ -539,8 +537,11 @@ impl GstreamerNv12CameraSource {
         self.info.clone()
     }
 
-    /// Get the next stereo NV12 frame pair, or `None` if the source is exhausted.
-    pub fn next_pair(&mut self) -> Result<Option<Nv12FramePair>, SourceError> {
+    /// Get the next `(left, right)` NV12 frame pair, or `None` if the
+    /// source is exhausted. The per-camera accessor for genuinely
+    /// pair-shaped consumers (stereo calibration); pipeline consumers
+    /// use [`FrameSource::next_frame`](reco_core::source::FrameSource).
+    pub fn next_pair(&mut self) -> Result<Option<(Nv12Data, Nv12Data)>, SourceError> {
         match self.rx.recv() {
             Ok(pair) => Ok(Some(pair)),
             Err(_) => Ok(None),
@@ -553,11 +554,9 @@ impl reco_core::source::FrameSource for GstreamerNv12CameraSource {
         self.info.clone()
     }
 
-    fn next_frame(
-        &mut self,
-    ) -> Result<Option<reco_core::source::StereoFrame>, reco_core::source::SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, reco_core::source::SourceError> {
         self.next_pair()
-            .map(|opt| opt.map(reco_core::source::StereoFrame::Nv12))
+            .map(|opt| opt.map(|(left, right)| FrameSet::Nv12(vec![left, right])))
     }
 }
 
@@ -847,14 +846,14 @@ mod nvmm_source {
             self.info.clone()
         }
 
-        /// Pull the next NVMM stereo frame as [`StereoFrame::NvmmResident`].
+        /// Pull the next NVMM stereo frame as [`FrameSet::NvmmResident`].
         ///
         /// Releases the previous frame's DMA-buf first (deferred release):
         /// the capture thread blocks until released, and the session has
         /// finished importing + detecting the prior frame by the time this
         /// is called again, so the buffer is safe to recycle. Exactly one
         /// frame is ever unreleased.
-        fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+        fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
             if self.outstanding {
                 self.release_previous();
                 self.outstanding = false;
@@ -862,10 +861,10 @@ mod nvmm_source {
             match self.next_pair()? {
                 Some(pair) => {
                     self.outstanding = true;
-                    Ok(Some(StereoFrame::NvmmResident {
-                        left: to_plane_info(&pair.left),
-                        right: to_plane_info(&pair.right),
-                    }))
+                    Ok(Some(FrameSet::NvmmResident([
+                        to_plane_info(&pair.left),
+                        to_plane_info(&pair.right),
+                    ])))
                 }
                 None => Ok(None),
             }

--- a/crates/reco-io/src/libcamera.rs
+++ b/crates/reco-io/src/libcamera.rs
@@ -18,7 +18,7 @@
 //!                                                     FrameSource::next_frame()
 //! ```
 
-use reco_core::source::{FramePair, SourceError, SourceInfo, StereoFrame, YuvData};
+use reco_core::source::{FrameSet, SourceError, SourceInfo, YuvData};
 use std::io::Read;
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
@@ -52,7 +52,7 @@ pub struct LibcameraConfig {
 /// It bypasses GStreamer and FFmpeg entirely, providing the lowest
 /// possible latency path from the camera ISP to the GPU renderer.
 pub struct LibcameraCameraSource {
-    rx: mpsc::Receiver<FramePair>,
+    rx: mpsc::Receiver<FrameSet>,
     info: SourceInfo,
     /// rpicam-vid child processes. One in single-camera mode, two in stereo.
     children: Vec<Child>,
@@ -167,7 +167,7 @@ impl LibcameraCameraSource {
             },
         );
 
-        let (tx, rx) = mpsc::sync_channel::<FramePair>(2);
+        let (tx, rx) = mpsc::sync_channel::<FrameSet>(2);
 
         let children = if single_camera {
             // Single-camera mode: one rpicam-vid, duplicate each frame.
@@ -183,11 +183,8 @@ impl LibcameraCameraSource {
                 .name("libcam_dup".into())
                 .spawn(move || {
                     while let Ok(frame) = cam_rx.recv() {
-                        let pair = FramePair {
-                            left: frame.clone(),
-                            right: frame,
-                        };
-                        if tx.send(pair).is_err() {
+                        let frames = FrameSet::Yuv420p(vec![frame.clone(), frame]);
+                        if tx.send(frames).is_err() {
                             break;
                         }
                     }
@@ -218,7 +215,7 @@ impl LibcameraCameraSource {
                 .name("libcam_pair".into())
                 .spawn(move || {
                     while let (Ok(left), Ok(right)) = (left_rx.recv(), right_rx.recv()) {
-                        if tx.send(FramePair { left, right }).is_err() {
+                        if tx.send(FrameSet::Yuv420p(vec![left, right])).is_err() {
                             break;
                         }
                     }
@@ -258,9 +255,9 @@ impl reco_core::source::FrameSource for LibcameraCameraSource {
         self.info.clone()
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match self.rx.recv() {
-            Ok(pair) => Ok(Some(StereoFrame::Yuv420p(pair))),
+            Ok(frames) => Ok(Some(frames)),
             Err(_) => Ok(None),
         }
     }

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -50,8 +50,6 @@ pub struct SmartFileSource {
 
 enum SourceMode {
     Cpu(crate::adapters::FfmpegFileSource),
-    /// Single pre-stitched panorama for mono topologies.
-    Mono(crate::adapters::FfmpegMonoSource),
     #[cfg(target_os = "linux")]
     GpuZeroCopy(Box<LinuxZeroCopyState>),
     #[cfg(target_os = "macos")]
@@ -208,30 +206,35 @@ impl SmartFileSource {
             )
         } else {
             Self::open_cpu(
-                left,
-                right,
+                &[left.clone(), right.clone()],
                 sync_offset,
                 false,
                 info,
                 pixel_format,
                 full_range,
-                left_rotation,
-                right_rotation,
             )
         }
     }
 
+    /// Open a CPU-decode source for any number of inputs (projection
+    /// order). Format, fps, and color range are probed from input 0;
+    /// per-input rotation is probed by the decode layer.
     pub fn open_cpu_only(
-        left: &crate::stitch_job::InputPath,
-        right: &crate::stitch_job::InputPath,
+        inputs: &[crate::stitch_job::InputPath],
         sync_offset: i64,
         software_decode: bool,
     ) -> Result<Self, SourceError> {
-        let left_probe_path = left.first_path();
+        let [first, ..] = inputs else {
+            return Err(SourceError::Init {
+                path: "(none)".into(),
+                reason: "at least one input video is required".into(),
+            });
+        };
+        let probe_path = first.first_path();
 
-        let probe = crate::ffmpeg::decoder::VideoDecoder::open(left_probe_path).map_err(|e| {
+        let probe = crate::ffmpeg::decoder::VideoDecoder::open(probe_path).map_err(|e| {
             SourceError::Init {
-                path: left_probe_path.display().to_string(),
+                path: probe_path.display().to_string(),
                 reason: format!("{e}"),
             }
         })?;
@@ -245,53 +248,37 @@ impl SmartFileSource {
         };
         let pixel_format = probe.pixel_format();
         let full_range = probe.is_full_range();
-        let left_rotation = probe.rotation();
         drop(probe);
 
-        let right_rotation = crate::ffmpeg::decoder::VideoDecoder::open(right.first_path())
-            .map(|d| d.rotation())
-            .unwrap_or_else(|e| {
-                log::warn!("Failed to probe right video for rotation ({e}), assuming 0 degrees");
-                0
-            });
-
         Self::open_cpu(
-            left,
-            right,
+            inputs,
             sync_offset,
             software_decode,
             info,
             pixel_format,
             full_range,
-            left_rotation,
-            right_rotation,
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn open_cpu(
-        left: &crate::stitch_job::InputPath,
-        right: &crate::stitch_job::InputPath,
+        inputs: &[crate::stitch_job::InputPath],
         sync_offset: i64,
         software_decode: bool,
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
         full_range: bool,
-        left_rotation: i32,
-        right_rotation: i32,
     ) -> Result<Self, SourceError> {
-        let source = crate::adapters::FfmpegFileSource::open_from_inputs(
-            left,
-            right,
-            sync_offset,
-            software_decode,
-        )?;
+        let source =
+            crate::adapters::FfmpegFileSource::open_inputs(inputs, sync_offset, software_decode)?;
         log::info!(
-            "SmartFileSource: CPU decode ({}x{}, {pixel_format:?}{})",
+            "SmartFileSource: CPU decode ({} camera(s), {}x{}, {pixel_format:?}{})",
+            inputs.len(),
             info.width,
             info.height,
             if full_range { ", full-range" } else { "" }
         );
+        let left_rotation = source.left_rotation();
+        let right_rotation = source.right_rotation();
         Ok(Self {
             mode: SourceMode::Cpu(source),
             info,
@@ -547,33 +534,6 @@ impl SmartFileSource {
         )
     }
 
-    /// Open a single-input mono source (cylinder calibrations).
-    ///
-    /// Always CPU frames - the mono GPU pass is not wired yet.
-    /// `software_decode` forces the software decoder (`--cpu`).
-    pub fn open_mono(
-        input: &crate::stitch_job::InputPath,
-        software_decode: bool,
-    ) -> Result<Self, SourceError> {
-        let source = crate::adapters::FfmpegMonoSource::open(input, software_decode)?;
-        let info = source.info();
-        log::info!(
-            "SmartFileSource: mono CPU decode ({}x{})",
-            info.width,
-            info.height
-        );
-        Ok(Self {
-            mode: SourceMode::Mono(source),
-            info,
-            pixel_format: GpuPixelFormat::Nv12,
-            full_range: false,
-            left_rotation: 0,
-            right_rotation: 0,
-            decode_mode: "CPU mono",
-            exhausted: false,
-        })
-    }
-
     /// Human-readable description of the active decode path.
     pub fn decode_mode(&self) -> &'static str {
         self.decode_mode
@@ -644,7 +604,6 @@ impl FrameSource for SmartFileSource {
 
     fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match &mut self.mode {
-            SourceMode::Mono(source) => source.next_frame(),
             SourceMode::Cpu(source) => {
                 let frame = source.next_frame()?;
                 if frame.is_none() {
@@ -713,12 +672,11 @@ impl FrameSource for SmartFileSource {
     }
 
     fn is_gpu_resident(&self) -> bool {
-        !matches!(self.mode, SourceMode::Cpu(_) | SourceMode::Mono(_))
+        !matches!(self.mode, SourceMode::Cpu(_))
     }
 
     fn skip_frames(&mut self, count: u64) -> Result<u64, SourceError> {
         match &mut self.mode {
-            SourceMode::Mono(source) => source.skip_frames(count),
             #[cfg(target_os = "linux")]
             SourceMode::GpuZeroCopy(state) => {
                 let rx = state
@@ -790,7 +748,6 @@ impl FrameSource for SmartFileSource {
         // implement `try_next_frame`, so their local flag is sufficient).
         match &self.mode {
             SourceMode::Cpu(source) => self.exhausted || source.is_exhausted(),
-            SourceMode::Mono(_) => self.exhausted,
             #[cfg(target_os = "linux")]
             SourceMode::GpuZeroCopy(_) => self.exhausted,
             #[cfg(target_os = "macos")]

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -19,7 +19,7 @@
 //! ```
 
 use reco_core::render::renderer::GpuPixelFormat;
-use reco_core::source::{FrameSource, SourceError, SourceInfo, StereoFrame};
+use reco_core::source::{FrameSet, FrameSource, SourceError, SourceInfo};
 
 /// GPU-aware stereo file source that auto-selects the optimal decode path.
 ///
@@ -84,7 +84,7 @@ struct WindowsZeroCopyState {
     ///
     /// The `_frame_ref` inside each D3d11Frame pins the decode pool slice
     /// in FFmpeg's surface allocator. Without this, the slice is recycled
-    /// as soon as the raw pointers are extracted into `StereoFrame::D3d11Resident`,
+    /// as soon as the raw pointers are extracted into `FrameSet::D3d11Resident`,
     /// and the decoder thread can overwrite the surface before `stage_frame`
     /// copies it - causing frame reordering glitches on Intel and NVIDIA.
     ///
@@ -642,7 +642,7 @@ impl FrameSource for SmartFileSource {
         self.info.clone()
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         match &mut self.mode {
             SourceMode::Mono(source) => source.next_frame(),
             SourceMode::Cpu(source) => {
@@ -659,9 +659,8 @@ impl FrameSource for SmartFileSource {
                     .as_ref()
                     .expect("frame_rx taken during shutdown");
                 match rx.recv() {
-                    Ok(signal) => Ok(Some(StereoFrame::GpuResident {
-                        left_slot: signal.left_slot,
-                        right_slot: signal.right_slot,
+                    Ok(signal) => Ok(Some(FrameSet::GpuResident {
+                        slots: [signal.left_slot, signal.right_slot],
                     })),
                     Err(_) => {
                         self.exhausted = true;
@@ -671,10 +670,7 @@ impl FrameSource for SmartFileSource {
             }
             #[cfg(target_os = "macos")]
             SourceMode::MetalZeroCopy(rx) => match rx.recv() {
-                Ok(pair) => Ok(Some(StereoFrame::MetalResident {
-                    left: pair.left,
-                    right: pair.right,
-                })),
+                Ok(pair) => Ok(Some(FrameSet::MetalResident([pair.left, pair.right]))),
                 Err(_) => {
                     self.exhausted = true;
                     Ok(None)
@@ -689,19 +685,23 @@ impl FrameSource for SmartFileSource {
                 };
                 match pair_rx.recv() {
                     Ok((left, right)) => {
-                        let stereo = StereoFrame::D3d11Resident {
-                            left_texture: left.texture,
-                            left_slice: left.array_slice,
-                            right_texture: right.texture,
-                            right_slice: right.array_slice,
-                        };
+                        let frames = FrameSet::D3d11Resident([
+                            reco_core::source::D3d11CameraFrame {
+                                texture: left.texture,
+                                slice: left.array_slice,
+                            },
+                            reco_core::source::D3d11CameraFrame {
+                                texture: right.texture,
+                                slice: right.array_slice,
+                            },
+                        ]);
                         // Keep the D3d11Frame pair alive so FFmpeg doesn't
                         // recycle the decode pool slices before stage_frame
                         // copies them. The previous guard is dropped here,
                         // which is safe because its staging copy already
                         // completed in the previous loop iteration.
                         state.live_frame_guard = Some((left, right));
-                        Ok(Some(stereo))
+                        Ok(Some(frames))
                     }
                     Err(_) => {
                         self.exhausted = true;

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -277,8 +277,8 @@ impl SmartFileSource {
             info.height,
             if full_range { ", full-range" } else { "" }
         );
-        let left_rotation = source.left_rotation();
-        let right_rotation = source.right_rotation();
+        let left_rotation = source.rotation(0);
+        let right_rotation = source.rotation(1);
         Ok(Self {
             mode: SourceMode::Cpu(source),
             info,

--- a/crates/reco-io/src/smart_source.rs
+++ b/crates/reco-io/src/smart_source.rs
@@ -1,4 +1,4 @@
-//! GPU-aware stereo file source with automatic backend selection.
+//! GPU-aware file source with automatic backend selection.
 //!
 //! [`SmartFileSource`] is the standard way to open video files for stitching.
 //! It probes the input, detects the best decode path (GPU zero-copy or CPU),
@@ -518,19 +518,17 @@ impl SmartFileSource {
         info: SourceInfo,
         pixel_format: GpuPixelFormat,
         full_range: bool,
-        left_rotation: i32,
-        right_rotation: i32,
+        _left_rotation: i32,
+        _right_rotation: i32,
     ) -> Result<Self, SourceError> {
         log::info!("SmartFileSource: zero-copy not yet implemented for this platform, using CPU");
         Self::open_cpu(
-            left,
-            right,
+            &[left.clone(), right.clone()],
             sync_offset,
+            false,
             info,
             pixel_format,
             full_range,
-            left_rotation,
-            right_rotation,
         )
     }
 

--- a/crates/reco-io/src/stacked_video/replay.rs
+++ b/crates/reco-io/src/stacked_video/replay.rs
@@ -8,7 +8,7 @@
 //! frame is passed through to the stitch pipeline unmodified while a
 //! copy is packed into the replay encoder on the same thread.
 //!
-//! Only the CPU `StereoFrame::Yuv420p` variant is recorded today:
+//! Only two-camera CPU `FrameSet::Yuv420p` sets are recorded today:
 //!
 //! - `Nv12` (Jetson ISP / NVDEC on Linux): not yet supported;
 //!   would need an NV12 pack variant or a one-off Nv12->Yuv420p
@@ -27,7 +27,7 @@ use reco_core::core::types::StackedReplayGpuRecorder as CoreStackedGpuRecorder;
 use reco_core::core::types::StackedReplayRecorder as CoreStackedReplayRecorder;
 use reco_core::gpu::yuv_stack_packer::StackedAtlas;
 use reco_core::render::pipeline::YuvPlanes;
-use reco_core::source::{FrameSource, SourceError, SourceInfo, StereoFrame, YuvFrame};
+use reco_core::source::{FrameSet, FrameSource, SourceError, SourceInfo, YuvFrame};
 use std::path::Path;
 
 /// Decorator FrameSource that also writes source frames to a
@@ -98,25 +98,25 @@ impl ReplayRecordingSource {
         self.frames_recorded
     }
 
-    fn record(&mut self, frame: &StereoFrame) {
+    fn record(&mut self, frame: &FrameSet) {
         let Some(ref mut encoder) = self.encoder else {
             return;
         };
         match frame {
-            StereoFrame::Yuv420p(pair) => {
+            FrameSet::Yuv420p(cams) if cams.len() == 2 => {
                 let info = self.inner.info();
                 let left = YuvFrame {
-                    y: pair.left.y.clone(),
-                    u: pair.left.u.clone(),
-                    v: pair.left.v.clone(),
+                    y: cams[0].y.clone(),
+                    u: cams[0].u.clone(),
+                    v: cams[0].v.clone(),
                     width: info.width,
                     height: info.height,
                     timestamp_us: 0,
                 };
                 let right = YuvFrame {
-                    y: pair.right.y.clone(),
-                    u: pair.right.u.clone(),
-                    v: pair.right.v.clone(),
+                    y: cams[1].y.clone(),
+                    u: cams[1].u.clone(),
+                    v: cams[1].v.clone(),
                     width: info.width,
                     height: info.height,
                     timestamp_us: 0,
@@ -140,9 +140,10 @@ impl ReplayRecordingSource {
             _ => {
                 if !self.warned_non_yuv420p {
                     log::warn!(
-                        "replay recording: source yields non-Yuv420p frames; \
-                         recording disabled for this session (Nv12/GPU-resident \
-                         variants need a separate pack path, not implemented yet)"
+                        "replay recording: source yields frames outside the 2-tile \
+                         Yuv420p format; recording disabled for this session \
+                         (Nv12/GPU-resident/mono sets need a separate pack path, \
+                         not implemented yet)"
                     );
                     self.warned_non_yuv420p = true;
                     self.encoder = None;
@@ -157,7 +158,7 @@ impl FrameSource for ReplayRecordingSource {
         self.inner.info()
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         let frame = self.inner.next_frame()?;
         if let Some(ref f) = frame {
             self.record(f);
@@ -165,7 +166,7 @@ impl FrameSource for ReplayRecordingSource {
         Ok(frame)
     }
 
-    fn try_next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn try_next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         let frame = self.inner.try_next_frame()?;
         if let Some(ref f) = frame {
             self.record(f);

--- a/crates/reco-io/src/stacked_video/source.rs
+++ b/crates/reco-io/src/stacked_video/source.rs
@@ -8,14 +8,12 @@
 //!   for N-arbitrary consumers (replay scrubbing, analysis).
 //! - The [`reco_core::source::FrameSource`] impl accepts only
 //!   `capacity == 2` layouts and yields
-//!   [`reco_core::source::StereoFrame::Yuv420p`] pairs so the
+//!   [`reco_core::source::FrameSet::Yuv420p`] sets so the
 //!   stitch pipeline can drive off a stacked recording as if it
 //!   were two independent cameras.
 use super::{GridLayout, StackError, unpack_yuv420p};
 use crate::ffmpeg::decoder::{DecodeError, VideoDecoder};
-use reco_core::source::{
-    FramePair, FrameSource, SourceError, SourceInfo, StereoFrame, YuvData, YuvFrame,
-};
+use reco_core::source::{FrameSet, FrameSource, SourceError, SourceInfo, YuvData, YuvFrame};
 use std::path::Path;
 use thiserror::Error;
 
@@ -123,7 +121,7 @@ impl FrameSource for StackedSource {
         }
     }
 
-    fn next_frame(&mut self) -> Result<Option<StereoFrame>, SourceError> {
+    fn next_frame(&mut self) -> Result<Option<FrameSet>, SourceError> {
         if self.layout.capacity() != 2 {
             return Err(SourceError::Read {
                 reason: format!(
@@ -147,17 +145,17 @@ impl FrameSource for StackedSource {
                     reason: format!("expected 2 tiles, got {}", v.len()),
                 })?;
         let [left, right] = tiles;
-        Ok(Some(StereoFrame::Yuv420p(FramePair {
-            left: YuvData {
+        Ok(Some(FrameSet::Yuv420p(vec![
+            YuvData {
                 y: left.y,
                 u: left.u,
                 v: left.v,
             },
-            right: YuvData {
+            YuvData {
                 y: right.y,
                 u: right.u,
                 v: right.v,
             },
-        })))
+        ])))
     }
 }

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -152,6 +152,44 @@ impl InputPath {
             Self::Chained(v) => v.clone(),
         }
     }
+
+    /// Build from an ordered, non-empty segment list: one path stays
+    /// [`Single`](Self::Single), several chain via the concat demuxer.
+    /// The vec-shaped twin of [`Self::parse_segments`] for consumers
+    /// that collect paths themselves (file pickers, env specs).
+    pub fn from_segments(mut paths: Vec<PathBuf>) -> Self {
+        debug_assert!(!paths.is_empty(), "an input needs at least one segment");
+        if paths.len() == 1 {
+            Self::Single(paths.remove(0))
+        } else {
+            Self::Chained(paths)
+        }
+    }
+
+    /// Parse a `;`-separated segment string (`a.mp4;b.mp4;c.mp4`) into
+    /// a chained input; a single path stays `Single`. Segments are
+    /// trimmed and empty entries (doubled or trailing `;`) dropped, so
+    /// `"a.mp4;"` is the single input `a.mp4`, not a path with a
+    /// stray semicolon. A string with no usable segment keeps the raw
+    /// text so `open` reports it as an invalid path.
+    pub fn parse_segments(s: &str) -> Self {
+        let parts: Vec<PathBuf> = s
+            .split(';')
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        if parts.is_empty() {
+            return Self::Single(PathBuf::from(s.trim()));
+        }
+        if parts.len() > 1 {
+            log::info!(
+                "input: {} segments, chaining via concat demuxer",
+                parts.len()
+            );
+        }
+        Self::from_segments(parts)
+    }
 }
 
 impl From<&str> for InputPath {
@@ -1141,6 +1179,34 @@ mod tests {
             msg.contains("consumes 2 camera input(s), but 1 were given"),
             "expected the typed arity error, got: {msg}"
         );
+    }
+
+    #[test]
+    fn parse_segments_handles_single_chained_and_stray_separators() {
+        assert!(matches!(
+            InputPath::parse_segments("a.mp4"),
+            InputPath::Single(p) if p == std::path::Path::new("a.mp4")
+        ));
+        assert!(matches!(
+            InputPath::parse_segments("a.mp4;b.mp4"),
+            InputPath::Chained(v) if v.len() == 2
+        ));
+        // A trailing separator is one input, not a path with a stray
+        // semicolon (the old CLI closure wrapped the raw string).
+        assert!(matches!(
+            InputPath::parse_segments("a.mp4;"),
+            InputPath::Single(p) if p == std::path::Path::new("a.mp4")
+        ));
+        assert!(matches!(
+            InputPath::parse_segments(" a.mp4 ; b.mp4 "),
+            InputPath::Chained(v) if v == vec![PathBuf::from("a.mp4"), PathBuf::from("b.mp4")]
+        ));
+        // Nothing usable: the raw text flows into open()'s
+        // invalid-path reporting instead of an empty chain.
+        assert!(matches!(
+            InputPath::parse_segments(";;"),
+            InputPath::Single(p) if p == std::path::Path::new(";;")
+        ));
     }
 
     #[test]

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -1,7 +1,7 @@
 //! One-shot file-to-file stitching (Layer 3 API).
 //!
-//! [`StitchJob`] is the simplest way to stitch two video files into a
-//! panoramic output. It handles all orchestration internally: GPU
+//! [`StitchJob`] is the simplest way to stitch per-camera video files
+//! into a panoramic output. It handles all orchestration internally: GPU
 //! initialization (or the all-software path via [`StitchJob::cpu`]),
 //! zero-copy detection, encoder creation, decode thread management,
 //! and audio passthrough.
@@ -207,12 +207,6 @@ impl From<&Path> for InputPath {
 impl From<PathBuf> for InputPath {
     fn from(p: PathBuf) -> Self {
         Self::Single(p)
-    }
-}
-
-impl<P: AsRef<Path>> From<Vec<P>> for InputPath {
-    fn from(paths: Vec<P>) -> Self {
-        Self::Chained(paths.iter().map(|p| p.as_ref().to_path_buf()).collect())
     }
 }
 

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -12,7 +12,7 @@
 //! use reco_io::StitchJob;
 //! use reco_io::output::{Codec, Quality};
 //!
-//! StitchJob::new("left.mp4", "right.mp4", "match.json", "output.mp4")
+//! StitchJob::new(["left.mp4", "right.mp4"], "match.json", "output.mp4")
 //!     .codec(Codec::HEVC)
 //!     .quality(Quality::High)
 //!     .on_progress(|p| println!("{:.0}%", p.percent()))
@@ -35,9 +35,11 @@ use reco_core::source::FrameSource;
 /// [`run`](Self::run) to execute. All GPU, encoder, and decode lifecycle
 /// is managed internally.
 pub struct StitchJob {
-    left: InputPath,
-    /// `None` for mono (single-input) topologies.
-    right: Option<InputPath>,
+    /// One input per camera, in projection order (index i pairs with
+    /// `calibration.lenses[i]`). Arity is validated against the
+    /// calibration's topology in [`run`](Self::run) before any decoder
+    /// spins up.
+    inputs: Vec<InputPath>,
     calibration: CalibrationSource,
     output: PathBuf,
 
@@ -233,15 +235,17 @@ pub enum StitchError {
 
 impl StitchJob {
     /// Create a job from file paths (loads calibration from JSON).
+    ///
+    /// `inputs` is one video per camera in projection order; the
+    /// calibration's topology decides how many are required (the
+    /// L-shape consumes two, the cylinder one).
     pub fn new(
-        left: impl Into<InputPath>,
-        right: impl Into<InputPath>,
+        inputs: impl IntoIterator<Item = impl Into<InputPath>>,
         calibration: impl AsRef<Path>,
         output: impl AsRef<Path>,
     ) -> Self {
         Self {
-            left: left.into(),
-            right: Some(right.into()),
+            inputs: inputs.into_iter().map(Into::into).collect(),
             calibration: CalibrationSource::File(calibration.as_ref().to_path_buf()),
             output: output.as_ref().to_path_buf(),
             codec: Codec::default(),
@@ -269,43 +273,13 @@ impl StitchJob {
         }
     }
 
-    /// Create a single-input job for mono topologies (the cylinder's
-    /// pre-stitched panorama). The calibration document must carry a
-    /// mono topology; [`run`](Self::run) rejects the mismatch.
-    pub fn mono(
-        input: impl Into<InputPath>,
-        calibration: impl AsRef<Path>,
-        output: impl AsRef<Path>,
-    ) -> Self {
-        let mut job = Self::new(
-            input,
-            InputPath::Single(PathBuf::new()),
-            calibration,
-            output,
-        );
-        job.right = None;
-        job
-    }
-
     /// Create a job with in-memory calibration (no JSON file needed).
     pub fn with_calibration(
-        left: impl Into<InputPath>,
-        right: impl Into<InputPath>,
+        inputs: impl IntoIterator<Item = impl Into<InputPath>>,
         calibration: reco_core::calibration::Calibration,
         output: impl AsRef<Path>,
     ) -> Self {
-        let mut job = Self::new(left, right, Path::new(""), output);
-        job.calibration = CalibrationSource::Memory(Box::new(calibration));
-        job
-    }
-
-    /// [`Self::mono`] with an in-memory calibration.
-    pub fn mono_with_calibration(
-        input: impl Into<InputPath>,
-        calibration: reco_core::calibration::Calibration,
-        output: impl AsRef<Path>,
-    ) -> Self {
-        let mut job = Self::mono(input, Path::new(""), output);
+        let mut job = Self::new(inputs, Path::new(""), output);
         job.calibration = CalibrationSource::Memory(Box::new(calibration));
         job
     }
@@ -451,7 +425,7 @@ impl StitchJob {
     /// # Example
     ///
     /// ```rust,ignore
-    /// StitchJob::new("left.mp4", "right.mp4", "match.json", "out.mp4")
+    /// StitchJob::new(["left.mp4", "right.mp4"], "match.json", "out.mp4")
     ///     .with_replay_recording("replay.mkv")
     ///     .run(&interrupted)?;
     /// ```
@@ -566,7 +540,7 @@ impl StitchJob {
     /// ```rust,ignore
     /// use reco_autocam::{AutocamConfig, TrackingMode};
     ///
-    /// StitchJob::new("left.mp4", "right.mp4", "match.json", "out.mp4")
+    /// StitchJob::new(["left.mp4", "right.mp4"], "match.json", "out.mp4")
     ///     .on_session(|session, source| {
     ///         let config = AutocamConfig::new("model.onnx")
     ///             .with_tracking_mode(TrackingMode::Field)
@@ -607,30 +581,25 @@ impl StitchJob {
         }
 
         // Input arity must match the calibration's topology before any
-        // decoder spins up.
-        let mono = cal.topology.camera_count() == 1;
-        match (mono, &self.right) {
-            (true, Some(_)) => {
-                return Err(StitchError::Other(
-                    "this calibration's topology consumes one input video, but two were \
-                     given"
-                        .into(),
-                ));
-            }
-            (false, None) => {
-                return Err(StitchError::Other(
-                    "this calibration's topology needs left and right input videos".into(),
-                ));
-            }
-            _ => {}
+        // decoder spins up. The topology decides the camera count -
+        // never the number of inputs handed in.
+        let camera_count = cal.topology.camera_count();
+        if self.inputs.len() != camera_count {
+            return Err(StitchError::Other(format!(
+                "this calibration's topology consumes {camera_count} camera input(s), \
+                 but {} were given",
+                self.inputs.len()
+            )));
         }
+        let mono = camera_count == 1;
 
         // Decode + render strategy. --cpu never touches the GPU;
         // otherwise the GPU renders and decode is zero-copy unless
         // forced off. Mono topologies render on the CPU executor
-        // regardless (the mono GPU pass is not wired yet).
+        // regardless (the mono GPU pass is not wired yet); zero-copy
+        // decode selection is a two-camera path.
         log::debug!(
-            "StitchJob::run: mono={mono} cpu_stitch={} force_cpu_decode={}",
+            "StitchJob::run: cameras={camera_count} cpu_stitch={} force_cpu_decode={}",
             self.cpu_stitch,
             self.force_cpu_decode
         );
@@ -638,25 +607,34 @@ impl StitchJob {
             if !self.cpu_stitch {
                 log::info!("mono topology: software render (the mono GPU pass is not wired yet)");
             }
+            // effective_sync passes through so the decode layer logs
+            // the single-input ignore instead of silently zeroing it.
             (
                 None,
-                crate::SmartFileSource::open_mono(&self.left, self.cpu_stitch)?,
+                crate::SmartFileSource::open_cpu_only(
+                    &self.inputs,
+                    effective_sync,
+                    self.cpu_stitch,
+                )?,
             )
         } else if self.cpu_stitch {
             log::info!("CPU stitch: software render + software decode, no GPU touched (--cpu)");
-            let right = self.right.as_ref().expect("arity checked above");
             (
                 None,
-                crate::SmartFileSource::open_cpu_only(&self.left, right, effective_sync, true)?,
+                crate::SmartFileSource::open_cpu_only(&self.inputs, effective_sync, true)?,
             )
         } else {
-            let right = self.right.as_ref().expect("arity checked above");
             let gpu = reco_core::gpu::GpuContext::new_blocking()?;
             let source = if self.force_cpu_decode {
                 log::info!("Force CPU decode: zero-copy disabled by --no-zero-copy");
-                crate::SmartFileSource::open_cpu_only(&self.left, right, effective_sync, false)?
+                crate::SmartFileSource::open_cpu_only(&self.inputs, effective_sync, false)?
             } else {
-                crate::SmartFileSource::open(&self.left, right, &gpu, effective_sync)?
+                crate::SmartFileSource::open(
+                    &self.inputs[0],
+                    &self.inputs[1],
+                    &gpu,
+                    effective_sync,
+                )?
             };
             (Some(gpu), source)
         };
@@ -742,7 +720,7 @@ impl StitchJob {
 
         // Configure lookahead buffer if requested.
         if self.lookahead_secs > 0.0 {
-            let fps = crate::adapters::FfmpegFileSource::frame_rate(self.left.first_path())
+            let fps = crate::adapters::FfmpegFileSource::frame_rate(self.inputs[0].first_path())
                 .map(|(n, d)| if d != 0 { n as f64 / d as f64 } else { 30.0 })
                 .unwrap_or(30.0);
             let frames = (self.lookahead_secs * fps).round() as usize;
@@ -787,18 +765,16 @@ impl StitchJob {
         // Resolve audio source paths from AudioMode. All chained segments are
         // included so passthrough spans the whole recording, not just file 1.
         let audio_source = match &self.audio {
-            AudioMode::CopyFrom(0) => Some(self.left.all_paths()),
-            AudioMode::CopyFrom(1) => match &self.right {
-                Some(right) => Some(right.all_paths()),
+            AudioMode::CopyFrom(n) => match self.inputs.get(*n) {
+                Some(input) => Some(input.all_paths()),
                 None => {
-                    log::warn!("AudioMode::CopyFrom(1) - a mono job has no right input");
+                    log::warn!(
+                        "AudioMode::CopyFrom({n}) - this job has {} input(s)",
+                        self.inputs.len()
+                    );
                     None
                 }
             },
-            AudioMode::CopyFrom(n) => {
-                log::warn!("AudioMode::CopyFrom({n}) - only 0 (left) and 1 (right) are valid");
-                None
-            }
             AudioMode::Disabled => None,
         };
 
@@ -1121,6 +1097,51 @@ impl StitchJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The arity check runs against the topology BEFORE any decoder or
+    /// GPU spins up: with nonexistent input paths, a wrong input count
+    /// must surface as the typed arity error, never as a file-open
+    /// error (which would prove a decoder was touched first).
+    #[test]
+    fn run_rejects_arity_mismatch_before_opening_inputs() {
+        let cam = || {
+            reco_core::calibration::Lens::fisheye(
+                640,
+                360,
+                320.0,
+                320.0,
+                320.0,
+                180.0,
+                [-0.02, 0.004, 0.0, 0.0],
+            )
+        };
+        let cal = reco_core::calibration::Calibration::new(
+            vec![cam(), cam()],
+            reco_core::projection::LShape {
+                intersect: 0.5,
+                x_ty: 0.0,
+                x_rz: 0.0,
+                z_rx: 0.0,
+                x_rx: 0.0,
+                z_rz: 0.0,
+                blend_width: 0.05,
+            },
+            reco_core::calibration::Framing {
+                axis_offset: 0.25,
+                tilt: 0.0,
+                roll: 0.0,
+            },
+        );
+        let job =
+            StitchJob::with_calibration(["does-not-exist.mp4"], cal, "arity-mismatch-out.mp4");
+        let interrupted = std::sync::atomic::AtomicBool::new(false);
+        let err = job.run(&interrupted).expect_err("1 input vs 2 cameras");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("consumes 2 camera input(s), but 1 were given"),
+            "expected the typed arity error, got: {msg}"
+        );
+    }
 
     #[test]
     fn all_paths_returns_every_chained_segment() {

--- a/crates/reco-io/src/v4l2.rs
+++ b/crates/reco-io/src/v4l2.rs
@@ -364,13 +364,17 @@ impl Drop for V4l2Camera {
 // and the File fd is Send.
 unsafe impl Send for V4l2Camera {}
 
+/// A left+right pair of raw Bayer frames, Arc-shared between the capture
+/// threads and the consumer (no per-frame allocation or copy).
+pub type BayerFramePair = (Arc<Vec<u8>>, Arc<Vec<u8>>);
+
 /// Stereo pair of V4L2 cameras for raw Bayer capture.
 ///
 /// Each camera runs in its own thread (parallel DQBUF, no phase-offset
 /// penalty). A pairing thread zips left+right into stereo pairs using
 /// Arc-shared buffers (no per-frame allocation or copy in the hot path).
 pub struct V4l2StereoCameraSource {
-    rx: std::sync::mpsc::Receiver<(Arc<Vec<u8>>, Arc<Vec<u8>>)>,
+    rx: std::sync::mpsc::Receiver<BayerFramePair>,
     info: reco_core::source::SourceInfo,
     stop: Arc<AtomicBool>,
 }
@@ -485,7 +489,7 @@ impl V4l2StereoCameraSource {
     ///
     /// Each Arc<Vec<u8>> is `width * height * 2` bytes of little-endian
     /// u16 (R16Uint). Arc-shared to avoid copying between threads.
-    pub fn next_pair(&mut self) -> io::Result<Option<(Arc<Vec<u8>>, Arc<Vec<u8>>)>> {
+    pub fn next_pair(&mut self) -> io::Result<Option<BayerFramePair>> {
         match self.rx.recv() {
             Ok(pair) => Ok(Some(pair)),
             Err(_) => Ok(None),

--- a/crates/reco-obs/README.md
+++ b/crates/reco-obs/README.md
@@ -4,7 +4,7 @@ OBS Studio source plugin. Embeds the reco stitching engine inside an OBS source 
 
 ## What it does
 
-- **Async-frame ingestion** — OBS delivers raw frames via `obs_source_get_frame`; reco-obs pushes them into `StitchCore::submit_frame_bgra` / `submit_frame_yuv`.
+- **Async-frame ingestion** — OBS delivers raw frames via `obs_source_get_frame`; reco-obs pushes them into `StitchCore::submit_frame_bgra_at_pose` / `submit_frame_yuv_at_pose`.
 - **Interactive pan/zoom** — mouse drag + wheel + keyboard translate to `ControlIntent`s → `PoseControl` → renderer.
 - **Live calibration** (M6 A14) — "Calibrate from current sources" action drives `reco_calibrate::calibrate_from_live` off the plugin's dual-source buffer.
 - **Replay recording** — opt-in stacked-video recording to disk (the M6.5 A18 push-API path), independent of OBS Record/Stream.

--- a/scripts/visualize_detections.py
+++ b/scripts/visualize_detections.py
@@ -113,12 +113,26 @@ def load_events(path):
     return frames, max_frame
 
 
+
+# The pipeline serializes `camera` as the camera index (0 = left,
+# 1 = right). Older JSONL files carried "Left"/"Right" strings; both
+# normalize to the index here so old captures stay readable.
+CAMERA_NAMES = {"left": 0, "right": 1}
+
+
+def det_camera(det):
+    cam = det.get("camera")
+    if isinstance(cam, int):
+        return cam
+    if isinstance(cam, str):
+        return CAMERA_NAMES.get(cam.lower(), -1)
+    return -1
+
 def draw_detections(img, detections, camera_filter, h, w):
     """Draw bounding boxes from DetectionsRaw. Returns detection count."""
     count = 0
     for det in detections:
-        cam = det.get("camera", "").lower()
-        if cam != camera_filter:
+        if det_camera(det) != camera_filter:
             continue
         cx, cy = det["camera_center"]
         sw, sh = det["camera_size"]
@@ -150,8 +164,7 @@ def draw_filter_removed(img, filter_events, camera_filter, h, w):
         removed = before_ids - after_ids
 
         for det in fev.get("before", []):
-            cam = det.get("camera", "").lower()
-            if cam != camera_filter:
+            if det_camera(det) != camera_filter:
                 continue
             key = (det["camera_center"][0], det["camera_center"][1])
             if key not in removed:
@@ -253,8 +266,7 @@ def draw_shared_overlay(img, frame_idx, frame_data, total_frames, fps):
 def draw_stale_detections(img, detections, camera_filter, h, w):
     """Draw last-known detections dimmed (for non-detection interval frames)."""
     for det in detections:
-        cam = det.get("camera", "").lower()
-        if cam != camera_filter:
+        if det_camera(det) != camera_filter:
             continue
         cx, cy = det["camera_center"]
         sw, sh = det["camera_size"]
@@ -287,10 +299,10 @@ def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
     panel_h = left.shape[0]
     fresh = len(frame_data["detections_raw"]) > 0
     if fresh:
-        draw_detections(left, frame_data["detections_raw"], "left", panel_h, panel_w)
+        draw_detections(left, frame_data["detections_raw"], 0, panel_h, panel_w)
     elif last_detections:
-        draw_stale_detections(left, last_detections, "left", panel_h, panel_w)
-    draw_filter_removed(left, frame_data["detection_filter"], "left", panel_h, panel_w)
+        draw_stale_detections(left, last_detections, 0, panel_h, panel_w)
+    draw_filter_removed(left, frame_data["detection_filter"], 0, panel_h, panel_w)
     draw_roi(left, roi_left, panel_h, panel_w)
     draw_camera_label(left, "L", panel_h, panel_w)
 
@@ -298,10 +310,10 @@ def annotate_frame(left_img, right_img, frame_idx, frame_data, last_detections,
         right = resize_keep_aspect(right_img, panel_w)
         rh = right.shape[0]
         if fresh:
-            draw_detections(right, frame_data["detections_raw"], "right", rh, panel_w)
+            draw_detections(right, frame_data["detections_raw"], 1, rh, panel_w)
         elif last_detections:
-            draw_stale_detections(right, last_detections, "right", rh, panel_w)
-        draw_filter_removed(right, frame_data["detection_filter"], "right", rh, panel_w)
+            draw_stale_detections(right, last_detections, 1, rh, panel_w)
+        draw_filter_removed(right, frame_data["detection_filter"], 1, rh, panel_w)
         draw_roi(right, roi_right, rh, panel_w)
         draw_camera_label(right, "R", rh, panel_w)
         combined = np.hstack([left, right]) if hstack else np.vstack([left, right])


### PR DESCRIPTION
## Description

Retires the `Option<right>` / `StereoFrame::Mono` hybrid. `FrameSet` replaces `StereoFrame`: CPU variants carry one payload per camera in projection order, platform zero-copy variants stay pinned to two cameras by type. One `StitchCore::submit_frame(&FrameSet)` replaces the yuv/nv12/mono submit trio; set length is validated against the projection's camera count at the stitch boundary.

`StitchJob` takes `inputs: Vec<InputPath>` through one constructor, with arity checked against the calibration topology before any decoder spins up. The CLI stitch subcommand is variadic (existing argv shapes unchanged). `FfmpegMonoSource` / `SourceMode::Mono` delete - mono decodes through the general N-input pipeline and gains rotation / full-range / 10-bit probing (it hardcoded all three before). `CameraId` becomes the `CameraIndex` alias into `calibration.lenses`; the events JSONL serializes `camera` as the integer index and `visualize_detections.py` reads both forms. `InputPath` owns segment parsing (fixes the stray-semicolon path bug). Consumer-less BGRA/YUV render paths are cut.

Also: `run_cpu` now applies the source's probed full range (never consumed on the CPU executor before); compile/clippy rot fixed in the v4l2 and non-desktop cfg arms that no CI lane builds.

The mono GPU arm keeps its typed not-wired error until the mono GPU pass lands; `preview` keeps two inputs until then.

## Checklist

- [x] I self-reviewed this change and it follows the project style guidelines
- [x] `cargo test --all` passes
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt --all -- --check` pass
- [x] I added or updated tests where it made sense