### PR TITLE
fix(reco-gui): loading from recent files never set the video inputs

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -1934,6 +1934,10 @@ fn main() -> anyhow::Result<()> {
         if let Some(app) = app_weak.upgrade() {
             sync_recent_paths(&s.user_settings, &app);
         }
+        // try_init and the segment list read left_input, not left_path -
+        // without it a recent pick never loads and the UI keeps saying
+        // "No video selected" (#328).
+        s.left_input = Some(reco_io::stitch_job::InputPath::Single(path.clone()));
         s.left_path = Some(path);
         drop(s);
         try_init_and_update(&state_ref, &app_weak);
@@ -1959,6 +1963,7 @@ fn main() -> anyhow::Result<()> {
         if let Some(app) = app_weak.upgrade() {
             sync_recent_paths(&s.user_settings, &app);
         }
+        s.right_input = Some(reco_io::stitch_job::InputPath::Single(path.clone()));
         s.right_path = Some(path);
         drop(s);
         try_init_and_update(&state_ref, &app_weak);


### PR DESCRIPTION
The recent-files handlers set `left_path`/`right_path` but not `left_input`/`right_input`, which `try_init` and the segment list read - a recent pick never loaded and the file bar kept showing "No video selected".

Fixes #328.