### PR TITLE
fix(reco-gui): keep newest log lines in telemetry bug reports

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -442,13 +442,6 @@ fn build_bug_report(state: &AppState, app_weak: &slint::Weak<RecoApp>) -> String
         report.push_str(&format!("\n## Files\n- Calibration: {name}\n"));
     }
 
-    report.push_str(
-        "\n## Description\n\
-         <!-- What happened? What did you expect? -->\n\n\
-         ## Steps to reproduce\n\
-         <!-- 1. ... 2. ... 3. ... -->\n",
-    );
-
     if let Some(log_path) = log_file_path()
         && let Ok(contents) = std::fs::read_to_string(&log_path)
     {

--- a/crates/reco-gui/src/telemetry_client.rs
+++ b/crates/reco-gui/src/telemetry_client.rs
@@ -160,7 +160,7 @@ impl TelemetryClient {
         self.send(
             "bug_report",
             Some(serde_json::json!({
-                "report": &report[..report.len().min(1800)],
+                "report": fit_bug_report(report),
             })),
         );
     }
@@ -181,7 +181,7 @@ impl TelemetryClient {
             "export_error",
             Some(serde_json::json!({
                 "error_type": "export_failed",
-                "error_message": &error[..error.len().min(500)],
+                "error_message": truncate_at_char_boundary(error, 500),
                 "codec": codec,
             })),
         );
@@ -201,8 +201,143 @@ impl TelemetryClient {
         self.send(
             "calibration_error",
             Some(serde_json::json!({
-                "error_message": &error[..error.len().min(500)],
+                "error_message": truncate_at_char_boundary(error, 500),
             })),
         );
+    }
+}
+
+/// Raw-byte budget for a bug report. The ingestion server rejects events
+/// whose props exceed its size cap (128KB, measured after JSON re-encoding)
+/// rather than truncating them; escaping inflates a raw byte at most
+/// sixfold, so 16KB raw can never reach the cap. Covers the full 200-line
+/// log tail in the common case.
+const MAX_REPORT_BYTES: usize = 16 * 1024;
+
+/// Fit a bug report under [`MAX_REPORT_BYTES`], dropping the OLDEST log
+/// lines first: the head (user description, contact, environment) and the
+/// newest log lines carry the diagnosis. The head is only cut if it alone
+/// exceeds the budget.
+fn fit_bug_report(report: &str) -> String {
+    if report.len() <= MAX_REPORT_BYTES {
+        return report.to_string();
+    }
+    // The exact header `build_bug_report` appends: a header line, an
+    // opening fence, the log lines, a closing fence. Matching through
+    // "(last " keeps a user-typed "## Log" in the free-text description
+    // from being misread as the section start.
+    let Some((head, log_rest)) = report.split_once("\n## Log (last ") else {
+        return truncate_at_char_boundary(report, MAX_REPORT_BYTES).to_string();
+    };
+    let lines: Vec<&str> = log_rest.lines().collect();
+    // lines[0] is the header remainder and lines[1] the opening fence;
+    // both are re-created below, so keep only the log content (whose last
+    // line is the closing fence).
+    let content: &[&str] = if lines.len() > 2 { &lines[2..] } else { &[] };
+    // Budgeting with the largest possible marker text never undercounts.
+    let header = |dropped: usize| format!("\n## Log (oldest {dropped} lines dropped)\n```\n");
+    let overhead = head.len() + header(content.len()).len();
+    if overhead >= MAX_REPORT_BYTES {
+        return truncate_at_char_boundary(head, MAX_REPORT_BYTES).to_string();
+    }
+    let budget = MAX_REPORT_BYTES - overhead;
+    let mut keep = 0;
+    let mut used = 0;
+    for line in content.iter().rev() {
+        if used + line.len() + 1 > budget {
+            break;
+        }
+        used += line.len() + 1;
+        keep += 1;
+    }
+    let kept = &content[content.len() - keep..];
+    let mut s = String::with_capacity(overhead + used + 8);
+    s.push_str(head);
+    s.push_str(&header(content.len() - keep));
+    for l in kept {
+        s.push_str(l);
+        s.push('\n');
+    }
+    // A non-empty suffix always ends with the original closing fence;
+    // only the everything-dropped case needs one re-added.
+    if kept.is_empty() {
+        s.push_str("```\n");
+    }
+    s
+}
+
+/// Truncate to at most `max` bytes at a char boundary; a raw byte slice
+/// panics when `max` lands inside a multi-byte char.
+fn truncate_at_char_boundary(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut end = max;
+    while !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn small_report_is_unchanged() {
+        let report = "## User description\nit broke\n\n## Log (last 200 lines)\n```\nline\n```\n";
+        assert_eq!(fit_bug_report(report), report);
+    }
+
+    fn synthetic_report(n_lines: usize) -> String {
+        let mut r = String::from(
+            "## User description\ncrash on export\n\n## Contact\nuser@example.com\n\
+             \n## Environment\n- Reco v1.0\n- OS: linux x86_64\n",
+        );
+        r.push_str("\n## Log (last 200 lines)\n```\n");
+        for i in 0..n_lines {
+            r.push_str(&format!(
+                "[INFO] log line number {i} padded with enough detail to take up realistic space\n"
+            ));
+        }
+        r.push_str("```\n");
+        r
+    }
+
+    #[test]
+    fn oversized_report_keeps_head_and_newest_lines() {
+        let fitted = fit_bug_report(&synthetic_report(400));
+        assert!(fitted.len() <= MAX_REPORT_BYTES);
+        assert!(fitted.contains("## User description"));
+        assert!(fitted.contains("user@example.com"));
+        assert!(fitted.contains("log line number 399"));
+        assert!(!fitted.contains("log line number 0 "));
+        assert!(fitted.contains("lines dropped"));
+    }
+
+    #[test]
+    fn oversized_report_without_log_section_is_cut_at_cap() {
+        let fitted = fit_bug_report(&"x".repeat(20_000));
+        assert!(fitted.len() <= MAX_REPORT_BYTES);
+        assert!(fitted.starts_with("xxx"));
+    }
+
+    #[test]
+    fn oversized_head_is_cut_even_with_log_section() {
+        let report = format!(
+            "{}\n## Log (last 200 lines)\n```\nline\n```\n",
+            "y".repeat(20_000)
+        );
+        let fitted = fit_bug_report(&report);
+        assert!(fitted.len() <= MAX_REPORT_BYTES);
+        assert!(fitted.starts_with("yyy"));
+    }
+
+    #[test]
+    fn char_boundary_truncation_never_panics() {
+        // Multi-byte char straddling the cut: é is 2 bytes.
+        let s = "é".repeat(300);
+        assert_eq!(truncate_at_char_boundary(&s, 499).len(), 498);
+        assert_eq!(truncate_at_char_boundary("short", 500), "short");
     }
 }


### PR DESCRIPTION
Bug reports were cut to the first 1800 bytes, so the log tail (the failure moment) never arrived, and the byte slice could panic on a UTF-8 boundary. Reports now keep the head (user description, contact, environment) plus the newest log lines within a 16KB budget, oldest lines dropped first; unfilled issue-template boilerplate no longer ships.

Split out of #437 to keep that PR fps-only. Depends on the server-side event size cap raise being deployed first (server rejects oversized events rather than truncating); the cap change is committed in the telemetry repo and deploys before any release carrying this.