### PR TITLE
fix(reco-io): replay recording follows the source frame rate

### DIFF
--- a/crates/reco-cli/src/camera.rs
+++ b/crates/reco-cli/src/camera.rs
@@ -310,7 +310,7 @@ pub fn run_camera(
         // non-Jetson the same default applies per session discussion
         // (NVENC + NV12 pack shader combo deferred to #271).
         let encoder_config = reco_io::stacked_video::encoder::StackedEncoderConfig {
-            fps: (capture_fps as i32, 1),
+            fps: Some((capture_fps as i32, 1)),
             ..Default::default()
         };
         let recorder = reco_io::stacked_video::replay::session_gpu_recorder(

--- a/crates/reco-io/src/stacked_video/encoder.rs
+++ b/crates/reco-io/src/stacked_video/encoder.rs
@@ -43,8 +43,13 @@ pub struct StackedEncoderConfig {
     /// handles YUV420P-to-NV12 interleave automatically when
     /// a hardware encoder is selected.
     pub inner: EncoderConfig,
-    /// Output frames-per-second (numerator, denominator).
-    pub fps: (i32, i32),
+    /// Output frames-per-second (numerator, denominator). `None` means
+    /// "follow the source": [`crate::StitchJob`] resolves it from the
+    /// probed source rate before opening the encoder. A bare
+    /// [`StackedEncoder`] opened with `None` falls back to 30fps with a
+    /// warning - a 60fps session recorded at a 30fps time base plays
+    /// half-speed.
+    pub fps: Option<(i32, i32)>,
 }
 
 impl Default for StackedEncoderConfig {
@@ -82,7 +87,7 @@ impl Default for StackedEncoderConfig {
                 gop_size: Some(30),
                 stream_url: None,
             },
-            fps: (30, 1),
+            fps: None,
         }
     }
 }
@@ -108,7 +113,14 @@ impl StackedEncoder {
         output_path: &Path,
         config: StackedEncoderConfig,
     ) -> Result<Self, StackedEncodeError> {
-        let fps = ffmpeg_next::Rational(config.fps.0, config.fps.1);
+        let (fps_num, fps_den) = config.fps.unwrap_or_else(|| {
+            log::warn!(
+                "StackedEncoder opened without an fps; defaulting to 30fps - \
+                 pass the source rate via StackedEncoderConfig::fps"
+            );
+            (30, 1)
+        });
+        let fps = ffmpeg_next::Rational(fps_num, fps_den);
         let encoder = VideoEncoder::new(
             output_path,
             layout.packed_width(),

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -846,12 +846,20 @@ impl StitchJob {
         )?;
 
         #[cfg(feature = "stacked-output")]
-        if let Some(ref mut cfg) = self.replay_recording
-            && cfg.encoder_config.inner.encoder_name.is_none()
-        {
-            cfg.encoder_config.inner.encoder_name =
-                crate::ffmpeg::encoder::VideoEncoder::replay_encoder_name(&enc_name)
-                    .map(String::from);
+        if let Some(ref mut cfg) = self.replay_recording {
+            if cfg.encoder_config.inner.encoder_name.is_none() {
+                cfg.encoder_config.inner.encoder_name =
+                    crate::ffmpeg::encoder::VideoEncoder::replay_encoder_name(&enc_name)
+                        .map(String::from);
+            }
+            if cfg.encoder_config.fps.is_none() {
+                cfg.encoder_config.fps = Some(fps_rational);
+                log::info!(
+                    "replay recording follows the source rate {}/{}",
+                    fps_rational.0,
+                    fps_rational.1
+                );
+            }
         }
 
         // Resolve processing window (start_time / end_time / max_frames).


### PR DESCRIPTION
StackedEncoderConfig.fps hardcoded (30, 1) and StitchJob never overrode it, so a 60fps session's replay.mkv carried a 30fps time base and played half-speed. fps is now Option: None means the job resolves it from the probed source rate (same pattern as the replay encoder_name default); the camera path already passed its capture rate explicitly; a bare StackedEncoder without an fps warns and falls back to 30.

Verified by running: a replay-enabled stitch of a 29.97fps source now produces a replay.mkv probing 30000/1001 on both stream rates (previously 30/1), with the resolution logged. Closes #439.