### PR TITLE
Show update-available as a toolbar button instead of auto-opening a browser

### DIFF
--- a/crates/reco-gui/src/main.rs
+++ b/crates/reco-gui/src/main.rs
@@ -2447,6 +2447,19 @@ fn main() -> anyhow::Result<()> {
         let _ = open::that("https://forum.reco-project.org/");
     });
 
+    // User-initiated now (toolbar button, see `update-available` in
+    // main.slint) rather than an automatic browser-open the moment the
+    // background version check finds a newer release.
+    let app_weak = app.as_weak();
+    app.on_open_update_page(move || {
+        let Some(app) = app_weak.upgrade() else {
+            return;
+        };
+        let tag = app.get_update_tag();
+        let url = format!("https://github.com/reco-project/video-stitcher/releases/tag/{tag}");
+        let _ = open::that(&url);
+    });
+
     let app_weak = app.as_weak();
     app.on_pick_prefs_model(move || {
         let dialog = rfd::FileDialog::new()
@@ -3693,22 +3706,24 @@ fn main() -> anyhow::Result<()> {
             let mut s = state_ref.borrow_mut();
 
             // Check for update notification from the background thread.
+            // Surfaced as a toolbar button (`update-available`/`update-tag`)
+            // the user can click when they're ready, not an unasked
+            // browser tab - see `open-update-page`'s handler below for
+            // where the actual `open::that` call now lives.
             if let Ok(mut guard) = update_check.try_lock()
                 && let Some(tag) = guard.take()
                 && let Some(app) = app_weak.upgrade()
             {
-                        let url = format!(
-                            "https://github.com/reco-project/video-stitcher/releases/tag/{tag}"
-                        );
                         s.toasts.push_with_ttl(
                             Severity::Info,
                             format!("Update available: {tag}"),
-                            "Opening download page in your browser.",
+                            "Click \"Update available\" in the toolbar to open the download page.",
                             Duration::from_secs(30),
                         );
                         log::info!("Toast pushed for update {tag}");
                         crate::toast::sync_to_ui(&s.toasts, &app);
-                        let _ = open::that(&url);
+                        app.set_update_available(true);
+                        app.set_update_tag(tag.into());
             }
 
             // Poll for calibration results from the background thread.

--- a/crates/reco-gui/ui/main.slint
+++ b/crates/reco-gui/ui/main.slint
@@ -494,6 +494,12 @@ export component RecoApp inherits Window {
     in-out property <float> fps: 0.0;
     in-out property <bool> calibrating: false;
     in-out property <string> calibration-step: "";
+    // Set once the background update-check thread finds a newer GitHub
+    // release; drives the toolbar's "Update available" button instead of
+    // auto-opening a browser tab (see `open-update-page` below).
+    in-out property <bool> update-available: false;
+    in-out property <string> update-tag: "";
+    callback open-update-page();
     in-out property <bool> has-both-videos: left-path != "" && right-path != "";
     in-out property <bool> has-roi: false;
     in-out property <[float]> roi-points-x: [];
@@ -877,6 +883,16 @@ export component RecoApp inherits Window {
 
                 Button { text: "?"; clicked => { root.shortcuts-dialog-open = true; } }
                 Button { text: "⚙"; clicked => { root.open-prefs-dialog(); } }
+
+                // Only ever appears once the background version check
+                // actually finds a newer release; clicking opens the
+                // download page - no more auto-opening a browser tab
+                // unasked (see `open-update-page` / `update-available`'s
+                // doc comment).
+                if root.update-available: Button {
+                    text: "Update available (" + root.update-tag + ")";
+                    clicked => { root.open-update-page(); }
+                }
 
                 Button {
                     text: "Export…";


### PR DESCRIPTION
Closes #466.

## Problem

The background version-check thread in `reco-gui` correctly detects a newer GitHub release, but then calls `open::that(&url)` unconditionally the moment it finds one - popping the user's default browser open with no interaction, on every build including debug builds used while actively developing the GUI (the exact complaint in #466).

## Fix

The check result now only sets `update-available`/`update-tag` on the Slint app instead of opening anything directly. A new toolbar `Button` (visible only while `update-available` is true) sits just before Export. Clicking it fires `open-update-page()`, whose Rust handler builds the release URL from `update-tag` and opens it - the exact same `open::that()` call as before, just user-initiated instead of automatic.

The existing toast notification is unchanged (still appears on update-detected), its text updated to point at the new button instead of promising an auto-opened tab.

## Verification

- `cargo fmt --check` / `cargo clippy` clean (no new warnings from the touched files)
- `cargo test -p reco-gui` green
- `cargo build -p reco-gui` clean
- Manually tested in a running instance with a real update available - button appears and opens the release page as expected.

<img width="485" height="70" alt="afbeelding" src="https://github.com/user-attachments/assets/bc6ca438-8f75-494f-a73c-62d3622d34dd" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)