### PR TITLE
fix(reco-calibrate): rand 0.10 renamed choose_multiple to sample

### DIFF
--- a/crates/reco-calibrate/src/ransac.rs
+++ b/crates/reco-calibrate/src/ransac.rs
@@ -55,7 +55,7 @@ pub fn ransac_fundamental(
 
     for _ in 0..max_iters {
         // Sample 8 random indices
-        let sample: Vec<usize> = indices.choose_multiple(&mut rng, 8).copied().collect();
+        let sample: Vec<usize> = indices.sample(&mut rng, 8).copied().collect();
 
         // Estimate F from the 8-point sample
         let f = match estimate_fundamental_8pt(pts1, pts2, &sample) {


### PR DESCRIPTION
The rand 0.10 bump (#414) deprecated IndexedRandom::choose_multiple (renamed to sample); clippy -D warnings turns that into an error, so dev's Check & Lint is red. One-line rename, clippy + tests pass on reco-calibrate.