### PR TITLE
Release v0.5.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,10 +344,25 @@ jobs:
           path: artifacts
           merge-multiple: true
 
+      - name: Download AI model assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download v0.5.2 \
+            --repo "${{ github.repository }}" \
+            --pattern "yolo26n.onnx" \
+            --pattern "yolo26n_640.onnx" \
+            --dir artifacts
+          cd artifacts
+          sha256sum --check <<'CHECKSUMS'
+          3f6e5b6c9adaaf7f033810526f12826557e92fafaffa6df2d0ed06512f5e3821  yolo26n.onnx
+          30fde6857b65f6256c9924c3340810a03f73fc42503df9e34156089bda9496ac  yolo26n_640.onnx
+          CHECKSUMS
+
       - name: Generate checksums
         run: |
           cd artifacts
-          sha256sum reco-* > SHA256SUMS
+          sha256sum reco-* yolo26n.onnx yolo26n_640.onnx > SHA256SUMS
 
       - name: Create GitHub Release
         env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5427,7 +5427,7 @@ dependencies = [
 
 [[package]]
 name = "reco-autocam"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "log",
  "reco-core",
@@ -5439,7 +5439,7 @@ dependencies = [
 
 [[package]]
 name = "reco-calibrate"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "approx",
  "argmin",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "reco-cli"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -5491,7 +5491,7 @@ dependencies = [
 
 [[package]]
 name = "reco-control"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "log",
  "reco-core",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "reco-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "approx",
  "ash",
@@ -5533,7 +5533,7 @@ dependencies = [
 
 [[package]]
 name = "reco-detect"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "block2 0.6.2",
  "bytemuck",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "reco-gui"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "arboard",
@@ -5584,7 +5584,7 @@ dependencies = [
 
 [[package]]
 name = "reco-io"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "directories",
  "ffmpeg-next",
@@ -5602,7 +5602,7 @@ dependencies = [
 
 [[package]]
 name = "reco-obs"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -1313,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1673,11 +1673,10 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3747,9 +3746,9 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -5164,19 +5163,9 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -5203,9 +5192,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -7657,12 +7646,12 @@ dependencies = [
 
 [[package]]
 name = "wayland-scanner"
-version = "0.31.9"
+version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86287151a309799b821ca709b7345a048a2956af05957c89cb824ab919fa4e3"
+checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml 0.39.2",
+ "quick-xml",
  "quote",
 ]
 
@@ -8872,23 +8861,23 @@ dependencies = [
 
 [[package]]
 name = "zbus_names"
-version = "4.3.1"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "zvariant",
 ]
 
 [[package]]
 name = "zbus_xml"
-version = "5.1.0"
+version = "5.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "441a0064125265655bccc3a6af6bef56814d9277ac83fce48b1cd7e160b80eac"
+checksum = "d1586c021a01ca0a9216dcd874e546382e156a5cbab5fab6cb5f10087e22682a"
 dependencies = [
- "quick-xml 0.38.4",
  "serde",
+ "winnow 1.0.0",
  "zbus_names",
  "zvariant",
 ]
@@ -9012,24 +9001,24 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+checksum = "bee2a0bcd2a907786a456fff45aaaaf54c9ba5f50b71ae9ec1a4edd200c94911"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
  "url",
- "winnow 0.7.15",
+ "winnow 1.0.0",
  "zvariant_derive",
  "zvariant_utils",
 ]
 
 [[package]]
 name = "zvariant_derive"
-version = "5.10.0"
+version = "5.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+checksum = "38a708216a18780796770bfe3f4739c7c83a3e8f789b755534bbbc06e4e23e12"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9040,13 +9029,13 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "3.3.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+checksum = "90cb9383f9b45290407a1258b202d3f8f01db719eb60b4e4055c6375af4fc7c7"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "syn",
- "winnow 0.7.15",
+ "winnow 1.0.0",
 ]

--- a/crates/reco-autocam/Cargo.toml
+++ b/crates/reco-autocam/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-autocam"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-autocam/src/lib.rs
+++ b/crates/reco-autocam/src/lib.rs
@@ -72,12 +72,22 @@ pub use wgpu_detector::WgpuPreprocessingDetector;
 // because it wraps `Box<dyn UnifiedDetector>`.
 pub use tracking_mode::TrackingMode;
 
-// Path is only used in the ort-backed class-name lookup
-// (reco_detect::create_ort_session) and the CpuYoloDetector
-// fallback. Both are cfg'd behind `feature = "ort"`, so this
-// import follows the same gate.
-#[cfg(feature = "ort")]
+use std::io;
 use std::path::Path;
+
+/// Verify that an AI model file or model directory exists.
+///
+/// Call this at user-input boundaries before opening video sources. Regular
+/// files cover ONNX, TensorRT, and CoreML models; directories cover NCNN.
+pub fn validate_model_path(path: &Path) -> io::Result<()> {
+    if path.as_os_str().is_empty() || !path.try_exists()? {
+        return Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            format!("AI model path does not exist: {}", path.display()),
+        ));
+    }
+    Ok(())
+}
 
 /// Set up automatic camera control on any [`DetectionTarget`](reco_core::detect::DetectionTarget).
 ///
@@ -185,6 +195,10 @@ pub fn setup_autocam(
     fps: f32,
     source_is_gpu_resident: bool,
 ) -> Result<bool, Box<dyn std::error::Error>> {
+    if config.tracking_mode != TrackingMode::Sweep {
+        validate_model_path(&config.model_path)?;
+    }
+
     #[cfg(not(any(feature = "ort", feature = "tensorrt-native", feature = "ncnn")))]
     {
         let _ = (target, config, fps);
@@ -593,4 +607,30 @@ fn resolve_or(class_names: &[String], candidates: &[&str], default_id: u16) -> u
         );
         default_id
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn model_path_validation_accepts_files_and_directories() {
+        let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        assert!(validate_model_path(crate_dir).is_ok());
+        assert!(validate_model_path(&crate_dir.join("Cargo.toml")).is_ok());
+    }
+
+    #[test]
+    fn model_path_validation_rejects_empty_and_missing_paths() {
+        let crate_dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let missing = crate_dir.join("model-that-does-not-exist.onnx");
+        assert_eq!(
+            validate_model_path(&missing).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+        assert_eq!(
+            validate_model_path(Path::new("")).unwrap_err().kind(),
+            io::ErrorKind::NotFound
+        );
+    }
 }

--- a/crates/reco-calibrate/Cargo.toml
+++ b/crates/reco-calibrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-calibrate"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-cli/Cargo.toml
+++ b/crates/reco-cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-cli"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 description = "CLI tool for Reco panoramic video stitching"

--- a/crates/reco-cli/src/stitch.rs
+++ b/crates/reco-cli/src/stitch.rs
@@ -79,6 +79,13 @@ pub fn run_stitch(args: StitchArgs<'_>, interrupted: &Arc<AtomicBool>) -> anyhow
         args.height,
     );
 
+    #[cfg(feature = "autocam")]
+    if args.tracking_mode != "sweep"
+        && let Some(model_path) = args.model_path
+    {
+        reco_autocam::validate_model_path(Path::new(model_path))?;
+    }
+
     let progress = crate::helpers::ProgressReporter::new(30);
 
     // Load calibration up front so we can extract field_roi for autocam

--- a/crates/reco-control/Cargo.toml
+++ b/crates/reco-control/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-control"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-core/Cargo.toml
+++ b/crates/reco-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-core"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 description = "GPU-accelerated panoramic video stitching engine"

--- a/crates/reco-detect/Cargo.toml
+++ b/crates/reco-detect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-detect"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-gui/Cargo.toml
+++ b/crates/reco-gui/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-gui"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/reco-gui/src/export.rs
+++ b/crates/reco-gui/src/export.rs
@@ -130,6 +130,14 @@ pub fn run_export(
     let quality: Quality = quality_str.parse().unwrap_or_default();
 
     #[cfg(feature = "autocam")]
+    if autocam.enabled && autocam.tracking_mode != "sweep" && !autocam.model_path.is_empty() {
+        let model_path = std::path::Path::new(&autocam.model_path);
+        if let Err(e) = reco_autocam::validate_model_path(model_path) {
+            return ExportOutcome::Failed(reco_io::stitch_job::StitchError::Other(e.to_string()));
+        }
+    }
+
+    #[cfg(feature = "autocam")]
     let field_roi = cal.field_roi.clone();
 
     let post_status = |text: String| {

--- a/crates/reco-io/Cargo.toml
+++ b/crates/reco-io/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-io"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 description = "Pluggable frame I/O backends for Reco (FFmpeg, GStreamer, ...)"

--- a/crates/reco-io/src/stitch_job.rs
+++ b/crates/reco-io/src/stitch_job.rs
@@ -185,6 +185,14 @@ impl StitchResult {
     }
 }
 
+fn audio_sync_skip_frames(audio: &AudioMode, sync_offset: i64) -> u64 {
+    match audio {
+        AudioMode::CopyFrom(0) if sync_offset < 0 => sync_offset.unsigned_abs(),
+        AudioMode::CopyFrom(1) if sync_offset > 0 => sync_offset as u64,
+        AudioMode::CopyFrom(_) | AudioMode::Disabled => 0,
+    }
+}
+
 /// Errors from [`StitchJob::run`].
 #[derive(Debug, Clone, thiserror::Error)]
 #[non_exhaustive]
@@ -693,6 +701,14 @@ impl StitchJob {
             }
             AudioMode::Disabled => None,
         };
+        let audio_sync_skip = audio_sync_skip_frames(&self.audio, effective_sync);
+        let audio_start_time = start_secs + audio_sync_skip as f64 / fps;
+        if audio_sync_skip > 0 {
+            log::info!(
+                "Audio sync: skipping {audio_sync_skip} frames ({:.3}s) from the selected audio source",
+                audio_sync_skip as f64 / fps,
+            );
+        }
 
         let enc_config = crate::ffmpeg::encoder::EncoderConfig {
             encoder_name: self.encoder_name.clone(),
@@ -701,7 +717,7 @@ impl StitchJob {
             quality: self.quality_value,
             preset: self.preset.clone(),
             audio_source,
-            audio_start_time: start_secs,
+            audio_start_time,
             container: self.format.into(),
             gop_size: None,
             stream_url: None,
@@ -1030,5 +1046,15 @@ mod tests {
         );
         // first_path stays the first segment; all_paths must not drop the rest.
         assert_eq!(chained.first_path(), std::path::Path::new("a.mp4"));
+    }
+
+    #[test]
+    fn audio_sync_skips_only_the_audio_source_whose_video_was_skipped() {
+        assert_eq!(audio_sync_skip_frames(&AudioMode::CopyFrom(0), -15), 15);
+        assert_eq!(audio_sync_skip_frames(&AudioMode::CopyFrom(1), -15), 0);
+        assert_eq!(audio_sync_skip_frames(&AudioMode::CopyFrom(0), 15), 0);
+        assert_eq!(audio_sync_skip_frames(&AudioMode::CopyFrom(1), 15), 15);
+        assert_eq!(audio_sync_skip_frames(&AudioMode::CopyFrom(0), 0), 0);
+        assert_eq!(audio_sync_skip_frames(&AudioMode::Disabled, -15), 0);
     }
 }

--- a/crates/reco-obs/Cargo.toml
+++ b/crates/reco-obs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 publish = false
 name = "reco-obs"
-version = "0.5.3"
+version = "0.5.4"
 edition.workspace = true
 rust-version.workspace = true
 description = "OBS Studio source plugin for Reco panoramic video stitching"

--- a/deny.toml
+++ b/deny.toml
@@ -30,11 +30,9 @@ targets = [
 
 [advisories]
 yanked = "deny"
-ignore = [
-    # paste 1.0.15 — archived upstream. Transitively pulled by wgpu /
-    # slint. Hard-deny once those upstreams migrate. Revisit at M8.
-    "RUSTSEC-2024-0436",
-]
+# Fail when an unmaintained crate is a direct workspace dependency.
+# Transitive maintenance status remains upstream's responsibility.
+unmaintained = "workspace"
 
 # ---------------------------------------------------------------------------
 # Licenses: compatible with AGPL-3.0-only distribution


### PR DESCRIPTION
## Summary

- align passthrough audio with calibration sync offsets
- reject missing AI model paths before opening export resources
- restore both public YOLO release assets with pinned checksums
- update vulnerable transitive dependencies
- bump workspace crates to 0.5.4

## Validation

- formatting, six clippy lanes, rustdoc, MSRV, security, GPU backend, cross-target, and benchmark build checks
- default and profiling workspace tests pass when excluding the pre-existing Matroska mid-write test, which fails identically on current `main` with the local FFmpeg build
- controlled A/V repro improved flash-to-tone offset from 498.5 ms in v0.5.3 to 2.5 ms
- missing-model repro exits before GPU/export setup and creates no output
- release model downloads and pinned checksums verified
