### PR TITLE
fix(reco-detect): don't queue DirectML alongside TensorRT/CUDA in the same ORT session

### DIFF
--- a/crates/reco-detect/src/ort_session.rs
+++ b/crates/reco-detect/src/ort_session.rs
@@ -264,7 +264,25 @@ pub fn create_ort_session(
     };
 
     // DirectML EP for Windows (AMD/Intel/NVIDIA via DX12).
-    #[cfg(target_os = "windows")]
+    //
+    // Mutually exclusive with TensorRT/CUDA in the same session: ORT
+    // rejects the combination outright at `commit_from_file` time with
+    // "DML EP can only be used with CPU EPs" - a declarative check on the
+    // registered provider *list*, independent of whether TensorRT/CUDA
+    // actually loads on this machine. Reproduced 2026-08-13 the first
+    // time a Windows build ever compiled `tensorrt` + the (unconditional
+    // on Windows) `directml` dependency together - both got queued onto
+    // the same builder below and every export crashed with "AI tracking
+    // failed: DML EP can only be used with CPU EPs", frozen preview and
+    // all. Gating this block out whenever `tensorrt`/`cuda` are compiled
+    // in restores the working single-GPU-EP-plus-CPU-fallback chain in
+    // both cases: TensorRT/CUDA alone (with implicit CPU fallback if
+    // unavailable) when either is compiled in, DirectML alone otherwise -
+    // never queue two mutually-exclusive GPU EPs onto one builder.
+    #[cfg(all(
+        target_os = "windows",
+        not(any(feature = "tensorrt", feature = "cuda"))
+    ))]
     let mut builder = {
         match builder.with_execution_providers([ort::ep::DirectML::default().build()]) {
             Ok(b) => {


### PR DESCRIPTION
## Problem

On Windows, `reco-gui`/`reco-cli`'s `Cargo.toml` unconditionally forces the `directml` feature regardless of what other backend features are requested (see `reco-gui/Cargo.toml`'s `[target.'cfg(windows)'.dependencies]` block). `create_ort_session` (`crates/reco-detect/src/ort_session.rs`) chains `with_execution_providers()` calls onto a single session builder - TensorRT (when the `tensorrt` feature is compiled in), then unconditionally also DirectML on Windows.

ONNX Runtime rejects DirectML combined with any other non-CPU execution provider in the same session's provider list - a hard, declarative check at `commit_from_file` time, independent of whether TensorRT actually loads on the machine. Building with `--features tensorrt` on Windows therefore crashes every AI-tracking export with:

```
AI tracking failed: DML EP can only be used with CPU EPs
```

The export continues but the preview freezes and tracking stops entirely - no detections, no panning.

## Fix

Gate the DirectML registration block with `not(any(feature = "tensorrt", feature = "cuda"))` in addition to the existing `target_os = "windows"` check, so the two mutually-exclusive GPU EPs are never queued onto the same builder. TensorRT/CUDA alone (with ORT's normal implicit CPU fallback if unavailable at runtime) when either is compiled in; DirectML alone otherwise.

## Verification

Reproduced by building `reco-cli` with `--features tensorrt,directml` (the exact combination `reco-gui` forces on Windows) - crashed before this fix with the exact error above, runs cleanly after it with TensorRT active end-to-end on a real export (899-frame stitch, AI tracking, TensorRT confirmed via `ORT: TensorRT execution provider enabled` + successful completion). Confirmed the default (DirectML-only) and tensorrt-only-without-directml builds are unaffected. `cargo test -p reco-detect` green, `cargo fmt --check`/`cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)