### PR TITLE
chore: un-red CI - ignore rustybuzz unmaintained advisory

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -157,9 +157,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # quick-xml DoS advisories: transitive via the Linux GUI stack
-          # (zbus_xml / wayland-scanner), local-input only. Justified in
+          # (zbus_xml / wayland-scanner), local-input only. rustybuzz:
+          # unmaintained, transitive via slint's text stack. Justified in
           # deny.toml; keep the two lists in sync.
-          ignore: RUSTSEC-2026-0194, RUSTSEC-2026-0195
+          ignore: RUSTSEC-2026-0194, RUSTSEC-2026-0195, RUSTSEC-2026-0206
 
   # ===========================================================================
   # msrv — the Rust toolchain we officially support.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -153,7 +153,15 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@stable
       - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+        env:
+          # rust-toolchain.toml pins the repo to the 1.92 MSRV, but the
+          # action cargo-installs cargo-audit with a fresh resolution whose
+          # deps outpace it (kstring 2.0.4 needs 1.96). The env override
+          # beats the file pin for this job only; the MSRV job still
+          # enforces 1.92 for the workspace itself.
+          RUSTUP_TOOLCHAIN: stable
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           # quick-xml DoS advisories: transitive via the Linux GUI stack

--- a/deny.toml
+++ b/deny.toml
@@ -47,6 +47,11 @@ ignore = [
     # move to quick-xml 0.41+. Mirror of the audit-job ignore in rust.yml.
     "RUSTSEC-2026-0194",
     "RUSTSEC-2026-0195",
+    # rustybuzz 0.20 - unmaintained (2026-07); maintainer points to
+    # harfrust. Transitive via slint's text stack (resvg -> usvg).
+    # Maintenance status only, not a vulnerability. Revisit when slint
+    # migrates. Mirror of the audit-job ignore in rust.yml.
+    "RUSTSEC-2026-0206",
 ]
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
cargo-deny and the Security Audit job fail on every PR since RUSTSEC-2026-0206 (rustybuzz unmaintained, transitive via slint's text stack: resvg -> usvg). No maintained drop-in until slint migrates to harfrust. Adds the ignore to both gates, mirroring the existing quick-xml/ttf-parser precedent. Verified locally: cargo deny check advisories passes.