### PR TITLE
fix: ort load-dynamic init deadlock; bundle ONNX Runtime with the Unix CLI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,19 @@ jobs:
       # ----------------------------------------------------------------
       # Build
       # ----------------------------------------------------------------
+      # dlopen("libonnxruntime.so"/".dylib") consults the executable's
+      # runpath, so $ORIGIN/@loader_path lets the bundled runtime resolve
+      # from the extracted tarball without ORT_DYLIB_PATH or a system
+      # install (#446).
+      - name: Set bundled-library rpath (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            echo 'RUSTFLAGS=-C link-arg=-Wl,-rpath,@loader_path' >> "$GITHUB_ENV"
+          else
+            echo 'RUSTFLAGS=-C link-arg=-Wl,-rpath,$ORIGIN' >> "$GITHUB_ENV"
+          fi
+
       - name: Build release binaries
         run: |
           cargo build --release --target ${{ matrix.target }} -p reco-cli --features load-dynamic
@@ -234,6 +247,15 @@ jobs:
           staging="reco-cli-${{ github.ref_name }}-${{ matrix.name }}"
           mkdir "$staging"
           cp "target/${{ matrix.target }}/release/${{ matrix.binary }}" "$staging/"
+          # Bundle ONNX Runtime under the exact name ort dlopens; a
+          # missing runtime used to hang --model runs outright (#446).
+          if [ -n "$ORT_LIB" ] && [ -f "$ORT_LIB" ]; then
+            if [ "$RUNNER_OS" = "macOS" ]; then
+              cp "$ORT_LIB" "$staging/libonnxruntime.dylib"
+            else
+              cp "$ORT_LIB" "$staging/libonnxruntime.so"
+            fi
+          fi
           cp LICENSE "$staging/"
           tar czf "$staging.tar.gz" "$staging"
 
@@ -245,9 +267,14 @@ jobs:
             staging="reco-gui-${{ github.ref_name }}-${{ matrix.name }}"
             mkdir "$staging"
             cp "$gui_bin" "$staging/"
-            # Bundle ONNX Runtime for AI detection
+            # Bundle ONNX Runtime under the exact name ort dlopens - the
+            # versioned filename it previously kept was never found (#446).
             if [ -n "$ORT_LIB" ] && [ -f "$ORT_LIB" ]; then
-              cp "$ORT_LIB" "$staging/"
+              if [ "$RUNNER_OS" = "macOS" ]; then
+                cp "$ORT_LIB" "$staging/libonnxruntime.dylib"
+              else
+                cp "$ORT_LIB" "$staging/libonnxruntime.so"
+              fi
             fi
             cp LICENSE "$staging/"
             tar czf "$staging.tar.gz" "$staging"

--- a/crates/reco-detect/Cargo.toml
+++ b/crates/reco-detect/Cargo.toml
@@ -15,7 +15,7 @@ ort = ["dep:ort", "dep:dirs"]
 cuda = ["ort", "ort/cuda"]
 tensorrt = ["ort", "ort/tensorrt"]
 coreml = ["ort", "ort/coreml"]
-load-dynamic = ["ort", "ort/load-dynamic"]
+load-dynamic = ["ort", "ort/load-dynamic", "dep:libloading"]
 tensorrt-native = []
 ncnn = []
 profiling = ["reco-core/profiling", "dep:tracing"]
@@ -24,6 +24,7 @@ profiling = ["reco-core/profiling", "dep:tracing"]
 reco-core = { path = "../reco-core" }
 ort = { version = "2.0.0-rc.12", optional = true }
 dirs = { version = "6", optional = true }
+libloading = { version = "0.9", optional = true }
 wgpu = "28"
 bytemuck = { version = "1", features = ["derive"] }
 log = "0.4"

--- a/crates/reco-detect/src/detectors/cpu.rs
+++ b/crates/reco-detect/src/detectors/cpu.rs
@@ -51,7 +51,7 @@ impl CpuYoloDetector {
     ///
     /// Class labels are auto-detected from the ONNX model's `names` metadata
     /// (standard for Ultralytics exports). Falls back to `["ball"]` if not found.
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, ort::Error> {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, crate::ort_session::SessionError> {
         Self::with_config(path, 0.10, Vec::new())
     }
 
@@ -63,7 +63,7 @@ impl CpuYoloDetector {
         path: impl AsRef<Path>,
         confidence_threshold: f32,
         labels: Vec<String>,
-    ) -> Result<Self, ort::Error> {
+    ) -> Result<Self, crate::ort_session::SessionError> {
         let (session, input_size, labels) =
             crate::ort_session::create_ort_session(path.as_ref(), labels)?;
 

--- a/crates/reco-detect/src/lib.rs
+++ b/crates/reco-detect/src/lib.rs
@@ -61,10 +61,10 @@ pub use detectors::trt::TrtGpuDetector;
 // Re-export shared utilities.
 pub use detectors::postprocess;
 pub use detectors::read_labels_file;
-#[cfg(feature = "ort")]
-pub use ort_session::create_ort_session;
 #[cfg(any(feature = "tensorrt", feature = "coreml"))]
 pub use ort_session::reco_cache_dir;
+#[cfg(feature = "ort")]
+pub use ort_session::{SessionError, create_ort_session};
 #[cfg(feature = "ort")]
 pub use probe::{AiProbeResult, probe_execution_providers};
 

--- a/crates/reco-detect/src/ort_session.rs
+++ b/crates/reco-detect/src/ort_session.rs
@@ -12,6 +12,131 @@ use ort::session::Session;
 
 use crate::detectors::cpu::parse_onnx_names;
 
+/// Errors from ORT session creation.
+///
+/// `RuntimeUnavailable` deliberately carries a plain `String`: with
+/// load-dynamic and no loadable runtime, constructing any `ort::Error`
+/// calls `CreateStatus` through `api()` and self-deadlocks in ort's init
+/// (#446), so no `ort::Error` may exist for this case.
+#[derive(Debug, thiserror::Error)]
+pub enum SessionError {
+    #[error("{0}")]
+    RuntimeUnavailable(String),
+    #[error(transparent)]
+    Ort(#[from] ort::Error),
+}
+
+/// One-shot verdict on whether the ONNX Runtime library can be loaded.
+///
+/// With load-dynamic, ort's first API call dlopens the runtime; when the
+/// load fails, ort builds the error through `Error::new`, which calls
+/// back into `api()` and re-enters the once-lock whose initializer is
+/// still on this thread's stack - a self-deadlock, not an error (#446).
+/// ort's failing init path must therefore never execute: the dylib is
+/// probed with our own dlopen first, and ort is only entered once the
+/// probe proves the load cannot fail.
+static ORT_RUNTIME: std::sync::OnceLock<Result<(), String>> = std::sync::OnceLock::new();
+
+/// `Ok` when the ONNX Runtime library loaded; `Err` with the reason otherwise.
+pub fn ort_runtime_available() -> Result<(), String> {
+    ORT_RUNTIME
+        .get_or_init(|| {
+            probe_ort_dylib()?;
+            // The probe proved the dylib loads and is API-compatible, so
+            // ort's init cannot reach the deadlocking error path.
+            // catch_unwind stays as a backstop for exotic init panics.
+            match std::panic::catch_unwind(Session::builder) {
+                Ok(Ok(_)) => Ok(()),
+                Ok(Err(e)) => Err(format!("ONNX Runtime init failed: {e}")),
+                Err(_) => Err("ONNX Runtime initialization panicked".to_string()),
+            }
+        })
+        .clone()
+}
+
+/// Verify the ONNX Runtime dynamic library loads and is API-compatible
+/// without going through ort (see [`ort_runtime_available`]). Mirrors
+/// ort's resolution order: `ORT_DYLIB_PATH`, else the platform soname
+/// next to the executable, else the plain soname via the system search
+/// path.
+#[cfg(feature = "load-dynamic")]
+fn probe_ort_dylib() -> Result<(), String> {
+    use std::ffi::{CStr, c_char, c_void};
+
+    #[cfg(target_os = "windows")]
+    const SONAME: &str = "onnxruntime.dll";
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    const SONAME: &str = "libonnxruntime.so";
+    #[cfg(any(target_os = "macos", target_os = "ios"))]
+    const SONAME: &str = "libonnxruntime.dylib";
+
+    // Field order mirrors OrtApiBase in onnxruntime_c_api.h.
+    #[repr(C)]
+    struct OrtApiBase {
+        get_api: unsafe extern "system" fn(u32) -> *const c_void,
+        get_version_string: unsafe extern "system" fn() -> *const c_char,
+    }
+
+    let name = match std::env::var("ORT_DYLIB_PATH") {
+        Ok(s) if !s.is_empty() => std::path::PathBuf::from(s),
+        _ => std::path::PathBuf::from(SONAME),
+    };
+    let path = if name.is_absolute() {
+        name
+    } else {
+        match std::env::current_exe()
+            .ok()
+            .and_then(|e| e.parent().map(|d| d.join(&name)))
+        {
+            Some(p) if p.exists() => p,
+            _ => name,
+        }
+    };
+
+    let lib = unsafe { libloading::Library::new(&path) }.map_err(|e| {
+        format!(
+            "ONNX Runtime library not found (`{}`: {e}). Install onnxruntime or \
+             place the library next to the executable.",
+            path.display()
+        )
+    })?;
+    let version = unsafe {
+        let base_getter: libloading::Symbol<unsafe extern "system" fn() -> *const OrtApiBase> = lib
+            .get(b"OrtGetApiBase")
+            .map_err(|e| format!("`{}` is not an ONNX Runtime library: {e}", path.display()))?;
+        let base = base_getter();
+        if base.is_null() {
+            return Err(format!("`{}`: OrtGetApiBase returned null", path.display()));
+        }
+        CStr::from_ptr(((*base).get_version_string)())
+            .to_string_lossy()
+            .into_owned()
+    };
+    let minor = version
+        .split('.')
+        .nth(1)
+        .and_then(|m| m.parse::<u32>().ok())
+        .unwrap_or(0);
+    if minor < ort::MINOR_VERSION {
+        return Err(format!(
+            "ONNX Runtime at `{}` is version {version}; ort needs >= 1.{}",
+            path.display(),
+            ort::MINOR_VERSION
+        ));
+    }
+    // Keep the mapping alive: ort dlopens the same file next (refcounted),
+    // and the probe's compatibility verdict must keep holding.
+    std::mem::forget(lib);
+    log::info!("ONNX Runtime {version} found at {}", path.display());
+    Ok(())
+}
+
+/// Statically linked ort cannot fail to load.
+#[cfg(not(feature = "load-dynamic"))]
+fn probe_ort_dylib() -> Result<(), String> {
+    Ok(())
+}
+
 /// Return a persistent cache directory for model engine/compilation caches.
 ///
 /// Resolves to `{platform_cache_dir}/reco/{subdir}`:
@@ -61,20 +186,19 @@ pub fn reco_cache_dir(subdir: &str) -> PathBuf {
 pub fn create_ort_session(
     model_path: &Path,
     fallback_labels: Vec<String>,
-) -> Result<(Session, u32, Vec<String>), ort::Error> {
-    // With load-dynamic, Session::builder() panics if the ORT library
-    // isn't installed. Catch the panic and convert to an error.
-    #[allow(unused_mut)]
-    let mut builder = match std::panic::catch_unwind(Session::builder) {
-        Ok(r) => r?,
-        Err(_) => {
-            return Err(ort::Error::wrap(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                "ONNX Runtime library not found. Install onnxruntime or place the DLL next to the executable.",
-            )));
-        }
+) -> Result<(Session, u32, Vec<String>), SessionError> {
+    // Session::builder() must not run when the runtime cannot load: ort's
+    // failing init self-deadlocks building its own error (#446), so the
+    // gate's cached verdict is the only safe way to learn availability.
+    // The same applies to constructing ANY ort::Error (its constructor
+    // calls CreateStatus through api()), hence SessionError.
+    if let Err(reason) = ort_runtime_available() {
+        return Err(SessionError::RuntimeUnavailable(reason));
     }
-    .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)?;
+    #[allow(unused_mut)]
+    let mut builder = Session::builder()?
+        .with_optimization_level(ort::session::builder::GraphOptimizationLevel::Level3)
+        .map_err(ort::Error::from)?;
 
     // Try TensorRT EP first (JIT-compiles for any GPU arch including Blackwell),
     // then CUDA EP, then fall back to CPU.
@@ -199,5 +323,15 @@ mod tests {
             result.is_err(),
             "loading a nonexistent model should return an error"
         );
+    }
+
+    #[test]
+    fn ort_gate_returns_same_verdict_on_repeat_calls() {
+        // The second call must return (not deadlock) and agree with the
+        // first - the load-dynamic missing-library case wedges ort's
+        // once-lock if Session::builder is entered twice (#446).
+        let first = ort_runtime_available();
+        let second = ort_runtime_available();
+        assert_eq!(first.is_ok(), second.is_ok());
     }
 }

--- a/crates/reco-detect/src/probe.rs
+++ b/crates/reco-detect/src/probe.rs
@@ -12,6 +12,8 @@
 
 use ort::session::Session;
 
+use crate::ort_session::ort_runtime_available;
+
 /// Result of probing available ONNX Runtime execution providers.
 ///
 /// Returned by [`probe_execution_providers`]. The GUI displays this
@@ -58,16 +60,19 @@ pub fn probe_execution_providers() -> AiProbeResult {
     let mut can_run_on_gpu_frames = false;
 
     // Test ORT itself loads. With load-dynamic, the library may not be
-    // installed. The ort crate panics with .expect() if the DLL/so isn't
-    // found, so we catch the panic here.
-    let builder = match std::panic::catch_unwind(Session::builder) {
-        Ok(Ok(b)) => Some(b),
-        Ok(Err(e)) => {
-            errors.push(format!("ORT init: {e}"));
-            None
-        }
-        Err(_) => {
-            errors.push("ONNX Runtime library not found. AI detection is unavailable.".to_string());
+    // installed; entering ort with an unloadable dylib self-deadlocks in
+    // its init (#446), so availability comes only from the gate's cached
+    // out-of-band probe.
+    let builder = match ort_runtime_available() {
+        Ok(()) => match Session::builder() {
+            Ok(b) => Some(b),
+            Err(e) => {
+                errors.push(format!("ORT init: {e}"));
+                None
+            }
+        },
+        Err(reason) => {
+            errors.push(reason);
             None
         }
     };


### PR DESCRIPTION
With `load-dynamic` and no loadable ONNX Runtime, the first `Session::builder()` self-deadlocks: `setup_api`'s dlopen failure constructs its error through `Error::new`, which calls back into `api()` and re-enters the once-lock whose initializer is still on the stack. Any `--model` run then hangs forever instead of reporting the missing library.

- reco-detect: probe the dylib with our own dlopen before ort is ever entered (same resolution order: `ORT_DYLIB_PATH`, exe-adjacent soname, system search) plus an `OrtGetApiBase` version check; the verdict is cached process-wide. New `SessionError::RuntimeUnavailable` since constructing any `ort::Error` pre-load takes the same deadlocking path.
- release workflow: bundle the downloaded ONNX Runtime with the Unix CLI package under the exact soname dlopen expects (the GUI bundle previously kept the versioned filename, which dlopen never matches), and link with `$ORIGIN`/`@loader_path` rpath so the bundled library resolves for both binaries.

Fixes the hang half of #446. Verified: missing runtime -> clean warning, export completes; runtime next to the binary -> detection loads and tracking enables.